### PR TITLE
feat: Upgrade cb-tumblebug to 0.10.10

### DIFF
--- a/java-module/docker-compose.yaml
+++ b/java-module/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
 
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.10.9
+    image: cloudbaristaorg/cb-tumblebug:0.10.10
     container_name: cb-tumblebug
     build:
       context: .


### PR DESCRIPTION
## Java Module
- Upgrade cb-tumblebug to 0.10.10