### PR TITLE
feat: add delete all sessions

### DIFF
--- a/python/insight/app/api/log_analysis/log_analysis.py
+++ b/python/insight/app/api/log_analysis/log_analysis.py
@@ -76,6 +76,23 @@ async def delete_log_analysis_session(
 
 
 
+@router.delete(
+    path="/log-analysis/sessions",
+    # description="Delete all sessions",
+    # responses="",
+    response_model=ResBodyLogAnalysisSessions,
+    operation_id="DeleteAllLogAnalysisSessions"
+)
+async def delete_all_log_analysis_session(
+        db: Session = Depends(get_db)
+):
+    log_analysis_service = LogAnalysisService(db=db)
+    result = log_analysis_service.delete_all_chat_sessions()
+
+    return ResBodyLogAnalysisSessions(data=result)
+
+
+
 @router.get(
     path="/log-analysis/session/{sessionId}/history",
     # description="",

--- a/python/insight/app/api/log_analysis/repo/repo.py
+++ b/python/insight/app/api/log_analysis/repo/repo.py
@@ -31,6 +31,10 @@ class LogAnalysisRepository:
             return session
         return None
 
+    def delete_all_sessions(self):
+        self.db.query(LogAnalysisChatSession).delete()
+        self.db.commit()
+
     def get_openai_key(self):
         return self.db.query(OpenAIAPIKey).first()
 
@@ -47,3 +51,4 @@ class LogAnalysisRepository:
     def delete_openai_key(self) -> None:
         self.db.query(OpenAIAPIKey).delete()
         self.db.commit()
+    


### PR DESCRIPTION
- Previously, you had to enter sessionId to clear log-analysis sessions.
- This feature allows you to erase all sessions at once.