### PR TITLE
feat: java: Route long-range metric queries to downsampling DB and warm portal-aligned range matrix

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/MonitoringCacheProperties.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/MonitoringCacheProperties.java
@@ -1,5 +1,6 @@
 package com.mcmp.o11ymanager.manager.config;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -44,11 +45,29 @@ public class MonitoringCacheProperties {
         /** Maximum number of recently-created VMs to warm per run. */
         private int topN = 10;
 
-        /** Realtime warming — short-range queries refreshed every minute. */
-        private Job realtime = new Job("0 * * * * *", 10, "1h", "1m");
+        /** Realtime warming — short-range queries (raw DB) refreshed every minute. */
+        private Job realtime =
+                new Job(
+                        "0 * * * * *",
+                        10,
+                        List.of(
+                                new RangeSpec("1h", "1m"),
+                                new RangeSpec("6h", "5m"),
+                                new RangeSpec("12h", "5m")));
 
-        /** Downsampling warming — long-range queries refreshed on the hourly DAG cycle. */
-        private Job downsampling = new Job("0 5 * * * *", 10, "7d", "1h");
+        /**
+         * Long-range warming — queries that route to the downsampling DB. Refreshed on the hourly
+         * Airflow DAG cycle.
+         */
+        private Job longrange =
+                new Job(
+                        "0 5 * * * *",
+                        10,
+                        List.of(
+                                new RangeSpec("1d", "5m"),
+                                new RangeSpec("3d", "15m"),
+                                new RangeSpec("5d", "30m"),
+                                new RangeSpec("7d", "1h")));
     }
 
     @Getter
@@ -60,17 +79,27 @@ public class MonitoringCacheProperties {
         /** Number of worker threads for parallel warming. */
         private int threadPoolSize;
 
-        /** Time range string passed to the warming query (e.g. {@code 1h}, {@code 7d}). */
-        private String range;
-
-        /** Group-by-time interval for the warming query. */
-        private String groupTime;
+        /** (range, group_time) combinations to pre-load on each tick. */
+        private List<RangeSpec> ranges;
 
         public Job() {}
 
-        public Job(String cron, int threadPoolSize, String range, String groupTime) {
+        public Job(String cron, int threadPoolSize, List<RangeSpec> ranges) {
             this.cron = cron;
             this.threadPoolSize = threadPoolSize;
+            this.ranges = ranges;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class RangeSpec {
+        private String range;
+        private String groupTime;
+
+        public RangeSpec() {}
+
+        public RangeSpec(String range, String groupTime) {
             this.range = range;
             this.groupTime = groupTime;
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/InfluxDbInfo.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/InfluxDbInfo.java
@@ -5,7 +5,11 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "influxdb")
-public record InfluxDbInfo(String database, String retentionPolicy, List<Server> servers) {
+public record InfluxDbInfo(
+        String database,
+        String downsamplingDatabase,
+        String retentionPolicy,
+        List<Server> servers) {
 
     public record Server(
             String url,

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
@@ -236,7 +236,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         InfluxDTO s =
                 InfluxDTO.builder()
                         .url(entity.getUrl())
-                        .database(entity.getDatabase())
+                        .database(pickDatabase(entity, req))
                         .username(entity.getUsername())
                         .password(entity.getPassword())
                         .build();
@@ -321,7 +321,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         InfluxDTO s =
                 InfluxDTO.builder()
                         .url(entity.getUrl())
-                        .database(entity.getDatabase())
+                        .database(pickDatabase(entity, req))
                         .username(entity.getUsername())
                         .password(entity.getPassword())
                         .build();
@@ -682,6 +682,61 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         }
         log.info("[DISCOVER-VMS] discovered {} active VM tuples", seen.size());
         return new ArrayList<>(seen);
+    }
+
+    // ------------------------------------db
+    // routing--------------------------------------------------//
+
+    /** Threshold (in seconds) above which metric requests are routed to the downsampling DB. */
+    private static final long DOWNSAMPLING_THRESHOLD_SECONDS = 24L * 3600L;
+
+    /**
+     * Returns the InfluxDB database name to query for the given request: the configured
+     * downsampling DB when the requested range is at least 1 day, otherwise the entity's default
+     * (raw) DB.
+     */
+    private String pickDatabase(InfluxEntity entity, MetricRequestDTO req) {
+        long rangeSec = parseRangeSeconds(req == null ? null : req.getRange());
+        if (rangeSec >= DOWNSAMPLING_THRESHOLD_SECONDS) {
+            String dsDb = influxDbInfo.downsamplingDatabase();
+            if (dsDb != null && !dsDb.isBlank()) {
+                return dsDb;
+            }
+        }
+        return entity.getDatabase();
+    }
+
+    /**
+     * Parses an InfluxQL-style relative range like {@code "1h"}, {@code "30m"}, {@code "2d"} into
+     * seconds. Returns 0 for null or unparseable inputs.
+     */
+    private static long parseRangeSeconds(String range) {
+        if (range == null || range.isBlank()) {
+            return 0L;
+        }
+        String s = range.trim().toLowerCase();
+        int i = 0;
+        while (i < s.length() && Character.isDigit(s.charAt(i))) {
+            i++;
+        }
+        if (i == 0 || i == s.length()) {
+            return 0L;
+        }
+        long n;
+        try {
+            n = Long.parseLong(s.substring(0, i));
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+        String unit = s.substring(i);
+        return switch (unit) {
+            case "s" -> n;
+            case "m" -> n * 60L;
+            case "h" -> n * 3600L;
+            case "d" -> n * 86400L;
+            case "w" -> n * 7L * 86400L;
+            default -> 0L;
+        };
     }
 
     // ------------------------------------helper--------------------------------------------------//

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheWarmScheduler.java
@@ -2,6 +2,7 @@ package com.mcmp.o11ymanager.manager.service.cache;
 
 import com.mcmp.o11ymanager.manager.config.MonitoringCacheProperties;
 import com.mcmp.o11ymanager.manager.config.MonitoringCacheProperties.Job;
+import com.mcmp.o11ymanager.manager.config.MonitoringCacheProperties.RangeSpec;
 import com.mcmp.o11ymanager.manager.dto.influx.MetricRequestDTO;
 import com.mcmp.o11ymanager.manager.dto.influx.VmRef;
 import com.mcmp.o11ymanager.manager.service.interfaces.InfluxDbService;
@@ -29,13 +30,16 @@ import org.springframework.stereotype.Component;
  * <p>Two independent jobs run on separate fixed thread pools:
  *
  * <ul>
- *   <li><b>realtime</b> — short-range queries (e.g. {@code 1h / 1m}) refreshed every minute.
- *   <li><b>downsampling</b> — long-range queries (e.g. {@code 7d / 1h}) refreshed on the hourly
- *       Airflow downsampling DAG cycle.
+ *   <li><b>realtime</b> — short-range queries (e.g. {@code 1h/1m, 6h/5m, 12h/5m}) refreshed every
+ *       minute. These hit the raw mc-observability InfluxDB.
+ *   <li><b>longrange</b> — long-range queries (e.g. {@code 1d/5m, 3d/15m, 5d/30m, 7d/1h}) refreshed
+ *       on the hourly Airflow downsampling DAG cycle. These automatically route to the downsampling
+ *       InfluxDB via {@code InfluxDbServiceImpl#pickDatabase}.
  * </ul>
  *
  * For each tick the scheduler discovers active VMs in InfluxDB, sorts by Tumblebug createdTime,
- * keeps the top-N most recently created, and submits per-VM warming tasks to the job's executor.
+ * keeps the top-N most recently created, and submits per-VM warming tasks (one per measurement ×
+ * range combo) to the job's executor.
  */
 @Slf4j
 @Component
@@ -52,18 +56,18 @@ public class MonitoringCacheWarmScheduler {
     private final VmCreatedTimeResolver vmCreatedTimeResolver;
 
     private ExecutorService realtimeExecutor;
-    private ExecutorService downsamplingExecutor;
+    private ExecutorService longrangeExecutor;
 
     @PostConstruct
     void init() {
         realtimeExecutor =
                 newFixedPool("mon-cache-warm-realtime", properties.getWarm().getRealtime());
-        downsamplingExecutor =
-                newFixedPool("mon-cache-warm-down", properties.getWarm().getDownsampling());
+        longrangeExecutor =
+                newFixedPool("mon-cache-warm-longrange", properties.getWarm().getLongrange());
         log.info(
-                "[CACHE-WARM] initialized realtimeThreads={}, downsamplingThreads={}",
+                "[CACHE-WARM] initialized realtimeThreads={}, longrangeThreads={}",
                 properties.getWarm().getRealtime().getThreadPoolSize(),
-                properties.getWarm().getDownsampling().getThreadPoolSize());
+                properties.getWarm().getLongrange().getThreadPoolSize());
     }
 
     @PreDestroy
@@ -71,8 +75,8 @@ public class MonitoringCacheWarmScheduler {
         if (realtimeExecutor != null) {
             realtimeExecutor.shutdownNow();
         }
-        if (downsamplingExecutor != null) {
-            downsamplingExecutor.shutdownNow();
+        if (longrangeExecutor != null) {
+            longrangeExecutor.shutdownNow();
         }
     }
 
@@ -81,24 +85,23 @@ public class MonitoringCacheWarmScheduler {
         runJob("realtime", properties.getWarm().getRealtime(), realtimeExecutor);
     }
 
-    @Scheduled(cron = "${monitoring.cache.warm.downsampling.cron:0 5 * * * *}")
-    public void scheduledDownsampling() {
-        runJob("downsampling", properties.getWarm().getDownsampling(), downsamplingExecutor);
+    @Scheduled(cron = "${monitoring.cache.warm.longrange.cron:0 5 * * * *}")
+    public void scheduledLongrange() {
+        runJob("longrange", properties.getWarm().getLongrange(), longrangeExecutor);
     }
 
     /** Triggers both warming jobs immediately (admin endpoint). */
     public int warmNow() {
         int realtime = runJob("realtime", properties.getWarm().getRealtime(), realtimeExecutor);
-        int downsampling =
-                runJob(
-                        "downsampling",
-                        properties.getWarm().getDownsampling(),
-                        downsamplingExecutor);
-        return realtime + downsampling;
+        int longrange = runJob("longrange", properties.getWarm().getLongrange(), longrangeExecutor);
+        return realtime + longrange;
     }
 
     private int runJob(String jobName, Job job, ExecutorService executor) {
-        if (job == null || executor == null) {
+        if (job == null
+                || executor == null
+                || job.getRanges() == null
+                || job.getRanges().isEmpty()) {
             return 0;
         }
         long started = System.currentTimeMillis();
@@ -120,16 +123,24 @@ public class MonitoringCacheWarmScheduler {
         for (VmWithCreatedAt entry : top) {
             futures.add(
                     CompletableFuture.runAsync(
-                            () -> warmOneVm(jobName, job, entry.vm(), measurements, ok, fail),
+                            () ->
+                                    warmOneVm(
+                                            jobName,
+                                            job.getRanges(),
+                                            entry.vm(),
+                                            measurements,
+                                            ok,
+                                            fail),
                             executor));
         }
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
 
         log.info(
-                "[CACHE-WARM:{}] vms={}, measurements={}, ok={}, fail={}, took={}ms",
+                "[CACHE-WARM:{}] vms={}, measurements={}, ranges={}, ok={}, fail={}, took={}ms",
                 jobName,
                 top.size(),
                 measurements.size(),
+                job.getRanges().size(),
                 ok.get(),
                 fail.get(),
                 System.currentTimeMillis() - started);
@@ -156,26 +167,29 @@ public class MonitoringCacheWarmScheduler {
 
     private void warmOneVm(
             String jobName,
-            Job job,
+            List<RangeSpec> ranges,
             VmRef vm,
             List<String> measurements,
             AtomicInteger ok,
             AtomicInteger fail) {
         for (String measurement : measurements) {
-            try {
-                influxDbService.getMetricsByVM(
-                        vm.nsId(), vm.mciId(), vm.vmId(), buildRequest(job, measurement));
-                ok.incrementAndGet();
-            } catch (Exception e) {
-                fail.incrementAndGet();
-                log.debug(
-                        "[CACHE-WARM:{}] failed ns={}, mci={}, vm={}, m={}, err={}",
-                        jobName,
-                        vm.nsId(),
-                        vm.mciId(),
-                        vm.vmId(),
-                        measurement,
-                        e.toString());
+            for (RangeSpec spec : ranges) {
+                try {
+                    influxDbService.getMetricsByVM(
+                            vm.nsId(), vm.mciId(), vm.vmId(), buildRequest(spec, measurement));
+                    ok.incrementAndGet();
+                } catch (Exception e) {
+                    fail.incrementAndGet();
+                    log.debug(
+                            "[CACHE-WARM:{}] failed ns={}, mci={}, vm={}, m={}, range={}, err={}",
+                            jobName,
+                            vm.nsId(),
+                            vm.mciId(),
+                            vm.vmId(),
+                            measurement,
+                            spec.getRange(),
+                            e.toString());
+                }
             }
         }
     }
@@ -206,11 +220,11 @@ public class MonitoringCacheWarmScheduler {
         return new ArrayList<>(withTime.subList(0, Math.min(topN, withTime.size())));
     }
 
-    private MetricRequestDTO buildRequest(Job job, String measurement) {
+    private MetricRequestDTO buildRequest(RangeSpec spec, String measurement) {
         MetricRequestDTO req = new MetricRequestDTO();
         req.setMeasurement(measurement);
-        req.setRange(job.getRange());
-        req.setGroupTime(job.getGroupTime());
+        req.setRange(spec.getRange());
+        req.setGroupTime(spec.getGroupTime());
         req.setFields(new ArrayList<>());
         req.setConditions(new ArrayList<>());
         return req;

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -69,6 +69,7 @@ loki:
 
 influxdb:
   database: ${INFLUX_DATABASE:mc-observability}
+  downsampling-database: ${INFLUX_DOWNSAMPLING_DATABASE:downsampling}
   retention-policy: ${INFLUX_RETENTION_POLICY:autogen}
   servers:
     - url: ${INFLUX1_URL:http://mc-observability-influx:8086}
@@ -93,13 +94,18 @@ monitoring:
       realtime:
         cron: ${MONITORING_CACHE_WARM_REALTIME_CRON:0 * * * * *}
         thread-pool-size: ${MONITORING_CACHE_WARM_REALTIME_THREADS:10}
-        range: ${MONITORING_CACHE_WARM_REALTIME_RANGE:1h}
-        group-time: ${MONITORING_CACHE_WARM_REALTIME_GROUP_TIME:1m}
-      downsampling:
-        cron: ${MONITORING_CACHE_WARM_DOWNSAMPLING_CRON:0 5 * * * *}
-        thread-pool-size: ${MONITORING_CACHE_WARM_DOWNSAMPLING_THREADS:10}
-        range: ${MONITORING_CACHE_WARM_DOWNSAMPLING_RANGE:7d}
-        group-time: ${MONITORING_CACHE_WARM_DOWNSAMPLING_GROUP_TIME:1h}
+        ranges:
+          - { range: 1h,  group-time: 1m }
+          - { range: 6h,  group-time: 5m }
+          - { range: 12h, group-time: 5m }
+      longrange:
+        cron: ${MONITORING_CACHE_WARM_LONGRANGE_CRON:0 5 * * * *}
+        thread-pool-size: ${MONITORING_CACHE_WARM_LONGRANGE_THREADS:10}
+        ranges:
+          - { range: 1d, group-time: 5m }
+          - { range: 3d, group-time: 15m }
+          - { range: 5d, group-time: 30m }
+          - { range: 7d, group-time: 1h }
 
 health:
   check-interval: ${HEALTH_INTERVAL:10000}


### PR DESCRIPTION
## Summary
- Route metric queries with range >= 1d to the downsampling InfluxDB (`pickDatabase`) so long-range views read pre-aggregated data instead of pounding the raw DB
- Add `influxdb.downsampling-database` config (default: `downsampling`) on `InfluxDbInfo`
- Refactor warm `Job` config to hold a list of `(range, group_time)` combos
- Wire portal-aligned defaults:
  - **realtime** (every minute, raw DB): `1h/1m`, `6h/5m`, `12h/5m`
  - **longrange** (every hour at :05, downsampling DB): `1d/5m`, `3d/15m`, `5d/30m`, `7d/1h`
- Rename the previous `downsampling` job to `longrange` to reflect that the routing — not the schedule — defines its purpose

## Test plan
- [ ] Send a metric query with `range=7d` and confirm it hits the downsampling DB (check log / DB query)
- [ ] Send a metric query with `range=1h` and confirm it still hits the raw DB
- [ ] Verify both warm jobs run on schedule and produce log lines with the expected combo counts
- [ ] `POST /api/o11y/monitoring/influxdb/cache/warm` triggers both jobs immediately