### PR TITLE
feat: Add React-based observability frontend

### DIFF
--- a/.github/workflows/deploy_front.yaml
+++ b/.github/workflows/deploy_front.yaml
@@ -1,0 +1,75 @@
+# Build and publish mc-observability-front container image
+name: CD - Front
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    tags:
+      - "v*.*.*"
+    paths:
+      - "front/**"
+      - ".github/workflows/deploy_front.yaml"
+  workflow_dispatch:
+
+env:
+  DOCKER_REGISTRY_NAME: cloudbaristaorg
+  GHCR_REGISTRY_NAME: ${{ github.repository_owner }}
+  IMAGE_NAME: mc-observability-front
+
+jobs:
+  build-and-publish:
+    name: Build and publish container image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{env.DOCKER_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+            ghcr.io/${{env.GHCR_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=semver,enable=true,pattern={{version}}
+            type=edge,enable=true,branch=main
+            type=ref,event=branch
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-front-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-front-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: ./front
+          file: ./front/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       - internal_network
       - external_network
     ports:
-      - 3001:3001
+      - 18081:18081
     depends_on:
       mc-observability-manager:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,6 +47,21 @@ services:
       timeout: 10s
       retries: 30
 
+  mc-observability-front:
+    build:
+      context: ./front
+      dockerfile: Dockerfile
+    container_name: mc-observability-front
+    restart: always
+    networks:
+      - internal_network
+      - external_network
+    ports:
+      - 3001:3001
+    depends_on:
+      mc-observability-manager:
+        condition: service_healthy
+
   mc-observability-infra:
     image: cloudbaristaorg/mc-observability-infra:edge
     container_name: mc-observability-infra

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite/

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 3001
+CMD ["nginx", "-g", "daemon off;"]

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -8,5 +8,5 @@ RUN npm run build
 FROM nginx:alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 3001
+EXPOSE 18081
 CMD ["nginx", "-g", "daemon off;"]

--- a/front/index.html
+++ b/front/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MC-Observability</title>
+  </head>
+  <body class="bg-gray-50 text-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 3001;
+    listen 18081;
     root /usr/share/nginx/html;
     index index.html;
 

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,0 +1,38 @@
+server {
+    listen 3001;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/o11y/ {
+        proxy_pass http://mc-observability-manager:18080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Origin "";
+        proxy_hide_header Access-Control-Allow-Origin;
+    }
+
+    location /tumblebug/ {
+        proxy_pass http://mc-infra-manager:1323;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Authorization "Basic ZGVmYXVsdDpkZWZhdWx0";
+        proxy_set_header Origin "";
+        proxy_hide_header Access-Control-Allow-Origin;
+    }
+
+    location /spider/ {
+        proxy_pass http://mc-infra-connector:1024;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Authorization "Basic ZGVmYXVsdDpkZWZhdWx0";
+        proxy_set_header Origin "";
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,0 +1,2942 @@
+{
+  "name": "mc-o11y-front",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mc-o11y-front",
+      "version": "0.1.0",
+      "dependencies": {
+        "apexcharts": "^4.3.0",
+        "axios": "^1.7.9",
+        "react": "^18.3.1",
+        "react-apexcharts": "^1.7.0",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.28.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "vite": "^6.0.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@svgdotjs/svg.draggable.js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.6.tgz",
+      "integrity": "sha512-7iJFm9lL3C40HQcqzEfezK2l+dW2CpoVY3b77KQGqc8GXWa6LhhmX5Ckv7alQfUXBuZbjpICZ+Dvq1czlGx7gA==",
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
+    "node_modules/@svgdotjs/svg.filter.js": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.filter.js/-/svg.filter.js-3.0.9.tgz",
+      "integrity": "sha512-/69XMRCDoam2HgC4ldHIaDgeQf1ViHIsa0Ld4uWgiXtZ+E24DWHe/9Ib6kbNiZ7WRIdlVokUDR1Fg0kjIpkfbw==",
+      "dependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@svgdotjs/svg.js": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.5.tgz",
+      "integrity": "sha512-/VNHWYhNu+BS7ktbYoVGrCmsXDh+chFMaONMwGNdIBcFHrWqk2jY8fNyr3DLdtQUIalvkPfM554ZSFa3dm3nxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Fuzzyma"
+      }
+    },
+    "node_modules/@svgdotjs/svg.resize.js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.resize.js/-/svg.resize.js-2.0.5.tgz",
+      "integrity": "sha512-4heRW4B1QrJeENfi7326lUPYBCevj78FJs8kfeDxn5st0IYPIRXoTtOSYvTzFWgaWWXd3YCDE6ao4fmv91RthA==",
+      "engines": {
+        "node": ">= 14.18"
+      },
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4",
+        "@svgdotjs/svg.select.js": "^4.0.1"
+      }
+    },
+    "node_modules/@svgdotjs/svg.select.js": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
+      "integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
+      "engines": {
+        "node": ">= 14.18"
+      },
+      "peerDependencies": {
+        "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@yr/monotone-cubic-spline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA=="
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-4.7.0.tgz",
+      "integrity": "sha512-iZSrrBGvVlL+nt2B1NpqfDuBZ9jX61X9I2+XV0hlYXHtTwhwLTHDKGXjNXAgFBDLuvSYCB/rq2nPWVPRv2DrGA==",
+      "dependencies": {
+        "@svgdotjs/svg.draggable.js": "^3.0.4",
+        "@svgdotjs/svg.filter.js": "^3.0.8",
+        "@svgdotjs/svg.js": "^3.2.4",
+        "@svgdotjs/svg.resize.js": "^2.0.2",
+        "@svgdotjs/svg.select.js": "^4.0.1",
+        "@yr/monotone-cubic-spline": "^1.0.3"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.334",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-apexcharts": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.9.0.tgz",
+      "integrity": "sha512-DDBzQFuKdwyCEZnji1yIcjlnV8hRr4VDabS5Y3iuem/WcTq6n4VbjWPzbPm3aOwW4I+rf/gA3zWqhws4z9CwLw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "apexcharts": ">=4.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    }
+  }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mc-o11y-front",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "apexcharts": "^4.3.0",
+    "axios": "^1.7.9",
+    "react": "^18.3.1",
+    "react-apexcharts": "^1.7.0",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "vite": "^6.0.3"
+  }
+}

--- a/front/postcss.config.js
+++ b/front/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { useAppContext } from './context/AppContext';
+import { setApiToken } from './api/client';
+import Layout from './components/Layout';
+import ErrorBoundary from './components/ErrorBoundary';
+import EmbedLayout from './components/EmbedLayout';
+import MonitoringDashboard from './pages/MonitoringDashboard';
+import MciOverview from './pages/MciOverview';
+import LogViewer from './pages/LogViewer';
+import MonitoringConfig from './pages/MonitoringConfig';
+import InsightDashboard from './pages/InsightDashboard';
+import AlertManager from './pages/AlertManager';
+import HomePage from './pages/HomePage';
+
+export default function App() {
+  const { token } = useAppContext();
+
+  useEffect(() => {
+    if (token) setApiToken(token);
+  }, [token]);
+
+  return (
+    <ErrorBoundary>
+    <Routes>
+      {/* Standalone — full nav + test console */}
+      <Route path="/" element={<HomePage />} />
+      <Route element={<Layout />}>
+        <Route path="/monitoring/:nsId/:mciId/:vmId" element={<MonitoringDashboard />} />
+        <Route path="/monitoring/:nsId/:mciId" element={<MciOverview />} />
+        <Route path="/logs/:nsId/:mciId/:vmId" element={<LogViewer />} />
+        <Route path="/logs/:nsId/:mciId" element={<LogViewer />} />
+        <Route path="/config/:nsId/:mciId" element={<MonitoringConfig />} />
+        <Route path="/insight/:nsId/:mciId/:vmId" element={<InsightDashboard />} />
+        <Route path="/insight/:nsId/:mciId" element={<InsightDashboard />} />
+        <Route path="/alerts/:nsId/:mciId" element={<AlertManager />} />
+      </Route>
+
+      {/* Embed — no nav, for iframe */}
+      <Route element={<EmbedLayout />}>
+        <Route path="/embed/monitoring/:nsId/:mciId/:vmId" element={<MonitoringDashboard />} />
+        <Route path="/embed/monitoring/:nsId/:mciId" element={<MciOverview />} />
+        <Route path="/embed/logs/:nsId/:mciId/:vmId" element={<LogViewer />} />
+        <Route path="/embed/logs/:nsId/:mciId" element={<LogViewer />} />
+        <Route path="/embed/config/:nsId/:mciId" element={<MonitoringConfig />} />
+        <Route path="/embed/insight/:nsId/:mciId/:vmId" element={<InsightDashboard />} />
+        <Route path="/embed/insight/:nsId/:mciId" element={<InsightDashboard />} />
+        <Route path="/embed/alerts/:nsId/:mciId" element={<AlertManager />} />
+      </Route>
+    </Routes>
+    </ErrorBoundary>
+  );
+}

--- a/front/src/api/client.js
+++ b/front/src/api/client.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+let _token = null;
+
+export function setApiToken(token) {
+  _token = token;
+}
+
+const client = axios.create({
+  baseURL: '',
+  headers: { 'Content-Type': 'application/json' },
+});
+
+client.interceptors.request.use((config) => {
+  if (_token && _token !== 'bypass') {
+    config.headers.Authorization = `Bearer ${_token}`;
+  }
+  return config;
+});
+
+export default client;

--- a/front/src/api/csp.js
+++ b/front/src/api/csp.js
@@ -1,0 +1,65 @@
+import client from './client';
+
+// Based on cb-spider MonitoringHandler interface (MonitoringHandler.go)
+// MetricType enum: cpu_usage, memory_usage, disk_read, disk_write, disk_read_ops, disk_write_ops, network_in, network_out
+// Response: MetricData { metricName, metricUnit, timestampValues: [{timestamp, value}] }
+// API: GET /spider/monitoring/vm/:VMName/:MetricType?ConnectionName=...&periodMinute=...&timeBeforeHour=...
+
+const CSP_METRICS = [
+  { key: 'cpu_usage', label: 'CPU Usage', unit: '%' },
+  { key: 'memory_usage', label: 'Memory Available', unit: 'bytes' },
+  { key: 'disk_read', label: 'Disk Read', unit: 'bytes' },
+  { key: 'disk_write', label: 'Disk Write', unit: 'bytes' },
+  { key: 'disk_read_ops', label: 'Disk Read Ops', unit: 'count' },
+  { key: 'disk_write_ops', label: 'Disk Write Ops', unit: 'count' },
+  { key: 'network_in', label: 'Network In', unit: 'bytes' },
+  { key: 'network_out', label: 'Network Out', unit: 'bytes' },
+];
+
+export { CSP_METRICS };
+
+/**
+ * @param {string} connectionName - cb-spider connection name (e.g. "azure-koreacentral")
+ * @param {string} cspResourceName - CSP-level VM name (from Tumblebug vm.cspResourceName)
+ * @param {string} metricType - one of CSP_METRICS keys
+ * @param {string} periodMinute - aggregation interval (default "5")
+ * @param {string} timeBeforeHour - lookback hours (default "1")
+ */
+export async function getCspMetric(connectionName, cspResourceName, metricType, periodMinute = '5', timeBeforeHour = '1') {
+  const res = await client.get(`/spider/monitoring/vm/${cspResourceName}/${metricType}`, {
+    params: { ConnectionName: connectionName, periodMinute, timeBeforeHour },
+  });
+  return res.data || {};
+}
+
+/** Fetch all CSP metrics for a VM. Returns { cpu_usage: {metricName, metricUnit, series}, ... } */
+export async function getAllCspMetrics(connectionName, cspResourceName, timeBeforeHour = '1') {
+  const results = {};
+  await Promise.allSettled(
+    CSP_METRICS.map(async (m) => {
+      const data = await getCspMetric(connectionName, cspResourceName, m.key, '5', timeBeforeHour);
+      results[m.key] = {
+        ...m,
+        metricName: data.metricName || m.label,
+        metricUnit: data.metricUnit || m.unit,
+        series: [{
+          name: data.metricName || m.label,
+          data: (data.timestampValues || []).map((v) => ({
+            x: new Date(v.timestamp).getTime(),
+            y: parseFloat(v.value),
+          })),
+        }],
+      };
+    })
+  );
+  return results;
+}
+
+// Supported CSP providers for monitoring (Azure, AWS, GCP)
+export const CSP_SUPPORTED_PROVIDERS = ['azure', 'aws', 'gcp'];
+
+export function isCspSupported(connectionName) {
+  if (!connectionName) return false;
+  const lower = connectionName.toLowerCase();
+  return CSP_SUPPORTED_PROVIDERS.some((p) => lower.includes(p));
+}

--- a/front/src/api/insight.js
+++ b/front/src/api/insight.js
@@ -1,0 +1,83 @@
+import client from './client';
+
+// Anomaly Detection
+export async function getAnomalySettings() {
+  const res = await client.get('/api/o11y/insight/anomaly-detection/settings');
+  return res.data?.data || [];
+}
+
+export async function createAnomalySetting(body) {
+  const res = await client.post('/api/o11y/insight/anomaly-detection/settings', body);
+  return res.data?.data || res.data;
+}
+
+export async function deleteAnomalySetting(seq) {
+  return client.delete(`/api/o11y/insight/anomaly-detection/settings/${seq}`);
+}
+
+export async function getAnomalyOptions() {
+  const res = await client.get('/api/o11y/insight/anomaly-detection/options');
+  return res.data?.data || {};
+}
+
+export async function getAnomalyMeasurements() {
+  const res = await client.get('/api/o11y/insight/anomaly-detection/measurement');
+  return res.data?.data || [];
+}
+
+export async function getAnomalyHistory(nsId, mciId, vmId, measurement, startTime, endTime) {
+  const params = { measurement };
+  if (startTime) params.start_time = startTime;
+  if (endTime) params.end_time = endTime;
+  const path = vmId
+    ? `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${mciId}/vm/${vmId}/history`
+    : `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${mciId}/history`;
+  const res = await client.get(path, { params });
+  return res.data?.data || res.data?.responseData || {};
+}
+
+// Prediction
+export async function getPredictionOptions() {
+  const res = await client.get('/api/o11y/insight/predictions/options');
+  return res.data?.data || {};
+}
+
+export async function getPredictionHistory(nsId, mciId, vmId, measurement, startTime, endTime) {
+  const params = { measurement };
+  if (startTime) params.start_time = startTime;
+  if (endTime) params.end_time = endTime;
+  const path = vmId
+    ? `/api/o11y/insight/predictions/ns/${nsId}/mci/${mciId}/vm/${vmId}/history`
+    : `/api/o11y/insight/predictions/ns/${nsId}/mci/${mciId}/history`;
+  const res = await client.get(path, { params });
+  return res.data?.data || res.data?.responseData || {};
+}
+
+export async function runPrediction(nsId, mciId, vmId, body) {
+  const path = vmId
+    ? `/api/o11y/insight/predictions/ns/${nsId}/mci/${mciId}/vm/${vmId}`
+    : `/api/o11y/insight/predictions/ns/${nsId}/mci/${mciId}`;
+  const res = await client.post(path, body);
+  return res.data?.data || res.data?.responseData || {};
+}
+
+// LLM
+export async function getLlmModels() {
+  const res = await client.get('/api/o11y/insight/llm/model');
+  return res.data?.data || [];
+}
+
+export async function getLlmSessions() {
+  const res = await client.get('/api/o11y/insight/llm/session');
+  return res.data?.data || [];
+}
+
+export async function createLlmSession(body) {
+  const res = await client.post('/api/o11y/insight/llm/session', body);
+  return res.data?.data || res.data;
+}
+
+export async function getLlmHistory(sessionId) {
+  const res = await client.get(`/api/o11y/insight/llm/session/${sessionId}/history`);
+  return res.data?.data || [];
+}

--- a/front/src/api/logs.js
+++ b/front/src/api/logs.js
@@ -1,0 +1,49 @@
+import client from './client';
+
+export async function queryLogs({ nsId, mciId, vmId, keyword, limit = 50, rangeHours = 24 }) {
+  let logql = `{NS_ID="${nsId}", MCI_ID="${mciId}"`;
+  if (vmId) logql += `, VM_ID="${vmId}"`;
+  logql += '}';
+  if (keyword) logql += ` |~ "(?i)${keyword}"`;
+
+  const now = new Date();
+  const start = new Date(now.getTime() - rangeHours * 60 * 60 * 1000);
+
+  const res = await client.get('/api/o11y/log/query_range', {
+    params: {
+      query: logql,
+      limit: String(limit),
+      start: Math.floor(start.getTime() / 1000).toString(),
+      end: Math.floor(now.getTime() / 1000).toString(),
+    },
+  });
+  const body = res.data?.data || res.data || {};
+  // Normalize: API returns { status, data: [...] } where each entry has { labels, timestamp, value(json string) }
+  const entries = body.data || body || [];
+  if (!Array.isArray(entries)) return [];
+  return entries.map((e) => {
+    let parsed = {};
+    try { parsed = typeof e.value === 'string' ? JSON.parse(e.value) : (e.value || {}); } catch {}
+    return {
+      timestamp: parsed.time || (e.timestamp ? new Date(e.timestamp / 1e6).toISOString() : ''),
+      message: parsed.message || '',
+      level: e.labels?.level || parsed.level || '',
+      vm_id: e.labels?.VM_ID || '',
+      host: e.labels?.host || parsed.host || '',
+      service: parsed.service || e.labels?.service || '',
+      source: parsed.source || e.labels?.source || '',
+      labels: e.labels || {},
+      raw: parsed,
+    };
+  });
+}
+
+export async function getLogLabels() {
+  const res = await client.get('/api/o11y/log/labels');
+  return res.data?.data || [];
+}
+
+export async function getLogLabelValues(label) {
+  const res = await client.get(`/api/o11y/log/labels/${label}/values`);
+  return res.data?.data || [];
+}

--- a/front/src/api/monitoring.js
+++ b/front/src/api/monitoring.js
@@ -1,0 +1,60 @@
+import client from './client';
+
+export async function getMeasurementFields() {
+  const res = await client.get('/api/o11y/monitoring/influxdb/measurement');
+  return res.data?.data || [];
+}
+
+export async function getPlugins() {
+  const res = await client.get('/api/o11y/monitoring/plugins');
+  return res.data?.data || [];
+}
+
+export async function getMetricsByVM(nsId, mciId, vmId, { measurement, range, groupTime, fields, conditions }) {
+  const res = await client.post(`/api/o11y/monitoring/influxdb/metric/${nsId}/${mciId}/${vmId}`, {
+    measurement,
+    range,
+    group_time: groupTime,
+    group_by: ['vm_id'],
+    limit: 2000,
+    fields: fields || [],
+    conditions: conditions || [],
+  });
+  return res.data?.data || [];
+}
+
+export async function getMetricsByNsMci(nsId, mciId, { measurement, range, groupTime, fields, conditions }) {
+  const res = await client.post(`/api/o11y/monitoring/influxdb/metric/${nsId}/${mciId}`, {
+    measurement,
+    range,
+    group_time: groupTime,
+    group_by: ['vm_id'],
+    limit: 2000,
+    fields: fields || [],
+    conditions: conditions || [],
+  });
+  return res.data?.data || [];
+}
+
+export async function getPrediction(nsId, mciId, vmId, measurement) {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString();
+  const endTime = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  const res = await client.post(`/api/o11y/insight/predictions/ns/${nsId}/mci/${mciId}/vm/${vmId}`, {
+    measurement,
+    start_time: startTime,
+    end_time: endTime,
+  });
+  return res.data?.data || res.data?.responseData || {};
+}
+
+export async function getDetectionHistory(nsId, mciId, vmId, measurement) {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString();
+  const endTime = now.toISOString();
+  const res = await client.get(
+    `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${mciId}/vm/${vmId}/history`,
+    { params: { measurement, start_time: startTime, end_time: endTime } }
+  );
+  return res.data?.data || res.data?.responseData || {};
+}

--- a/front/src/api/trigger.js
+++ b/front/src/api/trigger.js
@@ -1,0 +1,56 @@
+import client from './client';
+
+// Trigger policies
+export async function getPolicies(page = 1, size = 20) {
+  const res = await client.get('/api/o11y/trigger/policy', { params: { page, size } });
+  return res.data?.data || {};
+}
+
+export async function createPolicy(body) {
+  const res = await client.post('/api/o11y/trigger/policy', body);
+  return res.data?.data || res.data;
+}
+
+export async function deletePolicy(id) {
+  return client.delete(`/api/o11y/trigger/policy/${id}`);
+}
+
+export async function addVmToPolicy(policyId, body) {
+  return client.post(`/api/o11y/trigger/policy/${policyId}/vm`, body);
+}
+
+export async function removeVmFromPolicy(policyId, body) {
+  return client.delete(`/api/o11y/trigger/policy/${policyId}/vm`, { data: body });
+}
+
+export async function updatePolicyChannels(policyId, channels) {
+  return client.put(`/api/o11y/trigger/policy/${policyId}/channel`, channels);
+}
+
+// Alerts
+export async function getAlerts() {
+  const res = await client.get('/api/o11y/trigger/alert/alerts');
+  return res.data || [];
+}
+
+export async function getAlertRules() {
+  const res = await client.get('/api/o11y/trigger/alert/alert-rules');
+  return res.data || [];
+}
+
+// Notification
+export async function getNotiChannels() {
+  const res = await client.get('/api/o11y/trigger/noti/channel');
+  return res.data?.data || {};
+}
+
+export async function getNotiHistory(page = 1, size = 20) {
+  const res = await client.get('/api/o11y/trigger/noti/history', { params: { page, size } });
+  return res.data?.data || {};
+}
+
+// Trigger history
+export async function getTriggerHistory(page = 1, size = 20) {
+  const res = await client.get('/api/o11y/trigger/history', { params: { page, size } });
+  return res.data?.data || {};
+}

--- a/front/src/api/tumblebug.js
+++ b/front/src/api/tumblebug.js
@@ -1,0 +1,18 @@
+import client from './client';
+
+const TB_BASE = '/tumblebug';
+
+export async function getNsList() {
+  const res = await client.get(`${TB_BASE}/ns`);
+  return res.data?.ns || [];
+}
+
+export async function getMciList(nsId) {
+  const res = await client.get(`${TB_BASE}/ns/${nsId}/mci`);
+  return res.data?.mci || [];
+}
+
+export async function getMci(nsId, mciId) {
+  const res = await client.get(`${TB_BASE}/ns/${nsId}/mci/${mciId}`);
+  return res.data || {};
+}

--- a/front/src/api/vm.js
+++ b/front/src/api/vm.js
@@ -1,0 +1,42 @@
+import client from './client';
+
+export async function getVmList(nsId, mciId) {
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${mciId}/vm`);
+  return res.data?.data || [];
+}
+
+export async function getVm(nsId, mciId, vmId) {
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}`);
+  return res.data?.data || res.data?.responseData || null;
+}
+
+export async function installAgent(nsId, mciId, vmId) {
+  const res = await client.post(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}`, { name: vmId });
+  return res.data;
+}
+
+export async function uninstallAgent(nsId, mciId, vmId) {
+  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}`);
+  return res.data;
+}
+
+export async function getVmItems(nsId, mciId, vmId) {
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}/item`);
+  return res.data?.data || [];
+}
+
+export async function createVmItem(nsId, mciId, vmId, item) {
+  const body = { pluginSeq: item.pluginSeq, pluginConfig: item.pluginConfig || '' };
+  const res = await client.post(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}/item`, body);
+  return res.data;
+}
+
+export async function updateVmItem(nsId, mciId, vmId, item) {
+  const res = await client.put(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}/item`, item);
+  return res.data;
+}
+
+export async function deleteVmItem(nsId, mciId, vmId, itemSeq) {
+  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${mciId}/vm/${vmId}/item/${itemSeq}`);
+  return res.data;
+}

--- a/front/src/components/EmbedLayout.jsx
+++ b/front/src/components/EmbedLayout.jsx
@@ -1,0 +1,9 @@
+import { Outlet } from 'react-router-dom';
+
+export default function EmbedLayout() {
+  return (
+    <div className="h-screen overflow-auto p-4">
+      <Outlet />
+    </div>
+  );
+}

--- a/front/src/components/ErrorBoundary.jsx
+++ b/front/src/components/ErrorBoundary.jsx
@@ -1,0 +1,26 @@
+import { Component } from 'react';
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="p-4 bg-red-50 border border-red-200 rounded m-4">
+          <h3 className="text-red-700 font-bold mb-2">Render Error</h3>
+          <pre className="text-xs text-red-600 whitespace-pre-wrap">{this.state.error.toString()}</pre>
+          <button onClick={() => this.setState({ error: null })} className="mt-2 text-sm bg-red-600 text-white px-3 py-1 rounded">Retry</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -1,0 +1,160 @@
+import { useState, useEffect, useCallback } from 'react';
+import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
+import { setApiToken } from '../api/client';
+import { getNsList, getMciList, getMci } from '../api/tumblebug';
+
+const navItems = [
+  { label: 'Monitoring', path: 'monitoring' },
+  { label: 'Logs', path: 'logs' },
+  { label: 'Config', path: 'config' },
+  { label: 'Insight', path: 'insight' },
+  { label: 'Alerts', path: 'alerts' },
+];
+
+export default function Layout() {
+  const { nsId, mciId, vmId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const currentSection = navItems.find((n) => location.pathname.includes(`/${n.path}/`))?.path || 'monitoring';
+
+  const [showDevTools, setShowDevTools] = useState(false);
+  const [bypassAuth, setBypassAuth] = useState(true);
+
+  const [nsList, setNsList] = useState([]);
+  const [mciList, setMciList] = useState([]);
+  const [vmList, setVmList] = useState([]);
+
+  useEffect(() => {
+    if (bypassAuth) setApiToken('bypass');
+  }, [bypassAuth]);
+
+  // Load NS list
+  useEffect(() => {
+    getNsList().then(setNsList).catch(() => setNsList([]));
+  }, []);
+
+  // NS 변경 → MCI 목록 갱신
+  const loadMciList = useCallback(async (ns) => {
+    if (!ns) { setMciList([]); return []; }
+    try {
+      const list = await getMciList(ns);
+      const arr = Array.isArray(list) ? list : [];
+      setMciList(arr);
+      return arr;
+    } catch { setMciList([]); return []; }
+  }, []);
+
+  // MCI 변경 → VM 목록 갱신
+  const loadVmList = useCallback(async (ns, mci) => {
+    if (!ns || !mci) { setVmList([]); return; }
+    try {
+      const data = await getMci(ns, mci);
+      setVmList(data.vm || []);
+    } catch { setVmList([]); }
+  }, []);
+
+  // URL의 nsId/mciId 가 바뀔 때마다 목록 갱신
+  useEffect(() => { loadMciList(nsId); }, [nsId, loadMciList]);
+  useEffect(() => { loadVmList(nsId, mciId); }, [nsId, mciId, loadVmList]);
+
+  // NS 드롭다운 변경
+  async function handleNsChange(newNs) {
+    const mcis = await loadMciList(newNs);
+    const firstMci = mcis[0]?.id;
+    if (firstMci) {
+      navigate(`/${currentSection}/${newNs}/${firstMci}`);
+    }
+  }
+
+  // MCI 드롭다운 변경
+  function handleMciChange(newMci) {
+    if (!newMci) return;
+    navigate(`/${currentSection}/${nsId}/${newMci}`);
+  }
+
+  // VM 드롭다운 변경
+  function handleVmChange(newVm) {
+    if (!nsId || !mciId) return;
+    let path = `/${currentSection}/${nsId}/${mciId}`;
+    if (newVm) path += `/${newVm}`;
+    navigate(path);
+  }
+
+  const buildPath = (base) => {
+    return `/${base}/${nsId}/${mciId}`;
+  };
+
+  return (
+    <div className="flex flex-col h-screen">
+      <nav className="flex items-center gap-1 px-4 py-2 bg-white border-b border-gray-200 text-sm shrink-0 flex-wrap">
+        <a href="/" className="font-semibold text-gray-700 mr-3 hover:text-blue-600">MC-Observability</a>
+
+        {navItems.map((item) => (
+          <NavLink key={item.path} to={buildPath(item.path)}
+            className={({ isActive }) =>
+              `px-3 py-1.5 rounded-md transition-colors ${isActive ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`
+            }>
+            {item.label}
+          </NavLink>
+        ))}
+
+        <div className="ml-auto flex items-center gap-1">
+          {/* NS */}
+          <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={nsId || ''}
+            onChange={(e) => handleNsChange(e.target.value)}>
+            <option value="">NS</option>
+            {nsList.map((ns) => <option key={ns.id} value={ns.id}>{ns.id}</option>)}
+          </select>
+          <span className="text-gray-300">/</span>
+          {/* MCI */}
+          <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={mciId || ''}
+            onChange={(e) => handleMciChange(e.target.value)}>
+            <option value="">MCI</option>
+            {mciList.map((m) => <option key={m.id} value={m.id}>{m.name || m.id}</option>)}
+          </select>
+          <span className="text-gray-300">/</span>
+          {/* VM */}
+          <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={vmId || ''}
+            onChange={(e) => handleVmChange(e.target.value)}>
+            <option value="">(MCI Overview)</option>
+            {vmList.map((vm) => <option key={vm.id} value={vm.id}>{vm.name || vm.id}</option>)}
+          </select>
+
+          <button onClick={() => setShowDevTools(!showDevTools)}
+            className={`ml-2 text-xs border rounded px-2 py-1 ${showDevTools ? 'bg-gray-800 text-white border-gray-800' : 'text-gray-400 border-gray-200 hover:text-gray-600'}`}>
+            Dev
+          </button>
+        </div>
+      </nav>
+
+      {showDevTools && (
+        <div className="bg-gray-800 text-gray-200 px-4 py-3 text-xs space-y-2 shrink-0">
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input type="checkbox" checked={bypassAuth} onChange={(e) => { setBypassAuth(e.target.checked); if (e.target.checked) setApiToken('bypass'); }} />
+              Token Bypass
+            </label>
+            <span className="text-gray-500">|</span>
+            <span>Path: <code className="text-green-400">/{currentSection}/{nsId}/{mciId}{vmId ? '/' + vmId : ''}</code></span>
+          </div>
+          <div className="border-t border-gray-700 pt-2">
+            <p className="text-yellow-300 font-semibold mb-1">iframe Integration</p>
+            <code className="block bg-gray-900 p-2 rounded text-green-300 whitespace-pre-wrap">{`<iframe src="${window.location.origin}/embed/${currentSection}/${nsId || '{nsId}'}/${mciId || '{mciId}'}${vmId ? '/' + vmId : ''}" />
+
+<script>
+iframe.onload = () => iframe.contentWindow.postMessage({
+  accessToken: "Bearer ...",
+  projectInfo: { ns_id: "${nsId || 'ns-1'}" }
+}, "${window.location.origin}");
+</script>`}</code>
+          </div>
+        </div>
+      )}
+
+      <main className="flex-1 overflow-auto p-4 bg-gray-50">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/front/src/components/LogTable.jsx
+++ b/front/src/components/LogTable.jsx
@@ -1,0 +1,130 @@
+import { useState, useMemo } from 'react';
+
+const PAGE_SIZE = 20;
+
+export default function LogTable({ logs }) {
+  const [selected, setSelected] = useState(null);
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.max(1, Math.ceil((logs?.length || 0) / PAGE_SIZE));
+  const paged = useMemo(() => (logs || []).slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE), [logs, page]);
+
+  // Reset page when logs change
+  useMemo(() => setPage(0), [logs]);
+
+  if (logs === null) {
+    return <p className="text-sm text-gray-400 py-4">Click Search to query logs</p>;
+  }
+  if (!logs || logs.length === 0) {
+    return <p className="text-sm text-gray-400 py-4">No logs found</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-4">
+        {/* Table */}
+        <div className="flex-1 overflow-auto max-h-[600px]">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="bg-gray-100 sticky top-0">
+                <th className="text-left px-3 py-2 border-b text-sm font-medium text-gray-600">Timestamp</th>
+                <th className="text-left px-3 py-2 border-b text-sm font-medium text-gray-600">Level</th>
+                <th className="text-left px-3 py-2 border-b text-sm font-medium text-gray-600">VM</th>
+                <th className="text-left px-3 py-2 border-b text-sm font-medium text-gray-600">Service</th>
+                <th className="text-left px-3 py-2 border-b text-sm font-medium text-gray-600">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paged.map((log, i) => (
+                <tr key={page * PAGE_SIZE + i} onClick={() => setSelected(log)}
+                  className={`cursor-pointer hover:bg-blue-50 ${selected === log ? 'bg-blue-100' : ''}`}>
+                  <td className="px-3 py-2 border-b whitespace-nowrap text-sm text-gray-500">{log.timestamp || '-'}</td>
+                  <td className="px-3 py-2 border-b text-sm"><LevelBadge level={log.level} /></td>
+                  <td className="px-3 py-2 border-b whitespace-nowrap text-sm">{log.vm_id || '-'}</td>
+                  <td className="px-3 py-2 border-b whitespace-nowrap text-sm">{log.service || '-'}</td>
+                  <td className="px-3 py-2 border-b text-sm truncate max-w-lg">{log.message || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Detail panel */}
+        {selected && (
+          <div className="w-96 bg-gray-50 rounded-md p-4 overflow-auto max-h-[600px] shrink-0 text-sm">
+            <h4 className="font-semibold mb-3">Log Detail</h4>
+            <div className="space-y-1.5 mb-3">
+              <Row label="Timestamp" value={selected.timestamp} />
+              <Row label="Level" value={selected.level} />
+              <Row label="VM" value={selected.vm_id} />
+              <Row label="Host" value={selected.host} />
+              <Row label="Service" value={selected.service} />
+              <Row label="Source" value={selected.source} />
+            </div>
+            <h4 className="font-semibold mb-1">Message</h4>
+            <pre className="whitespace-pre-wrap break-all text-gray-700 bg-white p-3 rounded border text-sm leading-relaxed">
+              {selected.message}
+            </pre>
+            <h4 className="font-semibold mt-3 mb-1">Labels</h4>
+            <pre className="whitespace-pre-wrap break-all text-gray-500 bg-white p-3 rounded border text-xs">
+              {JSON.stringify(selected.labels, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-gray-500">{logs.length} logs total</span>
+        <div className="flex items-center gap-1">
+          <button onClick={() => setPage(0)} disabled={page === 0}
+            className="px-2 py-1 border rounded disabled:opacity-30 hover:bg-gray-100">&laquo;</button>
+          <button onClick={() => setPage(page - 1)} disabled={page === 0}
+            className="px-2 py-1 border rounded disabled:opacity-30 hover:bg-gray-100">&lsaquo;</button>
+          {pageNumbers(page, totalPages).map((p) =>
+            p === '...' ? (
+              <span key={`dots-${Math.random()}`} className="px-1 text-gray-400">...</span>
+            ) : (
+              <button key={p} onClick={() => setPage(p)}
+                className={`px-2.5 py-1 border rounded ${p === page ? 'bg-blue-600 text-white border-blue-600' : 'hover:bg-gray-100'}`}>
+                {p + 1}
+              </button>
+            )
+          )}
+          <button onClick={() => setPage(page + 1)} disabled={page >= totalPages - 1}
+            className="px-2 py-1 border rounded disabled:opacity-30 hover:bg-gray-100">&rsaquo;</button>
+          <button onClick={() => setPage(totalPages - 1)} disabled={page >= totalPages - 1}
+            className="px-2 py-1 border rounded disabled:opacity-30 hover:bg-gray-100">&raquo;</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }) {
+  return (
+    <div className="flex">
+      <span className="text-gray-500 w-24 shrink-0">{label}:</span>
+      <span className="text-gray-800">{value || '-'}</span>
+    </div>
+  );
+}
+
+function pageNumbers(current, total) {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i);
+  const pages = [];
+  pages.push(0);
+  if (current > 3) pages.push('...');
+  for (let i = Math.max(1, current - 1); i <= Math.min(total - 2, current + 1); i++) pages.push(i);
+  if (current < total - 4) pages.push('...');
+  pages.push(total - 1);
+  return pages;
+}
+
+function LevelBadge({ level }) {
+  const l = (level || '').toUpperCase();
+  const c = l === 'ERROR' || l === 'FATAL' ? 'bg-red-100 text-red-700' :
+    l === 'WARNING' || l === 'WARN' ? 'bg-yellow-100 text-yellow-700' :
+    l === 'INFO' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500';
+  return <span className={`px-2 py-0.5 rounded text-sm ${c}`}>{level || '-'}</span>;
+}

--- a/front/src/components/MeasurementSelector.jsx
+++ b/front/src/components/MeasurementSelector.jsx
@@ -1,0 +1,74 @@
+const RANGE_OPTIONS = [
+  { value: '1h', label: '1H' },
+  { value: '6h', label: '6H' },
+  { value: '12h', label: '12H' },
+  { value: '1d', label: '1D' },
+  { value: '3d', label: '3D' },
+  { value: '5d', label: '5D' },
+  { value: '7d', label: '7D' },
+];
+
+const PERIOD_MAP = {
+  '1h': '1m',
+  '6h': '5m',
+  '12h': '5m',
+  '1d': '5m',
+  '3d': '15m',
+  '5d': '30m',
+  '7d': '1h',
+};
+
+export { RANGE_OPTIONS, PERIOD_MAP };
+
+export default function MeasurementSelector({
+  measurements,
+  selectedMeasurement,
+  onMeasurementChange,
+  selectedRange,
+  onRangeChange,
+  onRefresh,
+  loading,
+}) {
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <select
+        className="border border-gray-300 rounded-md px-3 py-1.5 text-sm bg-white"
+        value={selectedMeasurement}
+        onChange={(e) => onMeasurementChange(e.target.value)}
+      >
+        <option value="">Measurement</option>
+        {measurements.map((m) => (
+          <option key={m} value={m}>{m}</option>
+        ))}
+      </select>
+
+      <div className="flex gap-1">
+        {RANGE_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => onRangeChange(opt.value)}
+            className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
+              selectedRange === opt.value
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      <button
+        onClick={onRefresh}
+        disabled={loading}
+        className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+      >
+        {loading ? 'Loading...' : 'Refresh'}
+      </button>
+
+      <span className="text-xs text-gray-400 ml-auto">
+        Period: {PERIOD_MAP[selectedRange] || '1m'}
+      </span>
+    </div>
+  );
+}

--- a/front/src/components/MetricChart.jsx
+++ b/front/src/components/MetricChart.jsx
@@ -1,0 +1,122 @@
+import Chart from 'react-apexcharts';
+
+const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16'];
+
+/**
+ * @param {string} measurement - e.g. "cpu", "disk", "mem", "net", "system"
+ * @param {string} metric - e.g. "used", "used_percent", "usage_idle", "bytes_recv"
+ */
+export default function MetricChart({ title, series, height = 240, chartType = 'area', measurement, metric }) {
+  if (!series || series.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
+        No data
+      </div>
+    );
+  }
+
+  const unit = detectUnit(measurement, metric);
+  const formatter = buildFormatter(unit);
+  const yTitle = unit.label ? `(${unit.label})` : '';
+
+  const options = {
+    chart: { type: chartType, toolbar: { show: true }, zoom: { enabled: true, type: 'x' }, animations: { enabled: false },
+      events: { scrolled: undefined, mouseWheel: { enabled: false } },
+    },
+    title: { text: title + (yTitle ? ` ${yTitle}` : ''), align: 'center', style: { fontSize: '14px', fontWeight: 600 } },
+    xaxis: { type: 'datetime', labels: { format: 'HH:mm:ss', style: { fontSize: '11px' }, datetimeUTC: false } },
+    yaxis: {
+      labels: { formatter, style: { fontSize: '11px' } },
+      title: { text: unit.label || '', style: { fontSize: '11px' } },
+    },
+    fill: { type: 'solid', opacity: 0.12 },
+    stroke: { curve: 'smooth', width: 2 },
+    colors: COLORS.slice(0, series.length),
+    legend: { show: true, position: 'top', horizontalAlign: 'left', fontSize: '11px' },
+    tooltip: {
+      theme: 'dark',
+      x: { format: 'yyyy-MM-dd HH:mm:ss' },
+      y: { formatter },
+    },
+    grid: { strokeDashArray: 4 },
+    dataLabels: { enabled: false },
+  };
+
+  return <Chart options={options} series={series} type={chartType} height={height} />;
+}
+
+// --- Unit detection ---
+
+const BYTE_FIELDS = [
+  'used', 'free', 'total', 'available', 'active', 'inactive', 'buffered', 'cached', 'shared', 'slab',
+  'bytes_recv', 'bytes_sent',
+  'read_bytes', 'write_bytes',
+];
+const PERCENT_FIELDS = [
+  'used_percent', 'usage_idle', 'usage_user', 'usage_system', 'usage_iowait',
+  'usage_irq', 'usage_softirq', 'usage_steal', 'usage_guest', 'usage_nice',
+  'inodes_used_percent',
+];
+const TIME_FIELDS = ['uptime', 'server_time'];
+
+function detectUnit(measurement, metric) {
+  const m = (metric || '').toLowerCase();
+  const meas = (measurement || '').toLowerCase();
+
+  if (PERCENT_FIELDS.includes(m) || m.includes('percent')) {
+    return { type: 'percent', label: '%' };
+  }
+  if (TIME_FIELDS.includes(m)) {
+    return { type: 'duration', label: 'sec' };
+  }
+  if (BYTE_FIELDS.includes(m)) {
+    if (meas === 'net' || meas === 'diskio') {
+      return { type: 'bytes_rate', label: 'bytes/s' };
+    }
+    return { type: 'bytes', label: 'bytes' };
+  }
+  return { type: 'number', label: '' };
+}
+
+function buildFormatter(unit) {
+  switch (unit.type) {
+    case 'percent':
+      return (v) => (v != null ? v.toFixed(1) + '%' : '');
+    case 'bytes':
+      return formatBytes;
+    case 'bytes_rate':
+      return (v) => formatBytes(v) + '/s';
+    case 'duration':
+      return formatDuration;
+    default:
+      return (v) => (v != null ? smartNumber(v) : '');
+  }
+}
+
+function formatBytes(v) {
+  if (v == null) return '';
+  const abs = Math.abs(v);
+  if (abs >= 1e12) return (v / 1e12).toFixed(2) + ' TB';
+  if (abs >= 1e9) return (v / 1e9).toFixed(2) + ' GB';
+  if (abs >= 1e6) return (v / 1e6).toFixed(2) + ' MB';
+  if (abs >= 1e3) return (v / 1e3).toFixed(1) + ' KB';
+  return v.toFixed(0) + ' B';
+}
+
+function formatDuration(v) {
+  if (v == null) return '';
+  if (v >= 86400) return (v / 86400).toFixed(1) + 'd';
+  if (v >= 3600) return (v / 3600).toFixed(1) + 'h';
+  if (v >= 60) return (v / 60).toFixed(1) + 'm';
+  return v.toFixed(0) + 's';
+}
+
+function smartNumber(v) {
+  if (v == null) return '';
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return (v / 1e9).toFixed(2) + 'G';
+  if (abs >= 1e6) return (v / 1e6).toFixed(2) + 'M';
+  if (abs >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+  if (Number.isInteger(v)) return v.toString();
+  return v.toFixed(2);
+}

--- a/front/src/context/AppContext.jsx
+++ b/front/src/context/AppContext.jsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+const AppContext = createContext(null);
+
+export function AppProvider({ children }) {
+  const [token, setToken] = useState(null);
+  const [workspaceInfo, setWorkspaceInfo] = useState(null);
+  const [projectInfo, setProjectInfo] = useState(null);
+  const [ready, setReady] = useState(false);
+
+  const handleMessage = useCallback((event) => {
+    const data = event.data;
+    if (!data || typeof data !== 'object' || !data.accessToken) return;
+    setToken(data.accessToken);
+    setWorkspaceInfo(data.workspaceInfo || null);
+    setProjectInfo(data.projectInfo || null);
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage);
+
+    // Allow standalone usage with URL params for dev/testing
+    const params = new URLSearchParams(window.location.search);
+    const urlToken = params.get('token');
+    if (urlToken) {
+      setToken(urlToken);
+      setProjectInfo({ ns_id: params.get('ns_id') || '' });
+      setReady(true);
+    }
+
+    return () => window.removeEventListener('message', handleMessage);
+  }, [handleMessage]);
+
+  const nsId = projectInfo?.ns_id || '';
+
+  return (
+    <AppContext.Provider value={{ token, workspaceInfo, projectInfo, nsId, ready }}>
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+export function useAppContext() {
+  return useContext(AppContext);
+}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/front/src/main.jsx
+++ b/front/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AppProvider } from './context/AppContext';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AppProvider>
+        <App />
+      </AppProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -1,0 +1,194 @@
+import { useState, useEffect } from 'react';
+import { getPolicies, createPolicy, deletePolicy, addVmToPolicy } from '../api/trigger';
+import { getNotiChannels, getNotiHistory } from '../api/trigger';
+import { useParams } from 'react-router-dom';
+
+const TABS = ['Policies', 'Notification History'];
+const RESOURCE_TYPES = ['CPU', 'MEMORY', 'DISK'];
+const AGG_TYPES = ['AVG', 'MAX', 'MIN', 'LAST'];
+
+export default function AlertManager() {
+  const { nsId, mciId } = useParams();
+  const [tab, setTab] = useState(0);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-1 bg-white rounded-lg shadow px-2 py-1">
+        {TABS.map((t, i) => (
+          <button key={t} onClick={() => setTab(i)}
+            className={`px-4 py-2 text-sm rounded ${tab === i ? 'bg-red-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}>
+            {t}
+          </button>
+        ))}
+      </div>
+      {tab === 0 && <PoliciesTab nsId={nsId} mciId={mciId} />}
+      {tab === 1 && <NotiHistoryTab />}
+    </div>
+  );
+}
+
+function PoliciesTab({ nsId, mciId }) {
+  const [policies, setPolicies] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const load = () => {
+    setLoading(true);
+    getPolicies(1, 50).then(data => setPolicies(data.content || []))
+      .catch(() => setPolicies([]))
+      .finally(() => setLoading(false));
+  };
+  useEffect(load, []);
+
+  async function handleDelete(id) {
+    await deletePolicy(id);
+    load();
+  }
+
+  async function handleAddVm(policyId) {
+    if (!nsId || !mciId) { alert('NS/MCI not set'); return; }
+    await addVmToPolicy(policyId, { namespaceId: nsId, targetScope: 'mci', targetId: mciId });
+    load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b flex justify-between items-center">
+          <span className="font-semibold text-sm">Trigger Policies</span>
+          <button onClick={() => setShowCreate(!showCreate)} className="text-xs bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700">
+            {showCreate ? 'Cancel' : '+ New Policy'}
+          </button>
+        </div>
+        {showCreate && <CreatePolicyForm onCreated={() => { setShowCreate(false); load(); }} />}
+        <div className="p-4 overflow-auto">
+          {loading ? <p className="text-sm text-gray-400">Loading...</p> : policies.length === 0 ? (
+            <p className="text-sm text-gray-400">No policies</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Title</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Resource</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Thresholds</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">VMs</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Actions</th>
+              </tr></thead>
+              <tbody>
+                {policies.map(p => (
+                  <tr key={p.id} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 border-b">{p.id}</td>
+                    <td className="px-3 py-2 border-b">{p.title}</td>
+                    <td className="px-3 py-2 border-b">{p.resourceType}</td>
+                    <td className="px-3 py-2 border-b text-xs">
+                      {p.thresholdCondition && `I:${p.thresholdCondition.info} W:${p.thresholdCondition.warning} C:${p.thresholdCondition.critical}`}
+                    </td>
+                    <td className="px-3 py-2 border-b text-xs">{p.vms?.length || 0}</td>
+                    <td className="px-3 py-2 border-b text-right space-x-2">
+                      <button onClick={() => handleAddVm(p.id)} className="text-xs text-blue-500 hover:text-blue-700">+MCI</button>
+                      <button onClick={() => handleDelete(p.id)} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CreatePolicyForm({ onCreated }) {
+  const [title, setTitle] = useState('');
+  const [desc, setDesc] = useState('');
+  const [resource, setResource] = useState('CPU');
+  const [agg, setAgg] = useState('AVG');
+  const [info, setInfo] = useState(20);
+  const [warning, setWarning] = useState(50);
+  const [critical, setCritical] = useState(80);
+  const [hold, setHold] = useState('5m');
+  const [repeat, setRepeat] = useState('1h');
+
+  async function submit(e) {
+    e.preventDefault();
+    await createPolicy({
+      title, description: desc, resourceType: resource, aggregationType: agg,
+      holdDuration: hold, repeatInterval: repeat,
+      thresholdCondition: { info: +info, warning: +warning, critical: +critical },
+    });
+    onCreated();
+  }
+
+  return (
+    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <input placeholder="Title" required value={title} onChange={e => setTitle(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <input placeholder="Description" value={desc} onChange={e => setDesc(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <select value={resource} onChange={e => setResource(e.target.value)} className="border rounded px-3 py-1.5 text-sm">
+          {RESOURCE_TYPES.map(r => <option key={r}>{r}</option>)}
+        </select>
+        <select value={agg} onChange={e => setAgg(e.target.value)} className="border rounded px-3 py-1.5 text-sm">
+          {AGG_TYPES.map(a => <option key={a}>{a}</option>)}
+        </select>
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <input type="number" placeholder="Info" value={info} onChange={e => setInfo(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <input type="number" placeholder="Warning" value={warning} onChange={e => setWarning(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <input type="number" placeholder="Critical" value={critical} onChange={e => setCritical(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <input placeholder="Hold (e.g. 5m)" value={hold} onChange={e => setHold(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <input placeholder="Repeat (e.g. 1h)" value={repeat} onChange={e => setRepeat(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+      </div>
+      <button type="submit" className="bg-red-600 text-white px-4 py-1.5 rounded text-sm hover:bg-red-700">Create</button>
+    </form>
+  );
+}
+
+function NotiHistoryTab() {
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getNotiHistory(1, 50).then(d => setHistory(d.content || []))
+      .catch(() => setHistory([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <div className="px-4 py-3 border-b font-semibold text-sm">Notification History</div>
+      <div className="p-4 overflow-auto">
+        {loading ? <p className="text-sm text-gray-400">Loading...</p> : history.length === 0 ? (
+          <p className="text-sm text-gray-400">No notifications</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead><tr className="bg-gray-50 text-left">
+              <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
+              <th className="px-3 py-2 border-b text-xs text-gray-500">Channel</th>
+              <th className="px-3 py-2 border-b text-xs text-gray-500">Recipients</th>
+              <th className="px-3 py-2 border-b text-xs text-gray-500">Status</th>
+              <th className="px-3 py-2 border-b text-xs text-gray-500">Time</th>
+            </tr></thead>
+            <tbody>
+              {history.map(h => (
+                <tr key={h.id} className="hover:bg-gray-50">
+                  <td className="px-3 py-2 border-b">{h.id}</td>
+                  <td className="px-3 py-2 border-b">{h.channel}</td>
+                  <td className="px-3 py-2 border-b text-xs">{h.recipients?.join(', ')}</td>
+                  <td className="px-3 py-2 border-b">
+                    <span className={`text-xs px-2 py-0.5 rounded-full ${h.isSucceeded ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+                      {h.isSucceeded ? 'OK' : 'FAIL'}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -1,0 +1,157 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppContext } from '../context/AppContext';
+import { setApiToken } from '../api/client';
+import { getNsList, getMciList, getMci } from '../api/tumblebug';
+
+export default function HomePage() {
+  const navigate = useNavigate();
+  const { token } = useAppContext();
+
+  const [bypassAuth, setBypassAuth] = useState(true);
+  const [manualToken, setManualToken] = useState('');
+
+  // Tumblebug cascade
+  const [nsList, setNsList] = useState([]);
+  const [nsId, setNsId] = useState('');
+  const [mciList, setMciList] = useState([]);
+  const [mciId, setMciId] = useState('');
+  const [vmList, setVmList] = useState([]);
+  const [vmId, setVmId] = useState('');
+  const [loadingNs, setLoadingNs] = useState(false);
+  const [loadingMci, setLoadingMci] = useState(false);
+  const [loadingVm, setLoadingVm] = useState(false);
+
+  useEffect(() => {
+    if (token) setManualToken(token);
+  }, [token]);
+
+  // Apply bypass on mount and whenever toggle changes
+  useEffect(() => {
+    if (bypassAuth) setApiToken('bypass');
+    else if (manualToken) setApiToken(manualToken);
+  }, [bypassAuth, manualToken]);
+
+  // Load NS list on mount
+  useEffect(() => {
+    setLoadingNs(true);
+    getNsList()
+      .then(setNsList)
+      .catch((e) => { console.error('NS load failed', e); setNsList([]); })
+      .finally(() => setLoadingNs(false));
+  }, [bypassAuth]);
+
+  // Load MCI when NS changes
+  useEffect(() => {
+    setMciList([]);
+    setMciId('');
+    setVmList([]);
+    setVmId('');
+    if (!nsId) return;
+    setLoadingMci(true);
+    getMciList(nsId)
+      .then((list) => setMciList(Array.isArray(list) ? list : []))
+      .catch(() => setMciList([]))
+      .finally(() => setLoadingMci(false));
+  }, [nsId]);
+
+  // Load VMs when MCI changes
+  useEffect(() => {
+    setVmList([]);
+    setVmId('');
+    if (!nsId || !mciId) return;
+    setLoadingVm(true);
+    getMci(nsId, mciId)
+      .then((data) => setVmList(data.vm || []))
+      .catch(() => setVmList([]))
+      .finally(() => setLoadingVm(false));
+  }, [nsId, mciId]);
+
+  function go(page) {
+    if (bypassAuth) {
+      setApiToken('bypass');
+    } else if (manualToken) {
+      setApiToken(manualToken);
+    }
+    if (!nsId || !mciId) {
+      alert('Namespace and MCI are required.');
+      return;
+    }
+    let path = `/${page}/${nsId}/${mciId}`;
+    if (vmId) path += `/${vmId}`;
+    navigate(path);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-lg shadow-lg p-8 w-full max-w-xl">
+        <h1 className="text-xl font-bold mb-1">MC-Observability</h1>
+        <p className="text-sm text-gray-500 mb-6">Standalone Test Console</p>
+
+        {/* Auth */}
+        <div className="mb-4">
+          <label className="flex items-center gap-2 text-sm mb-2 cursor-pointer">
+            <input type="checkbox" checked={bypassAuth} onChange={(e) => setBypassAuth(e.target.checked)} className="rounded" />
+            Bypass Authentication
+          </label>
+          {!bypassAuth && (
+            <input type="text" placeholder="Bearer token..." value={manualToken} onChange={(e) => setManualToken(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm font-mono" />
+          )}
+        </div>
+
+        {/* Tumblebug cascade selectors */}
+        <div className="space-y-3 mb-6">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Namespace (ns_id) *</label>
+            <select className="w-full border border-gray-300 rounded px-3 py-2 text-sm" value={nsId} onChange={(e) => setNsId(e.target.value)} disabled={loadingNs}>
+              <option value="">{loadingNs ? 'Loading...' : 'Select Namespace'}</option>
+              {nsList.map((ns) => <option key={ns.id} value={ns.id}>{ns.name || ns.id}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">MCI (mci_id) *</label>
+            <select className="w-full border border-gray-300 rounded px-3 py-2 text-sm" value={mciId} onChange={(e) => setMciId(e.target.value)} disabled={!nsId || loadingMci}>
+              <option value="">{loadingMci ? 'Loading...' : 'Select MCI'}</option>
+              {mciList.map((m) => <option key={m.id} value={m.id}>{m.name || m.id}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">VM (vm_id) — optional</label>
+            <select className="w-full border border-gray-300 rounded px-3 py-2 text-sm" value={vmId} onChange={(e) => setVmId(e.target.value)} disabled={!mciId || loadingVm}>
+              <option value="">{loadingVm ? 'Loading...' : 'All VMs'}</option>
+              {vmList.map((vm) => <option key={vm.id} value={vm.id}>{vm.name || vm.id} ({vm.status})</option>)}
+            </select>
+          </div>
+        </div>
+
+        {/* Nav buttons */}
+        <div className="grid grid-cols-2 gap-3">
+          <button onClick={() => go('monitoring')} className="bg-blue-600 text-white rounded py-2.5 text-sm font-medium hover:bg-blue-700">
+            Monitoring
+          </button>
+          <button onClick={() => go('logs')} className="bg-emerald-600 text-white rounded py-2.5 text-sm font-medium hover:bg-emerald-700">
+            Logs
+          </button>
+          <button onClick={() => go('config')} className="bg-amber-600 text-white rounded py-2.5 text-sm font-medium hover:bg-amber-700">
+            Monitoring Config
+          </button>
+          <button onClick={() => go('insight')} className="bg-purple-600 text-white rounded py-2.5 text-sm font-medium hover:bg-purple-700">
+            Insight
+          </button>
+          <button onClick={() => go('alerts')} className="bg-red-600 text-white rounded py-2.5 text-sm font-medium hover:bg-red-700">
+            Alerts
+          </button>
+          <button onClick={() => {
+            if (!nsId || !mciId) { alert('Select NS and MCI first'); return; }
+            window.open(vmId ? `/embed/monitoring/${nsId}/${mciId}/${vmId}` : `/embed/monitoring/${nsId}/${mciId}`, '_blank');
+          }} className="bg-gray-600 text-white rounded py-2.5 text-sm font-medium hover:bg-gray-700">
+            Embed Preview
+          </button>
+        </div>
+
+        <p className="mt-4 text-xs text-gray-400">NS/MCI/VM are loaded from Tumblebug. /embed/* routes have no nav (iframe mode).</p>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -1,0 +1,179 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { getAnomalySettings, createAnomalySetting, deleteAnomalySetting, getAnomalyHistory, getAnomalyMeasurements } from '../api/insight';
+import { getPredictionHistory, runPrediction } from '../api/insight';
+import { getVmList } from '../api/vm';
+import MetricChart from '../components/MetricChart';
+
+const TABS = ['Anomaly Detection', 'Prediction'];
+
+export default function InsightDashboard() {
+  const { nsId, mciId, vmId } = useParams();
+  const [tab, setTab] = useState(0);
+
+  return (
+    <div className="space-y-4">
+      {/* Tab bar */}
+      <div className="flex gap-1 bg-white rounded-lg shadow px-2 py-1">
+        {TABS.map((t, i) => (
+          <button key={t} onClick={() => setTab(i)}
+            className={`px-4 py-2 text-sm rounded ${tab === i ? 'bg-purple-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}>
+            {t}
+          </button>
+        ))}
+      </div>
+      {tab === 0 && <AnomalyTab nsId={nsId} mciId={mciId} vmId={vmId} />}
+      {tab === 1 && <PredictionTab nsId={nsId} mciId={mciId} vmId={vmId} />}
+    </div>
+  );
+}
+
+function AnomalyTab({ nsId, mciId, vmId }) {
+  const [settings, setSettings] = useState([]);
+  const [measurements, setMeasurements] = useState([]);
+  const [selectedMeasurement, setSelectedMeasurement] = useState('');
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getAnomalySettings().then(setSettings).catch(() => {});
+    getAnomalyMeasurements().then((d) => {
+      if (Array.isArray(d)) setMeasurements(d.map(m => m.measurement || m));
+      else setMeasurements([]);
+    }).catch(() => {});
+  }, []);
+
+  async function loadHistory() {
+    if (!selectedMeasurement) return;
+    setLoading(true);
+    try {
+      const data = await getAnomalyHistory(nsId, mciId, vmId, selectedMeasurement);
+      setHistory(data.values || []);
+    } catch { setHistory([]); }
+    setLoading(false);
+  }
+
+  async function handleDelete(seq) {
+    await deleteAnomalySetting(seq);
+    setSettings(await getAnomalySettings());
+  }
+
+  const chartSeries = history.length > 0 ? [{
+    name: 'Anomaly Score',
+    data: history.map(h => ({ x: new Date(h.timestamp).getTime(), y: h.anomaly_score })),
+  }] : [];
+
+  return (
+    <div className="space-y-4">
+      {/* Settings table */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">Anomaly Detection Settings</div>
+        <div className="p-4 overflow-auto">
+          {settings.length === 0 ? (
+            <p className="text-sm text-gray-400">No settings configured</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Seq</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">NS / MCI / VM</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Measurement</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Actions</th>
+              </tr></thead>
+              <tbody>
+                {settings.map((s, i) => (
+                  <tr key={s.settingSeq || s.seq || i} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 border-b">{s.settingSeq || s.seq}</td>
+                    <td className="px-3 py-2 border-b">{s.nsId || s.ns_id}/{s.mciId || s.mci_id}/{s.vmId || s.vm_id || '-'}</td>
+                    <td className="px-3 py-2 border-b">{s.measurement || '-'}</td>
+                    <td className="px-3 py-2 border-b text-right">
+                      <button onClick={() => handleDelete(s.settingSeq || s.seq)} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* History chart */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">Anomaly Detection History</div>
+        <div className="p-4">
+          <div className="flex gap-3 mb-4">
+            <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMeasurement} onChange={(e) => setSelectedMeasurement(e.target.value)}>
+              <option value="">Select Measurement</option>
+              {measurements.map(m => <option key={m} value={m}>{m}</option>)}
+            </select>
+            <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
+              {loading ? 'Loading...' : 'Load History'}
+            </button>
+          </div>
+          <MetricChart title="Anomaly Score" series={chartSeries} height={240} chartType="line" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PredictionTab({ nsId, mciId, vmId }) {
+  const [measurements, setMeasurements] = useState([]);
+  const [selectedMeasurement, setSelectedMeasurement] = useState('');
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getAnomalyMeasurements().then((d) => {
+      if (Array.isArray(d)) setMeasurements(d.map(m => m.measurement || m));
+      else setMeasurements([]);
+    }).catch(() => {});
+  }, []);
+
+  async function loadHistory() {
+    if (!selectedMeasurement) return;
+    setLoading(true);
+    try {
+      const data = await getPredictionHistory(nsId, mciId, vmId, selectedMeasurement);
+      setHistory(data.values || []);
+    } catch { setHistory([]); }
+    setLoading(false);
+  }
+
+  async function handleRunPrediction() {
+    if (!selectedMeasurement) return;
+    setLoading(true);
+    try {
+      await runPrediction(nsId, mciId, vmId, { measurement: selectedMeasurement });
+      await loadHistory();
+    } catch (e) {
+      console.error('Prediction failed', e);
+    }
+    setLoading(false);
+  }
+
+  const chartSeries = history.length > 0 ? [{
+    name: 'Prediction',
+    data: history.map(h => ({ x: new Date(h.timestamp).getTime(), y: parseFloat(h.value) })),
+  }] : [];
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <div className="px-4 py-3 border-b font-semibold text-sm">Prediction</div>
+      <div className="p-4">
+        <div className="flex gap-3 mb-4">
+          <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMeasurement} onChange={(e) => setSelectedMeasurement(e.target.value)}>
+            <option value="">Select Measurement</option>
+            {measurements.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+          <button onClick={handleRunPrediction} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
+            Run Prediction
+          </button>
+          <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
+            Load History
+          </button>
+        </div>
+        <MetricChart title="Prediction" series={chartSeries} height={240} />
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -1,0 +1,103 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { queryLogs } from '../api/logs';
+import { getMci } from '../api/tumblebug';
+import LogTable from '../components/LogTable';
+
+export default function LogViewer() {
+  const { nsId, mciId, vmId: routeVmId } = useParams();
+
+  const [vms, setVms] = useState([]);
+  const [selectedVmId, setSelectedVmId] = useState(routeVmId || '');
+  const [keyword, setKeyword] = useState('');
+  const [logs, setLogs] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  // Load VM list from Tumblebug
+  useEffect(() => {
+    if (!nsId || !mciId) return;
+    getMci(nsId, mciId)
+      .then((data) => setVms(data.vm || []))
+      .catch(() => setVms([]));
+  }, [nsId, mciId]);
+
+  useEffect(() => {
+    if (routeVmId) setSelectedVmId(routeVmId);
+  }, [routeVmId]);
+
+  const search = useCallback(async () => {
+    if (!nsId || !mciId) return;
+    setLoading(true);
+    try {
+      const result = await queryLogs({ nsId, mciId, vmId: selectedVmId, keyword });
+      setLogs(Array.isArray(result) ? result : []);
+    } catch (e) {
+      console.error('Log query failed', e);
+      setLogs([]);
+    }
+    setLoading(false);
+  }, [nsId, mciId, selectedVmId, keyword]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') search();
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Card: Log Manage */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">Log Manage</div>
+        <div className="p-4">
+          <div className="grid grid-cols-4 gap-4 mb-4">
+            {/* Workload (readonly) */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Workload</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={mciId || ''} readOnly />
+            </div>
+            {/* Server */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Server</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedVmId} onChange={(e) => setSelectedVmId(e.target.value)}>
+                <option value="">All</option>
+                {vms.map((vm) => {
+                  const id = vm.id || vm.vm_id || vm.name;
+                  return <option key={id} value={id}>{vm.name || id}</option>;
+                })}
+              </select>
+            </div>
+            {/* Keyword */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Keyword</label>
+              <input
+                type="text"
+                placeholder="Search keyword..."
+                value={keyword}
+                onChange={(e) => setKeyword(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              />
+            </div>
+            {/* Search button */}
+            <div className="flex items-end">
+              <button
+                onClick={search}
+                disabled={loading}
+                className="px-4 py-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm"
+              >
+                {loading ? 'Searching...' : 'Search'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Card: Log list */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">List of Log</div>
+        <div className="p-4">
+          <LogTable logs={logs} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/MciOverview.jsx
+++ b/front/src/pages/MciOverview.jsx
@@ -1,0 +1,302 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getMci } from '../api/tumblebug';
+import { getMetricsByVM } from '../api/monitoring';
+import { getAllCspMetrics, isCspSupported } from '../api/csp';
+import MetricChart from '../components/MetricChart';
+
+const AGENT_METRICS = [
+  { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
+  { key: 'mem', measurement: 'mem', field: 'used_percent', label: 'Memory Used', unit: '%' },
+  { key: 'disk', measurement: 'disk', field: 'used_percent', label: 'Disk Used', unit: '%' },
+];
+
+const CSP_OVERVIEW_KEYS = ['cpu_usage', 'memory_usage', 'network_in'];
+
+export default function MciOverview() {
+  const { nsId, mciId } = useParams();
+  const navigate = useNavigate();
+  const [vms, setVms] = useState([]);
+  const [vmData, setVmData] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [metricsLoading, setMetricsLoading] = useState(false);
+  const [selectedChart, setSelectedChart] = useState('cpu');
+  const [dataSource, setDataSource] = useState('agent'); // 'agent' | 'csp'
+
+  useEffect(() => {
+    if (!nsId || !mciId) return;
+    loadVms();
+  }, [nsId, mciId]);
+
+  async function loadVms() {
+    setLoading(true);
+    try {
+      const mciData = await getMci(nsId, mciId);
+      const vmList = mciData.vm || [];
+      setVms(vmList);
+      // Load metrics right after we have VMs
+      if (vmList.length > 0) {
+        setMetricsLoading(true);
+        if (dataSource === 'agent') await loadAgentData(vmList);
+        else await loadCspData(vmList);
+        setMetricsLoading(false);
+      }
+    } catch { setVms([]); }
+    setLoading(false);
+  }
+
+  // Reload when dataSource changes
+  useEffect(() => {
+    if (vms.length === 0) return;
+    setVmData({});
+    setMetricsLoading(true);
+    const load = dataSource === 'agent' ? loadAgentData : loadCspData;
+    load(vms).finally(() => setMetricsLoading(false));
+  }, [dataSource]);
+
+  async function loadAgentData(vmList) {
+    const data = {};
+    for (const vm of vmList) {
+      data[vm.id] = {};
+    }
+    await Promise.allSettled(
+      vmList.map(async (vm) => {
+        await Promise.allSettled(
+          AGENT_METRICS.map(async (m) => {
+            try {
+              const res = await getMetricsByVM(nsId, mciId, vm.id, {
+                measurement: m.measurement, range: '1h', groupTime: '1m',
+                fields: [{ function: 'mean', field: m.field }],
+              });
+              data[vm.id][m.key] = { res, ...m };
+            } catch (e) {
+              data[vm.id][m.key] = { res: [], ...m };
+            }
+          })
+        );
+      })
+    );
+    setVmData({ ...data });
+  }
+
+  async function loadCspData(vmList) {
+    const data = {};
+    await Promise.allSettled(
+      vmList.map(async (vm) => {
+        if (!vm.connectionName || !vm.cspResourceName) return;
+        const cspData = await getAllCspMetrics(vm.connectionName, vm.cspResourceName, '1');
+        data[vm.id] = cspData;
+      })
+    );
+    setVmData({ ...data });
+  }
+
+  if (loading) return <p className="text-sm text-gray-400 p-4">Loading VMs...</p>;
+  if (vms.length === 0) return <p className="text-sm text-gray-400 p-4">No VMs found</p>;
+
+  const hasCspVm = vms.some((vm) => isCspSupported(vm.connectionName));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">MCI Overview — {mciId}</h2>
+        <div className="flex items-center gap-3">
+          {hasCspVm && (
+            <div className="flex bg-gray-100 rounded-lg p-0.5 text-xs">
+              <button onClick={() => setDataSource('agent')}
+                className={`px-3 py-1 rounded-md ${dataSource === 'agent' ? 'bg-white shadow text-blue-600 font-medium' : 'text-gray-500'}`}>
+                Agent
+              </button>
+              <button onClick={() => setDataSource('csp')}
+                className={`px-3 py-1 rounded-md ${dataSource === 'csp' ? 'bg-white shadow text-blue-600 font-medium' : 'text-gray-500'}`}>
+                CSP
+              </button>
+            </div>
+          )}
+          <span className="text-xs text-gray-400">{vms.length} VMs</span>
+        </div>
+      </div>
+
+      {vms.map((vm) => (
+        <VmCard
+          key={vm.id}
+          vm={vm}
+          vmMetrics={vmData[vm.id] || {}}
+          dataSource={dataSource}
+          metricsLoading={metricsLoading}
+          selectedChart={selectedChart}
+          onSelectChart={setSelectedChart}
+          onClickChart={() => navigate(`/monitoring/${nsId}/${mciId}/${vm.id}${dataSource === 'csp' ? '?source=csp' : ''}`)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function VmCard({ vm, vmMetrics, dataSource, metricsLoading, selectedChart, onSelectChart, onClickChart }) {
+  const cspSupported = isCspSupported(vm.connectionName);
+
+  if (dataSource === 'csp') {
+    return <CspVmCard vm={vm} metrics={vmMetrics} metricsLoading={metricsLoading} selectedChart={selectedChart} onSelectChart={onSelectChart} onClickChart={onClickChart} cspSupported={cspSupported} />;
+  }
+  return <AgentVmCard vm={vm} metrics={vmMetrics} metricsLoading={metricsLoading} selectedChart={selectedChart} onSelectChart={onSelectChart} onClickChart={onClickChart} cspSupported={cspSupported} />;
+}
+
+function AgentVmCard({ vm, metrics, metricsLoading, selectedChart, onSelectChart, onClickChart, cspSupported }) {
+  const gauges = AGENT_METRICS.map((m) => {
+    const d = metrics[m.key];
+    const last = d?.res ? getLastValue(d.res) : null;
+    const val = last != null ? (m.invert ? 100 - last : last) : null;
+    return { ...m, value: val, display: val != null ? val.toFixed(1) + '%' : '-' };
+  });
+
+  const activeMetric = AGENT_METRICS.find((m) => m.key === selectedChart) || AGENT_METRICS[0];
+  const chartData = metrics[selectedChart];
+  const chartSeries = chartData?.res ? toSeries(chartData.res, activeMetric.label, activeMetric.invert) : [];
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <VmHeader vm={vm} showCspBadge={false} cspAvailable={cspSupported} />
+      <div className="flex">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
+          {gauges.map((g) => (
+            <GaugeItem key={g.key} g={g} active={selectedChart === g.key} onClick={() => onSelectChart(g.key)} />
+          ))}
+        </div>
+        <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
+          {metricsLoading ? (
+            <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading data...</div>
+          ) : (
+            <MetricChart title={activeMetric.label} series={chartSeries} height={220} measurement={activeMetric.measurement} metric={activeMetric.field} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CspVmCard({ vm, metrics, metricsLoading, selectedChart, onSelectChart, onClickChart, cspSupported }) {
+  if (!cspSupported) {
+    return (
+      <div className="bg-white rounded-lg shadow">
+        <VmHeader vm={vm} showCspBadge={true} cspAvailable={false} />
+        <div className="p-8 text-center text-sm text-gray-400">CSP monitoring not supported for this provider</div>
+      </div>
+    );
+  }
+
+  const cspKeys = Object.keys(metrics);
+  const activeKey = cspKeys.includes(selectedChart) ? selectedChart : (cspKeys[0] || 'cpu_usage');
+  const activeData = metrics[activeKey];
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <VmHeader vm={vm} showCspBadge={true} cspAvailable={true} />
+      <div className="flex">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
+          {cspKeys.map((key) => {
+            const m = metrics[key];
+            const lastVal = m?.series?.[0]?.data?.length > 0 ? m.series[0].data[m.series[0].data.length - 1].y : null;
+            const display = lastVal != null ? formatCspValue(lastVal, m.metricUnit) : '-';
+            return (
+              <GaugeItem key={key} g={{ key, label: m?.metricName || key, display }}
+                active={activeKey === key} onClick={() => onSelectChart(key)} noBar />
+            );
+          })}
+        </div>
+        <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
+          {metricsLoading ? (
+            <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading CSP data...</div>
+          ) : activeData?.series ? (
+            <MetricChart title={`${activeData.metricName} (${activeData.metricUnit})`} series={activeData.series} height={220} />
+          ) : (
+            <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm">No data</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VmHeader({ vm, showCspBadge, cspAvailable }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-b">
+      <div className="flex items-center gap-3">
+        <span className="font-semibold text-sm">{vm.name || vm.id}</span>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${vm.status === 'Running' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{vm.status || '-'}</span>
+        {showCspBadge && cspAvailable && <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600">CSP</span>}
+        {cspAvailable && !showCspBadge && <span className="text-xs text-gray-400">(CSP available)</span>}
+      </div>
+      <div className="text-xs text-gray-400">{vm.connectionName} {vm.publicIP && <span className="ml-2 font-mono">{vm.publicIP}</span>}</div>
+    </div>
+  );
+}
+
+function GaugeItem({ g, active, onClick, noBar }) {
+  return (
+    <div onClick={onClick}
+      className={`cursor-pointer rounded-md px-2 py-1.5 transition-colors ${active ? 'bg-blue-50 ring-1 ring-blue-300' : 'hover:bg-gray-50'}`}>
+      <div className="flex justify-between text-xs mb-1">
+        <span className={`font-medium ${active ? 'text-blue-700' : 'text-gray-500'}`}>{g.label}</span>
+        <span className={`font-semibold ${getColor(g.value)}`}>{g.display}</span>
+      </div>
+      {!noBar && g.value != null && (
+        <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+          <div className={`h-full rounded-full ${getBarColor(g.value)}`} style={{ width: `${Math.min(100, g.value)}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatCspValue(v, unit) {
+  if (v == null) return '-';
+  const u = (unit || '').toLowerCase();
+  if (u.includes('percent') || u === '%') return v.toFixed(1) + '%';
+  if (u.includes('bytes')) {
+    if (v >= 1e9) return (v / 1e9).toFixed(2) + ' GB';
+    if (v >= 1e6) return (v / 1e6).toFixed(2) + ' MB';
+    if (v >= 1e3) return (v / 1e3).toFixed(1) + ' KB';
+    return v.toFixed(0) + ' B';
+  }
+  return v.toFixed(2);
+}
+
+function getLastValue(metricDTOs) {
+  if (!metricDTOs || metricDTOs.length === 0) return null;
+  const m = metricDTOs[0];
+  if (!m.values || m.values.length === 0) return null;
+  const lastRow = m.values[m.values.length - 1];
+  const timeIdx = (m.columns || []).indexOf('timestamp');
+  const valIdx = timeIdx === 0 ? 1 : 0;
+  return lastRow[valIdx] != null ? parseFloat(lastRow[valIdx]) : null;
+}
+
+function toSeries(metricDTOs, name, invert) {
+  if (!metricDTOs || metricDTOs.length === 0) return [];
+  return metricDTOs.map((m) => {
+    const timeIdx = (m.columns || []).indexOf('timestamp');
+    const valIdx = timeIdx === 0 ? 1 : 0;
+    return {
+      name: name || 'value',
+      data: (m.values || []).filter((row) => row[valIdx] != null).map((row) => ({
+        x: typeof row[timeIdx] === 'string' ? new Date(row[timeIdx]).getTime() : row[timeIdx],
+        y: invert ? 100 - parseFloat(row[valIdx]) : parseFloat(row[valIdx]),
+      })),
+    };
+  });
+}
+
+function getColor(v) {
+  if (v == null) return 'text-gray-400';
+  if (v >= 80) return 'text-red-600';
+  if (v >= 60) return 'text-yellow-600';
+  return 'text-green-600';
+}
+
+function getBarColor(v) {
+  if (v == null) return 'bg-gray-300';
+  if (v >= 80) return 'bg-red-500';
+  if (v >= 60) return 'bg-yellow-500';
+  return 'bg-blue-500';
+}

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { getVmList, getVm, getVmItems, installAgent, uninstallAgent, createVmItem, deleteVmItem } from '../api/vm';
+import { getPlugins } from '../api/monitoring';
+import { getMci } from '../api/tumblebug';
+
+export default function MonitoringConfig() {
+  const { nsId, mciId } = useParams();
+  const [vms, setVms] = useState([]);
+  const [filter, setFilter] = useState('');
+  const [selectedVm, setSelectedVm] = useState(null);
+  const [items, setItems] = useState([]);
+  const [plugins, setPlugins] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [itemLoading, setItemLoading] = useState(false);
+  const [busy, setBusy] = useState(false); // block metric toggles
+  const [busyMsg, setBusyMsg] = useState('');
+  const [globalBusy, setGlobalBusy] = useState(false); // block entire page (install/uninstall)
+  const pollRef = useRef(null);
+
+  const loadVms = useCallback(async () => {
+    if (!nsId || !mciId) return;
+    setLoading(true);
+    try {
+      const mciData = await getMci(nsId, mciId);
+      const tbVms = mciData.vm || [];
+      let o11yVms = [];
+      try { o11yVms = await getVmList(nsId, mciId); } catch {}
+      const o11yMap = {};
+      o11yVms.forEach((v) => { o11yMap[v.vm_id || v.id] = v; });
+      setVms(tbVms.map((vm) => {
+        const o = o11yMap[vm.id] || {};
+        return { ...vm, monitoring_agent_status: o.monitoring_agent_status || null, log_agent_status: o.log_agent_status || null, registered: !!o11yMap[vm.id] };
+      }));
+    } catch { setVms([]); }
+    setLoading(false);
+  }, [nsId, mciId]);
+
+  useEffect(() => { loadVms(); return () => { if (pollRef.current) clearInterval(pollRef.current); }; }, [loadVms]);
+  useEffect(() => { getPlugins().then(setPlugins).catch(() => setPlugins([])); }, []);
+
+  async function selectVm(vm) {
+    if (globalBusy) return;
+    setSelectedVm(vm);
+    setItems([]);
+    if (!vm.registered) return;
+    setItemLoading(true);
+    try { setItems(await getVmItems(nsId, mciId, vm.id)); } catch { setItems([]); }
+    setItemLoading(false);
+  }
+
+  // --- Install / Uninstall with polling ---
+  async function handleInstall(e, vm) {
+    e.stopPropagation();
+    if (!confirm(`Install monitoring agent on "${vm.name || vm.id}"?`)) return;
+    setGlobalBusy(true);
+    setBusyMsg(`Installing agent on ${vm.name || vm.id}...`);
+    try {
+      await installAgent(nsId, mciId, vm.id);
+      startPolling(vm.id);
+    } catch (err) {
+      alert('Install failed: ' + (err.response?.data?.error_message || err.message));
+      setGlobalBusy(false);
+      setBusyMsg('');
+    }
+  }
+
+  async function handleUninstall(e, vm) {
+    e.stopPropagation();
+    if (!confirm(`Uninstall monitoring agent from "${vm.name || vm.id}"?`)) return;
+    setGlobalBusy(true);
+    setBusyMsg(`Uninstalling agent from ${vm.name || vm.id}...`);
+    try {
+      await uninstallAgent(nsId, mciId, vm.id);
+      await loadVms();
+      if (selectedVm?.id === vm.id) { setSelectedVm(null); setItems([]); }
+    } catch (err) {
+      alert('Uninstall failed: ' + (err.response?.data?.error_message || err.message));
+    }
+    setGlobalBusy(false);
+    setBusyMsg('');
+  }
+
+  function startPolling(vmId) {
+    if (pollRef.current) clearInterval(pollRef.current);
+    let count = 0;
+    pollRef.current = setInterval(async () => {
+      count++;
+      try {
+        const vmData = await getVm(nsId, mciId, vmId);
+        const status = vmData?.monitoring_agent_status || vmData?.monitoringAgentStatus;
+        setBusyMsg(`Installing agent... (${status || 'checking'}) [${count * 5}s]`);
+        if (status === 'SUCCESS' || status === 'FAILED' || count > 60) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+          setGlobalBusy(false);
+          setBusyMsg('');
+          await loadVms();
+          if (status === 'SUCCESS') {
+            // Auto-select the VM to show items
+            const refreshedVms = await getVmList(nsId, mciId);
+            const found = refreshedVms.find(v => (v.vm_id || v.id) === vmId);
+            if (found) selectVm({ ...found, id: vmId, registered: true });
+          }
+        }
+      } catch {
+        // Keep polling
+      }
+    }, 5000);
+  }
+
+  // --- Metric toggle with confirmation + overlay ---
+  async function handleToggle(plugin, isActive) {
+    if (!selectedVm || busy) return;
+    const action = isActive ? 'Disable' : 'Enable';
+    if (!confirm(`${action} "${plugin.name}" monitoring metric on ${selectedVm.name || selectedVm.id}?`)) return;
+
+    setBusy(true);
+    setBusyMsg(`${action === 'Enable' ? 'Enabling' : 'Disabling'} ${plugin.name} metric...`);
+    try {
+      if (isActive) {
+        const item = items.find((it) => it.pluginSeq === plugin.seq);
+        if (item) await deleteVmItem(nsId, mciId, selectedVm.id, item.seq);
+      } else {
+        await createVmItem(nsId, mciId, selectedVm.id, { pluginSeq: plugin.seq });
+      }
+      setItems(await getVmItems(nsId, mciId, selectedVm.id));
+    } catch (err) {
+      alert('Failed: ' + (err.response?.data?.error_message || err.message));
+    }
+    setBusy(false);
+    setBusyMsg('');
+  }
+
+  const filteredVms = filter ? vms.filter((vm) => (vm.name || vm.id || '').toLowerCase().includes(filter.toLowerCase())) : vms;
+  const inputPlugins = plugins.filter((p) => p.pluginType === 'INPUT');
+  const activeSeqs = new Set(items.map((it) => it.pluginSeq));
+
+  return (
+    <div className="space-y-4 relative">
+      {/* Global busy overlay (install/uninstall) */}
+      {globalBusy && (
+        <div className="fixed inset-0 bg-white/60 backdrop-blur-sm z-50 flex items-center justify-center">
+          <div className="bg-white rounded-lg shadow-xl p-6 text-center">
+            <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+            <p className="text-sm font-medium text-gray-700">{busyMsg}</p>
+            <p className="text-xs text-gray-400 mt-1">Please wait...</p>
+          </div>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold">Monitor Setting / Workload</div>
+        <div className="p-4"><span className="text-sm text-gray-600">Workload: </span><span className="font-medium">{mciId}</span></div>
+      </div>
+
+      {/* Server list */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b flex items-center justify-between">
+          <span className="font-semibold">List of Servers</span>
+          <div className="flex items-center gap-2">
+            <input type="text" placeholder="Filter..." value={filter} onChange={(e) => setFilter(e.target.value)} className="border rounded px-2 py-1 text-sm w-40" />
+            <button onClick={loadVms} className="text-sm text-gray-500 hover:text-gray-700">Refresh</button>
+          </div>
+        </div>
+        <div className="overflow-auto">
+          <table className="w-full text-sm">
+            <thead><tr className="bg-gray-50 text-left">
+              <th className="px-4 py-2.5 border-b text-gray-500">Name</th>
+              <th className="px-4 py-2.5 border-b text-gray-500">VM ID</th>
+              <th className="px-4 py-2.5 border-b text-gray-500">Status</th>
+              <th className="px-4 py-2.5 border-b text-gray-500">Monitoring Agent</th>
+              <th className="px-4 py-2.5 border-b text-gray-500">Log Agent</th>
+              <th className="px-4 py-2.5 border-b text-gray-500 text-right">Actions</th>
+            </tr></thead>
+            <tbody>
+              {loading ? <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">Loading...</td></tr>
+              : filteredVms.length === 0 ? <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">No servers</td></tr>
+              : filteredVms.map((vm) => (
+                <tr key={vm.id} onClick={() => selectVm(vm)}
+                  className={`cursor-pointer hover:bg-blue-50 ${selectedVm?.id === vm.id ? 'bg-blue-100' : ''}`}>
+                  <td className="px-4 py-2.5 border-b font-medium">{vm.name || vm.id}</td>
+                  <td className="px-4 py-2.5 border-b text-gray-500">{vm.id}</td>
+                  <td className="px-4 py-2.5 border-b"><Badge status={vm.status} /></td>
+                  <td className="px-4 py-2.5 border-b"><AgentBadge status={vm.monitoring_agent_status} /></td>
+                  <td className="px-4 py-2.5 border-b"><AgentBadge status={vm.log_agent_status} /></td>
+                  <td className="px-4 py-2.5 border-b text-right">
+                    {!vm.registered
+                      ? <button onClick={(e) => handleInstall(e, vm)} disabled={busy} className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install Agent</button>
+                      : vm.monitoring_agent_status === 'INSTALLING'
+                      ? <span className="text-sm text-yellow-600 animate-pulse">Installing...</span>
+                      : <button onClick={(e) => handleUninstall(e, vm)} disabled={busy} className="text-sm text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Metric toggle table */}
+      {selectedVm && (
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-4 py-3 border-b font-semibold">Monitoring Metrics — {selectedVm.name || selectedVm.id}</div>
+          <div className="p-4 relative">
+            {/* Metric toggle busy overlay */}
+            {busy && (
+              <div className="absolute inset-0 bg-white/70 backdrop-blur-[2px] z-10 flex items-center justify-center rounded">
+                <div className="text-center">
+                  <div className="w-6 h-6 border-3 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
+                  <p className="text-sm text-gray-600">{busyMsg}</p>
+                </div>
+              </div>
+            )}
+            {!selectedVm.registered ? (
+              <div className="text-center py-6">
+                <p className="text-sm text-gray-500 mb-3">Agent not installed.</p>
+                <button onClick={(e) => handleInstall(e, selectedVm)} disabled={busy} className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50">Install Agent</button>
+              </div>
+            ) : itemLoading ? (
+              <p className="text-sm text-gray-400 animate-pulse">Loading metrics...</p>
+            ) : (
+              <table className="w-full text-sm">
+                <thead><tr className="bg-gray-50 text-left">
+                  <th className="px-4 py-2.5 border-b text-gray-500 w-20">Active</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">Metric</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">Plugin ID</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">State</th>
+                </tr></thead>
+                <tbody>
+                  {inputPlugins.map((plugin) => {
+                    const isActive = activeSeqs.has(plugin.seq);
+                    const item = items.find((it) => it.pluginSeq === plugin.seq);
+                    return (
+                      <tr key={plugin.seq} className={`hover:bg-gray-50 ${busy ? 'opacity-50 pointer-events-none' : ''}`}>
+                        <td className="px-4 py-2.5 border-b">
+                          <button onClick={() => handleToggle(plugin, isActive)} disabled={busy}
+                            className={`w-11 h-6 rounded-full relative transition-colors ${isActive ? 'bg-blue-600' : 'bg-gray-300'} disabled:opacity-50`}>
+                            <span className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${isActive ? 'left-6' : 'left-1'}`} />
+                          </button>
+                        </td>
+                        <td className="px-4 py-2.5 border-b font-medium">{plugin.name}</td>
+                        <td className="px-4 py-2.5 border-b text-gray-500">{plugin.pluginId}</td>
+                        <td className="px-4 py-2.5 border-b">
+                          {isActive
+                            ? <span className="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">{item?.state || 'ACTIVE'}</span>
+                            : <span className="text-gray-400 text-xs">Not configured</span>}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Badge({ status }) {
+  const s = (status || '').toUpperCase();
+  const c = s.includes('RUNNING') ? 'bg-green-100 text-green-700' : s === 'FAILED' ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500';
+  return <span className={`text-xs px-2 py-0.5 rounded-full ${c}`}>{status || '-'}</span>;
+}
+
+function AgentBadge({ status }) {
+  if (!status) return <span className="text-xs text-gray-400">Not installed</span>;
+  const s = status.toUpperCase();
+  const c = s === 'SUCCESS' ? 'bg-green-100 text-green-700' : s === 'INSTALLING' ? 'bg-yellow-100 text-yellow-700' :
+    s === 'SERVICE_INACTIVE' ? 'bg-orange-100 text-orange-700' : s === 'FAILED' ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500';
+  return <span className={`text-xs px-2 py-0.5 rounded-full ${c}`}>{status}</span>;
+}

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -1,0 +1,482 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { getMeasurementFields, getMetricsByVM } from '../api/monitoring';
+import { getMci } from '../api/tumblebug';
+import { getPlugins, getPrediction, getDetectionHistory } from '../api/monitoring';
+import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
+import { getVmItems } from '../api/vm';
+import MetricChart from '../components/MetricChart';
+
+const RANGE_OPTIONS = [
+  { value: '1h', label: '1H' },
+  { value: '6h', label: '6H' },
+  { value: '12h', label: '12H' },
+  { value: '1d', label: '1D' },
+  { value: '3d', label: '3D' },
+  { value: '5d', label: '5D' },
+  { value: '7d', label: '7D' },
+];
+
+const PERIOD_OPTIONS = [
+  { value: '1m', label: '1m' },
+  { value: '3m', label: '3m' },
+  { value: '5m', label: '5m' },
+  { value: '10m', label: '10m' },
+  { value: '15m', label: '15m' },
+  { value: '30m', label: '30m' },
+  { value: '1h', label: '1h' },
+];
+
+const AGG_OPTIONS = [
+  { value: 'mean', label: 'Mean' },
+  { value: 'max', label: 'Max' },
+  { value: 'min', label: 'Min' },
+  { value: 'last', label: 'Last' },
+  { value: 'sum', label: 'Sum' },
+];
+
+export default function MonitoringDashboard() {
+  const { nsId, mciId, vmId: routeVmId } = useParams();
+  const [searchParams] = useSearchParams();
+  const initialSource = searchParams.get('source') || 'agent';
+
+  // Cascade selectors
+  const [vms, setVms] = useState([]);
+  const [selectedVmId, setSelectedVmId] = useState(routeVmId || '');
+  const [measurements, setMeasurements] = useState([]);
+  const [selectedMeasurement, setSelectedMeasurement] = useState('');
+  const [metrics, setMetrics] = useState([]);
+  const [selectedMetric, setSelectedMetric] = useState('');
+  const [selectedAgg, setSelectedAgg] = useState('mean');
+  const [selectedRange, setSelectedRange] = useState('1h');
+  const [selectedPeriod, setSelectedPeriod] = useState('1m');
+
+  // Toggles
+  const [predictionEnabled, setPredictionEnabled] = useState(false);
+  const [detectionEnabled, setDetectionEnabled] = useState(false);
+
+  // Auto-refresh
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [refreshInterval, setRefreshInterval] = useState(30);
+
+  // Data source: agent (InfluxDB) or csp (cb-spider)
+  const [dataSource, setDataSource] = useState(initialSource);
+  const [cspMetrics, setCspMetrics] = useState(null);
+  const [selectedCspMetric, setSelectedCspMetric] = useState('cpu_usage');
+  const [cspVmInfo, setCspVmInfo] = useState(null); // { connectionName, cspResourceName }
+
+  // Chart data
+  const [chartSeries, setChartSeries] = useState([]);
+  const [chartTitle, setChartTitle] = useState('');
+  const [chartMeasurement, setChartMeasurement] = useState('');
+  const [chartMetric, setChartMetric] = useState('');
+  const [detectionSeries, setDetectionSeries] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  // Auto-loaded overview charts (always shown when VM is selected). null = not loaded yet
+  const [overviewCharts, setOverviewCharts] = useState(null);
+
+  // All measurement fields (for metric dropdown)
+  const [allFields, setAllFields] = useState([]);
+
+  // Load VMs from Tumblebug
+  const [vmsLoaded, setVmsLoaded] = useState(false);
+  useEffect(() => {
+    if (!nsId || !mciId) return;
+    setVmsLoaded(false);
+    getMci(nsId, mciId)
+      .then((data) => { setVms(data.vm || []); setVmsLoaded(true); })
+      .catch(() => { setVms([]); setVmsLoaded(true); });
+  }, [nsId, mciId]);
+
+  // Load all measurement fields (for metric dropdown options)
+  const [activeItemNames, setActiveItemNames] = useState(null); // null = not loaded, Set = loaded
+  useEffect(() => {
+    getMeasurementFields().then(setAllFields).catch(() => setAllFields([]));
+  }, []);
+
+  // Load active items for selected VM → filter measurements
+  useEffect(() => {
+    if (!nsId || !mciId || !selectedVmId) { setActiveItemNames(null); setMeasurements([]); return; }
+    getVmItems(nsId, mciId, selectedVmId)
+      .then((items) => {
+        const names = new Set(items.map((it) => it.pluginName || it.name));
+        setActiveItemNames(names);
+      })
+      .catch(() => setActiveItemNames(null));
+  }, [nsId, mciId, selectedVmId]);
+
+  // Filter measurements to only those active on the VM
+  useEffect(() => {
+    if (!activeItemNames) {
+      // Fallback: show all plugins if items not loaded
+      getPlugins()
+        .then((data) => setMeasurements(data.filter((p) => p.pluginType === 'INPUT').map((p) => p.name || p.pluginId)))
+        .catch(() => setMeasurements([]));
+      return;
+    }
+    setMeasurements([...activeItemNames]);
+  }, [activeItemNames]);
+
+  // When measurement changes, populate metrics
+  useEffect(() => {
+    if (!selectedMeasurement) {
+      setMetrics([]);
+      setSelectedMetric('');
+      return;
+    }
+    const found = allFields.find((f) => f.measurement === selectedMeasurement);
+    let fieldKeys = found && found.fields ? found.fields.map((f) => f.key) : [];
+    // Add virtual "usage_percent" for cpu (100 - usage_idle)
+    if (selectedMeasurement === 'cpu' && fieldKeys.includes('usage_idle') && !fieldKeys.includes('usage_percent')) {
+      fieldKeys = ['usage_percent', ...fieldKeys];
+    }
+    setMetrics(fieldKeys);
+    setSelectedMetric('');
+  }, [selectedMeasurement, allFields]);
+
+  // Set route vmId
+  useEffect(() => {
+    if (routeVmId) setSelectedVmId(routeVmId);
+  }, [routeVmId]);
+
+  // Track CSP info for selected VM
+  useEffect(() => {
+    const vm = vms.find((v) => v.id === selectedVmId);
+    if (vm && vm.connectionName && vm.cspResourceName) {
+      setCspVmInfo({ connectionName: vm.connectionName, cspResourceName: vm.cspResourceName });
+    } else {
+      setCspVmInfo(null);
+    }
+  }, [selectedVmId, vms]);
+
+  // Load CSP metrics when dataSource=csp (wait for vms to load first)
+  const [cspLoading, setCspLoading] = useState(false);
+  useEffect(() => {
+    if (!vmsLoaded || dataSource !== 'csp' || !cspVmInfo) { setCspMetrics(null); return; }
+    setCspLoading(true);
+    setCspMetrics(null);
+    const hours = selectedRange.endsWith('d') ? parseInt(selectedRange) * 24 : parseInt(selectedRange);
+    getAllCspMetrics(cspVmInfo.connectionName, cspVmInfo.cspResourceName, String(hours || 1))
+      .then(setCspMetrics)
+      .catch(() => setCspMetrics({}))
+      .finally(() => setCspLoading(false));
+  }, [dataSource, cspVmInfo, selectedRange, vmsLoaded]);
+
+  // Overview loader
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const loadOverview = useCallback(async () => {
+    if (!nsId || !mciId || !selectedVmId) { setOverviewCharts(null); return; }
+    setOverviewLoading(true);
+    const overviewMetrics = [
+      { measurement: 'cpu', field: 'usage_idle', title: 'CPU Used', unit: '%', invert: true },
+      { measurement: 'mem', field: 'used_percent', title: 'Memory Used', unit: '%' },
+      { measurement: 'disk', field: 'used_percent', title: 'Disk Used', unit: '%' },
+    ];
+    const results = await Promise.allSettled(
+      overviewMetrics.map(async (m) => {
+        const data = await getMetricsByVM(nsId, mciId, selectedVmId, {
+          measurement: m.measurement, range: selectedRange, groupTime: selectedPeriod,
+          fields: [{ function: 'mean', field: m.field }],
+        });
+        const series = toChartSeries(data, m.field);
+        if (m.invert) {
+          series.forEach((s) => { s.name = m.title; s.data = s.data.map((d) => ({ ...d, y: 100 - d.y })); });
+        }
+        return { ...m, series };
+      })
+    );
+    setOverviewCharts(results.filter((r) => r.status === 'fulfilled').map((r) => r.value));
+    setOverviewLoading(false);
+  }, [nsId, mciId, selectedVmId, selectedRange, selectedPeriod]);
+
+  // Load on mount + when params change
+  useEffect(() => { loadOverview(); }, [loadOverview]);
+
+  // Auto-refresh timer
+  useEffect(() => {
+    if (!autoRefresh || !selectedVmId) return;
+    const id = setInterval(() => { loadOverview(); }, refreshInterval * 1000);
+    return () => clearInterval(id);
+  }, [autoRefresh, refreshInterval, loadOverview, selectedVmId]);
+
+  const startMonitoring = useCallback(async () => {
+    if (!selectedVmId || !selectedMeasurement || !selectedMetric) {
+      alert('Please select VM, Measurement, and Metric.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const isVirtualPercent = selectedMeasurement === 'cpu' && selectedMetric === 'usage_percent';
+      const actualField = isVirtualPercent ? 'usage_idle' : selectedMetric;
+      const displayMetric = isVirtualPercent ? 'usage_percent' : selectedMetric;
+
+      const data = await getMetricsByVM(nsId, mciId, selectedVmId, {
+        measurement: selectedMeasurement,
+        range: selectedRange,
+        groupTime: selectedPeriod,
+        fields: [{ function: selectedAgg, field: actualField }],
+      });
+      let series = toChartSeries(data, displayMetric);
+      if (isVirtualPercent) {
+        series = series.map((s) => ({
+          ...s,
+          name: 'usage_percent',
+          data: s.data.map((d) => ({ ...d, y: 100 - d.y })),
+        }));
+      }
+      setChartSeries(series);
+      setChartTitle(`${selectedMeasurement.toUpperCase()} - ${displayMetric}`);
+      setChartMeasurement(selectedMeasurement);
+      setChartMetric(displayMetric);
+
+      // Prediction overlay
+      if (predictionEnabled) {
+        try {
+          const pred = await getPrediction(nsId, mciId, selectedVmId, selectedMeasurement);
+          if (pred && pred.values && pred.values.length > 0) {
+            const predSeries = {
+              name: `${selectedMetric} (Predicted)`,
+              data: pred.values.map((v) => ({ x: new Date(v.timestamp).getTime(), y: parseFloat(v.value) })),
+            };
+            setChartSeries((prev) => [...prev, predSeries]);
+          }
+        } catch {}
+      }
+
+      // Detection chart
+      if (detectionEnabled) {
+        try {
+          const det = await getDetectionHistory(nsId, mciId, selectedVmId, selectedMeasurement);
+          if (det && det.values && det.values.length > 0) {
+            setDetectionSeries([{
+              name: 'Anomaly Score',
+              data: det.values.map((v) => ({ x: new Date(v.timestamp).getTime(), y: v.anomaly_score })),
+            }]);
+          } else {
+            setDetectionSeries([]);
+          }
+        } catch {
+          setDetectionSeries([]);
+        }
+      }
+    } catch (e) {
+      console.error('startMonitoring failed', e);
+    }
+    setLoading(false);
+  }, [nsId, mciId, selectedVmId, selectedMeasurement, selectedMetric, selectedAgg, selectedRange, selectedPeriod, predictionEnabled, detectionEnabled]);
+
+  return (
+    <div className="space-y-4">
+      {/* Card: Monitoring Trend / Workload */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b flex items-center justify-between">
+          <span className="font-semibold text-sm">Monitoring Trend / Workload</span>
+          {cspVmInfo && (
+            <div className="flex bg-gray-100 rounded-lg p-0.5 text-xs">
+              <button onClick={() => setDataSource('agent')}
+                className={`px-3 py-1 rounded-md ${dataSource === 'agent' ? 'bg-white shadow text-blue-600 font-medium' : 'text-gray-500'}`}>Agent</button>
+              <button onClick={() => setDataSource('csp')}
+                className={`px-3 py-1 rounded-md ${dataSource === 'csp' ? 'bg-white shadow text-blue-600 font-medium' : 'text-gray-500'}`}>CSP</button>
+            </div>
+          )}
+        </div>
+        <div className="p-4 space-y-4">
+          {/* Row 1: Workload (readonly) + Server */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Workload</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={mciId || ''} readOnly />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Server</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedVmId} onChange={(e) => setSelectedVmId(e.target.value)}>
+                <option value="">Select</option>
+                {vms.map((vm) => {
+                  const id = vm.id || vm.vm_id || vm.name;
+                  return <option key={id} value={id}>{vm.name || id}</option>;
+                })}
+              </select>
+            </div>
+          </div>
+
+          {/* Agent-specific controls */}
+          {dataSource === 'agent' && <>
+          {/* Row 2: Measurement, Metric, Aggregation */}
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Measurement</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMeasurement} onChange={(e) => setSelectedMeasurement(e.target.value)}>
+                <option value="">Select</option>
+                {measurements.map((m) => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Metric</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMetric} onChange={(e) => setSelectedMetric(e.target.value)}>
+                <option value="">Select</option>
+                {metrics.map((m) => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Aggregation</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedAgg} onChange={(e) => setSelectedAgg(e.target.value)}>
+                {AGG_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* Row 3: Range, Period, Prediction */}
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedRange} onChange={(e) => setSelectedRange(e.target.value)}>
+                {RANGE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Period</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedPeriod} onChange={(e) => setSelectedPeriod(e.target.value)}>
+                {PERIOD_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div />
+          </div>
+
+          {/* Switches */}
+          <div className="flex gap-6 flex-wrap items-center">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" className="rounded" checked={predictionEnabled} onChange={(e) => setPredictionEnabled(e.target.checked)} />
+              Extend Prediction
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" className="rounded" checked={detectionEnabled} onChange={(e) => setDetectionEnabled(e.target.checked)} />
+              Extend Detection
+            </label>
+            <div className="ml-auto flex items-center gap-2">
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="checkbox" className="rounded" checked={autoRefresh} onChange={(e) => setAutoRefresh(e.target.checked)} />
+                Auto Refresh
+              </label>
+              {autoRefresh && (
+                <select className="border border-gray-300 rounded px-2 py-1 text-xs" value={refreshInterval} onChange={(e) => setRefreshInterval(+e.target.value)}>
+                  <option value={10}>10s</option>
+                  <option value={30}>30s</option>
+                  <option value={60}>1m</option>
+                </select>
+              )}
+              {autoRefresh && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" title="Auto-refreshing" />}
+            </div>
+          </div>
+
+          {/* Start Monitoring button */}
+          <div className="text-center">
+            <button
+              onClick={startMonitoring}
+              disabled={loading}
+              className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {loading ? 'Loading...' : 'Start Monitoring'}
+            </button>
+          </div>
+          </>}
+
+          {/* CSP metric selector */}
+          {dataSource === 'csp' && selectedVmId && (
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">CSP Metric</label>
+              <div className="flex gap-1 flex-wrap">
+                {CSP_METRICS.map((m) => (
+                  <button key={m.key} onClick={() => setSelectedCspMetric(m.key)}
+                    className={`px-3 py-1.5 text-xs rounded-md border ${selectedCspMetric === m.key ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}>
+                    {m.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* CSP chart */}
+        {dataSource === 'csp' && selectedVmId && (
+          <div className="p-4 border-t">
+            <div className="mb-2 text-sm font-medium">
+              CSP: {vms.find(v => v.id === selectedVmId)?.name || selectedVmId}
+            </div>
+            {(cspLoading || !cspMetrics) ? (
+              <div className="flex items-center justify-center h-[300px] text-gray-400 animate-pulse">Loading CSP data...</div>
+            ) : cspMetrics[selectedCspMetric]?.series ? (
+              <div className="bg-white rounded border p-3">
+                <MetricChart
+                  title={`${cspMetrics[selectedCspMetric].metricName} (${cspMetrics[selectedCspMetric].metricUnit})`}
+                  series={cspMetrics[selectedCspMetric].series}
+                  height={300}
+                />
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-[300px] text-gray-400">No data</div>
+            )}
+          </div>
+        )}
+
+        {/* Overview charts — always shown when VM selected (agent mode only) */}
+        {dataSource === 'agent' && selectedVmId && (
+          <div className="p-4 border-t">
+            <div className="mb-2 text-sm font-medium">
+              VM: {vms.find(v => v.id === selectedVmId)?.name || selectedVmId}
+            </div>
+            {(overviewLoading || !overviewCharts) ? (
+              <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading metrics...</div>
+            ) : overviewCharts.length > 0 ? (
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+                {overviewCharts.map((oc) => (
+                  <div key={oc.measurement} className="bg-white rounded border p-3">
+                    <MetricChart title={oc.title} series={oc.series} height={160} measurement={oc.measurement} metric={oc.field} />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-[160px] text-gray-400">No data</div>
+            )}
+          </div>
+        )}
+
+        {/* Custom query chart (agent only) */}
+        {dataSource === 'agent' && chartSeries.length > 0 && (
+          <div className="p-4 border-t">
+            <div className="text-xs text-gray-500 mb-2">Custom Query — Trend Graph</div>
+            <div className="bg-white rounded border p-3">
+              <MetricChart title={chartTitle} series={chartSeries} height={240} measurement={chartMeasurement} metric={chartMetric} />
+            </div>
+
+            {detectionEnabled && detectionSeries.length > 0 && (
+              <div className="mt-4">
+                <div className="text-xs text-gray-500 mb-2">Detection Graph</div>
+                <div className="bg-white rounded border p-3">
+                  <MetricChart title="Anomaly Score Over Time" series={detectionSeries} height={240} chartType="line" />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function toChartSeries(metricDTOs, metricName) {
+  if (!metricDTOs || metricDTOs.length === 0) return [];
+  return metricDTOs.map((m) => {
+    const timeIdx = (m.columns || []).indexOf('timestamp');
+    const valIdx = timeIdx === 0 ? 1 : 0;
+    return {
+      name: metricName || m.columns?.[valIdx] || m.name || 'value',
+      data: (m.values || [])
+        .filter((row) => row[valIdx] !== null && row[valIdx] !== undefined)
+        .map((row) => ({
+          x: typeof row[timeIdx] === 'string' ? new Date(row[timeIdx]).getTime() : row[timeIdx],
+          y: parseFloat(row[valIdx]),
+        })),
+    };
+  });
+}

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: { extend: {} },
+  plugins: [],
+};

--- a/front/vite.config.js
+++ b/front/vite.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+    proxy: {
+      '/api/o11y': {
+        target: process.env.VITE_O11Y_API || 'http://localhost:18080',
+        changeOrigin: true,
+      },
+      '/tumblebug': {
+        target: process.env.VITE_TB_API || 'http://localhost:1323',
+        changeOrigin: true,
+      },
+      '/spider': {
+        target: process.env.VITE_SPIDER_API || 'http://localhost:1024',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/front/vite.config.js
+++ b/front/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3001,
+    port: 18081,
     proxy: {
       '/api/o11y': {
         target: process.env.VITE_O11Y_API || 'http://localhost:18080',


### PR DESCRIPTION
## Summary
- React 18 + Vite + Tailwind CSS + ApexCharts frontend for mc-observability
- Pages: Monitoring Dashboard, MCI Overview, Log Viewer, Monitoring Config, Insight, Alerts
- Agent/CSP monitoring toggle (cb-spider MonitoringHandler interface)
- Tumblebug integration for NS/MCI/VM cascade selection
- iframe embedding support (/embed/* routes, postMessage auth)
- Docker (nginx) with API proxy for mc-o11y-manager, Tumblebug, cb-spider
- GitHub Actions CI/CD workflow
- Auto-refresh, unit formatting, pagination, error boundary

## Test plan
- [x] Access http://HOST:18081 and verify NS/MCI/VM cascade from Tumblebug
- [x] Monitoring: Agent overview charts (CPU/Mem/Disk) + CSP toggle
- [x] Logs: Search with keyword, pagination
- [x] Config: Agent install, metric toggle enable/disable
- [x] Embed mode: /embed/monitoring/{ns}/{mci}/{vm}