### PR TITLE
fix: docker-compose.yaml: Set restart: always on all long-running services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -400,7 +400,7 @@ services:
   mc-observability-insight:
     image: cloudbaristaorg/mc-observability-insight:edge
     container_name: mc-observability-insight
-    restart: on-failure
+    restart: always
     networks:
       - internal_network
       - external_network
@@ -481,7 +481,7 @@ services:
   mc-observability-mcp-grafana:
     image: mcp/grafana:latest
     container_name: mc-observability-mcp-grafana
-    restart: on-failure
+    restart: always
     tty: true
     stdin_open: true
     ports:
@@ -504,7 +504,7 @@ services:
   mc-observability-mcp-maria:
     image: cloudbaristaorg/mc-observability-mcp-mariadb:edge
     container_name: mc-observability-mcp-maria
-    restart: on-failure
+    restart: always
     networks:
       - internal_network
       - external_network
@@ -576,6 +576,7 @@ services:
   mc-infra-manager:
     image: cloudbaristaorg/cb-tumblebug:0.12.5
     container_name: mc-infra-manager
+    restart: always
     networks:
       - internal_network
       - external_network
@@ -641,6 +642,7 @@ services:
   mc-infra-manager-etcd:
     image: gcr.io/etcd-development/etcd:v3.5.21
     container_name: mc-infra-manager-etcd
+    restart: always
     networks:
       - internal_network
     ports:
@@ -713,6 +715,7 @@ services:
   mc-infra-connector:
     image: cloudbaristaorg/cb-spider_azure_monitoring:edge
     container_name: mc-infra-connector
+    restart: always
     networks:
       - internal_network
       - external_network # for outbound access (not ideal for security)


### PR DESCRIPTION
Add or change `restart: always` for cb-tumblebug, cb-spider, etcd, insight, mcp-grafana, mcp-maria so the stack auto-recovers after host reboot. Init-volume oneshots remain `restart: no`.