### PR TITLE
fix: front: Align CSP metric labels with cb-spider standard

### DIFF
--- a/front/src/api/csp.js
+++ b/front/src/api/csp.js
@@ -22,34 +22,18 @@ export async function getCspMetric(connectionName, cspResourceName, metricType, 
   return res.data || {};
 }
 
-/**
- * Fetch all CSP metrics for a VM.
- * @param {number} totalMemoryGiB - VM total memory in GiB (from Tumblebug spec.memoryGiB). Used to convert Available Memory Bytes → %.
- */
-export async function getAllCspMetrics(connectionName, cspResourceName, timeBeforeHour = '1', totalMemoryGiB = 0) {
+/** Fetch all CSP metrics for a VM. */
+export async function getAllCspMetrics(connectionName, cspResourceName, timeBeforeHour = '1') {
   const results = {};
-  const totalMemoryBytes = totalMemoryGiB * 1024 * 1024 * 1024;
-
   await Promise.allSettled(
     CSP_METRICS.map(async (m) => {
       const data = await getCspMetric(connectionName, cspResourceName, m.key, '5', timeBeforeHour);
-      let metricName = data.metricName || m.label;
-      let metricUnit = data.metricUnit || m.unit;
-      let points = (data.timestampValues || []).map((v) => ({
+      const metricName = data.metricName || m.label;
+      const metricUnit = data.metricUnit || m.unit;
+      const points = (data.timestampValues || []).map((v) => ({
         x: new Date(v.timestamp).getTime(),
         y: parseFloat(v.value),
       }));
-
-      // Fallback: if server returns raw "Available Memory Bytes" instead of percent, convert here
-      if (m.key === 'memory_usage' && totalMemoryBytes > 0 && metricUnit === 'Bytes') {
-        points = points.map((p) => ({
-          ...p,
-          y: Math.max(0, (1 - p.y / totalMemoryBytes) * 100),
-        }));
-        metricName = 'Memory Usage Percent';
-        metricUnit = 'Percent';
-      }
-
       results[m.key] = {
         ...m,
         metricName,

--- a/front/src/api/csp.js
+++ b/front/src/api/csp.js
@@ -1,15 +1,16 @@
 import client from './client';
 
 // Based on cb-spider MonitoringHandler interface (MonitoringHandler.go)
+// Aligned with cb-spider MetricNameAndUnit() in MonitoringHandler.go
 const CSP_METRICS = [
-  { key: 'cpu_usage', label: 'CPU Usage', unit: '%' },
-  { key: 'memory_usage', label: 'Memory Usage', unit: '%' },
-  { key: 'disk_read', label: 'Disk Read', unit: 'bytes' },
-  { key: 'disk_write', label: 'Disk Write', unit: 'bytes' },
-  { key: 'disk_read_ops', label: 'Disk Read Ops', unit: 'count' },
-  { key: 'disk_write_ops', label: 'Disk Write Ops', unit: 'count' },
-  { key: 'network_in', label: 'Network In', unit: 'bytes' },
-  { key: 'network_out', label: 'Network Out', unit: 'bytes' },
+  { key: 'cpu_usage', label: 'CPU Usage Percent', unit: 'Percent' },
+  { key: 'memory_usage', label: 'Memory Usage Percent', unit: 'Percent' },
+  { key: 'disk_read', label: 'Disk Read Bytes', unit: 'Bytes' },
+  { key: 'disk_write', label: 'Disk Write Bytes', unit: 'Bytes' },
+  { key: 'disk_read_ops', label: 'Disk Read Operations/Sec', unit: 'CountPerSecond' },
+  { key: 'disk_write_ops', label: 'Disk Write Operations/Sec', unit: 'CountPerSecond' },
+  { key: 'network_in', label: 'Network In', unit: 'Bytes' },
+  { key: 'network_out', label: 'Network Out', unit: 'Bytes' },
 ];
 
 export { CSP_METRICS };
@@ -39,13 +40,13 @@ export async function getAllCspMetrics(connectionName, cspResourceName, timeBefo
         y: parseFloat(v.value),
       }));
 
-      // Convert "Available Memory Bytes" → "Memory Usage %"
+      // Fallback: if server returns raw "Available Memory Bytes" instead of percent, convert here
       if (m.key === 'memory_usage' && totalMemoryBytes > 0 && metricUnit === 'Bytes') {
         points = points.map((p) => ({
           ...p,
           y: Math.max(0, (1 - p.y / totalMemoryBytes) * 100),
         }));
-        metricName = 'Memory Usage';
+        metricName = 'Memory Usage Percent';
         metricUnit = 'Percent';
       }
 

--- a/front/src/pages/MciOverview.jsx
+++ b/front/src/pages/MciOverview.jsx
@@ -84,8 +84,7 @@ export default function MciOverview() {
     await Promise.allSettled(
       vmList.map(async (vm) => {
         if (!vm.connectionName || !vm.cspResourceName) return;
-        const memGiB = vm.spec?.memoryGiB || 0;
-        const cspData = await getAllCspMetrics(vm.connectionName, vm.cspResourceName, '1', memGiB);
+        const cspData = await getAllCspMetrics(vm.connectionName, vm.cspResourceName, '1');
         data[vm.id] = cspData;
       })
     );

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -144,7 +144,7 @@ export default function MonitoringDashboard() {
   useEffect(() => {
     const vm = vms.find((v) => v.id === selectedVmId);
     if (vm && vm.connectionName && vm.cspResourceName) {
-      setCspVmInfo({ connectionName: vm.connectionName, cspResourceName: vm.cspResourceName, memoryGiB: vm.spec?.memoryGiB || 0 });
+      setCspVmInfo({ connectionName: vm.connectionName, cspResourceName: vm.cspResourceName });
     } else {
       setCspVmInfo(null);
     }
@@ -157,7 +157,7 @@ export default function MonitoringDashboard() {
     setCspLoading(true);
     setCspMetrics(null);
     const hours = selectedRange.endsWith('d') ? parseInt(selectedRange) * 24 : parseInt(selectedRange);
-    getAllCspMetrics(cspVmInfo.connectionName, cspVmInfo.cspResourceName, String(hours || 1), cspVmInfo.memoryGiB || 0)
+    getAllCspMetrics(cspVmInfo.connectionName, cspVmInfo.cspResourceName, String(hours || 1))
       .then(setCspMetrics)
       .catch(() => setCspMetrics({}))
       .finally(() => setCspLoading(false));


### PR DESCRIPTION
## Summary
- Align CSP metric labels with cb-spider MetricNameAndUnit() standard (CPU Usage Percent, Memory Usage Percent, etc.)
- Remove frontend memory fallback conversion — server now returns percent natively
- Fix CSP gauge ordering to CPU/Memory/Disk/Network

## Test plan
- [ ] CSP mode: verify metric names match cb-spider interface
- [ ] Memory Usage shows percent, not bytes