### PR TITLE
feat: Cache Agent overview + CSP monitoring with Caffeine warming

### DIFF
--- a/front/src/pages/MciOverview.jsx
+++ b/front/src/pages/MciOverview.jsx
@@ -58,7 +58,7 @@ export default function MciOverview() {
         setVms(allVms);
         if (allVms.length > 0) {
           setMetricsLoading(true);
-          if (dataSource === 'agent') await loadAgentData(allVms);
+          if (dataSource === 'agent') await loadAgentData(allVms, mcis);
           else await loadCspData(allVms);
           setMetricsLoading(false);
         }
@@ -76,10 +76,12 @@ export default function MciOverview() {
     load(vms).finally(() => setMetricsLoading(false));
   }, [dataSource]);
 
-  async function loadAgentData(vmList) {
-    // Find which MCI each VM belongs to
+  async function loadAgentData(vmList, mcisArg) {
+    // Find which MCI each VM belongs to. Caller must pass the current mcis
+    // since the allMcis state may still be stale (setState is async).
+    const mcis = mcisArg || allMcis;
     const vmMciMap = {};
-    allMcis.forEach(m => (m.vm || []).forEach(v => { vmMciMap[v.id] = m.id; }));
+    mcis.forEach(m => (m.vm || []).forEach(v => { vmMciMap[v.id] = m.id; }));
 
     vmList.forEach(async (vm) => {
       const vmMciId = vmMciMap[vm.id] || mciId;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheService.java
@@ -51,14 +51,19 @@ public class CspCacheService {
                 properties.getExpireAfterWriteSeconds());
     }
 
-    /** Returns cached monitoring data or loads it via {@code loader} on miss. */
+    /**
+     * Returns cached monitoring data or loads it via {@code loader} on miss.
+     *
+     * <p>A cached entry with no {@code timestampValues} is treated as a miss so warm passes that
+     * landed between CSP publish cycles don't lock an empty response into the TTL window.
+     */
     public SpiderMonitoringInfo.Data getOrLoad(
             CspCacheKey key, Supplier<SpiderMonitoringInfo.Data> loader) {
         if (cache == null) {
             return loader.get();
         }
         SpiderMonitoringInfo.Data hit = cache.getIfPresent(key);
-        if (hit != null) {
+        if (hit != null && hasAnyTimestampValue(hit)) {
             manualHitCount.incrementAndGet();
             return hit;
         }
@@ -70,9 +75,17 @@ public class CspCacheService {
         return loaded;
     }
 
-    /** Direct put — used by warmers that already hold a freshly-fetched response. */
+    private static boolean hasAnyTimestampValue(SpiderMonitoringInfo.Data d) {
+        return d != null && d.getTimestampValues() != null && !d.getTimestampValues().isEmpty();
+    }
+
+    /**
+     * Direct put — used by warmers that already hold a freshly-fetched response. Empty responses
+     * are skipped so we don't trample a previously-cached non-empty value with a transient empty
+     * fetch from the provider.
+     */
     public void put(CspCacheKey key, SpiderMonitoringInfo.Data value) {
-        if (cache != null && value != null) {
+        if (cache != null && hasAnyTimestampValue(value)) {
             cache.put(key, value);
         }
     }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -6,7 +6,10 @@ import com.mcmp.o11ymanager.manager.dto.SpiderClusterList;
 import com.mcmp.o11ymanager.manager.dto.SpiderMonitoringInfo;
 import com.mcmp.o11ymanager.manager.dto.influx.VmRef;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCIList;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
+import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
 import com.mcmp.o11ymanager.manager.service.interfaces.InfluxDbService;
 import com.mcmp.o11ymanager.manager.service.interfaces.TumblebugService;
 import jakarta.annotation.PostConstruct;
@@ -67,6 +70,7 @@ public class CspCacheWarmScheduler {
     private final CspCacheService cspCacheService;
     private final SpiderClient spiderClient;
     private final TumblebugService tumblebugService;
+    private final TumblebugClient tumblebugClient;
     private final VmCreatedTimeResolver vmCreatedTimeResolver;
     private final InfluxDbService influxDbService;
 
@@ -111,7 +115,10 @@ public class CspCacheWarmScheduler {
         CspCacheProperties.Warm w = properties.getWarm();
 
         List<VmWithCsp> cspVms = collectCspVms();
-        Set<String> connectionNames = collectConnectionNames(cspVms);
+        // Connection names for cluster discovery come from ALL Tumblebug VMs in all NSs,
+        // not just InfluxDB-active VMs. K8s nodes don't report agent metrics so their
+        // connections would otherwise be missed.
+        Set<String> connectionNames = collectAllTumblebugConnections();
 
         AtomicInteger vmOk = new AtomicInteger();
         AtomicInteger vmFail = new AtomicInteger();
@@ -208,6 +215,57 @@ public class CspCacheWarmScheduler {
         for (VmWithCsp v : vms) {
             if (v.connectionName() != null && !v.connectionName().isBlank()) {
                 out.add(v.connectionName());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Walks every namespace and MCI in Tumblebug and collects unique connectionNames. K8s clusters
+     * often live in a connection that has no InfluxDB-active VM, so scanning all Tumblebug VMs is
+     * the only way to not miss their connections for warming.
+     */
+    private Set<String> collectAllTumblebugConnections() {
+        Set<String> out = new HashSet<>();
+        TumblebugNS nsList;
+        try {
+            nsList = tumblebugClient.getNSList();
+        } catch (Exception e) {
+            log.debug("[CSP-CACHE-WARM] getNSList failed: {}", e.toString());
+            return out;
+        }
+        if (nsList == null || nsList.getNs() == null) {
+            return out;
+        }
+        for (TumblebugNS.NS ns : nsList.getNs()) {
+            if (ns == null || ns.getId() == null) {
+                continue;
+            }
+            TumblebugMCIList mciList;
+            try {
+                mciList = tumblebugClient.getMCIList(ns.getId());
+            } catch (Exception e) {
+                log.debug(
+                        "[CSP-CACHE-WARM] getMCIList failed ns={}, err={}",
+                        ns.getId(),
+                        e.toString());
+                continue;
+            }
+            if (mciList == null || mciList.getMci() == null) {
+                continue;
+            }
+            for (TumblebugMCI mci : mciList.getMci()) {
+                if (mci == null || mci.getVm() == null) {
+                    continue;
+                }
+                for (TumblebugMCI.Vm vm : mci.getVm()) {
+                    if (vm != null
+                            && vm.getConnectionName() != null
+                            && !vm.getConnectionName().isBlank()
+                            && isCspSupported(vm.getConnectionName())) {
+                        out.add(vm.getConnectionName());
+                    }
+                }
             }
         }
         return out;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheService.java
@@ -69,6 +69,9 @@ public class MonitoringCacheService {
     /**
      * Returns the cached metric list for the given query, or computes it from InfluxDB via {@code
      * loader} on miss and stores the result.
+     *
+     * <p>An empty hit (cached but no data points) is treated as a miss so that once metrics
+     * actually start flowing the next call fills the cache with real data.
      */
     public List<MetricDTO> getOrLoad(
             String nsId,
@@ -83,7 +86,7 @@ public class MonitoringCacheService {
                 MonitoringCacheKey.of(nsId, mciId, vmId, req, properties.getBlockPeriodSeconds());
 
         List<MetricDTO> hit = cache.getIfPresent(key);
-        if (hit != null) {
+        if (hit != null && hasAnyDataPoint(hit)) {
             manualHitCount.incrementAndGet();
             log.debug(
                     "[MON-CACHE] HIT ns={}, mci={}, vm={}, bucket={}",
@@ -198,6 +201,19 @@ public class MonitoringCacheService {
                 return currentDuration;
             }
         };
+    }
+
+    /** True if at least one series in the list has at least one data point. */
+    private static boolean hasAnyDataPoint(List<MetricDTO> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return false;
+        }
+        for (MetricDTO m : dtos) {
+            if (m != null && m.values() != null && !m.values().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static int estimateWeight(


### PR DESCRIPTION
## Summary
- Add Caffeine-backed CSP monitoring proxy + warm scheduler so NS/MCI overview tab switches don't re-hit cb-spider/CSP APIs from cold.
- Add Agent-side \`overview\` warm job whose query shape (specific field, mean aggregation, groupBy=vm_id, limit=2000) matches what the frontend NS/MCI overview actually sends, fixing the existing warm that cached with \`fields=[]\` and produced cache-key mismatches on every UI request.
- Treat empty cache entries as misses so data that starts flowing mid-bucket isn't stuck behind a stale empty hit.
- Default cb-spider Basic Auth to \`default/default\`.
- Route frontend CSP monitoring through the manager (\`/api/o11y/monitoring/csp/**\`) instead of \`/spider/**\` direct, which is what makes the cache actually get used.
- Fix MciOverview agent path building a \`mciId=undefined\` URL when \`allMcis\` state is still stale at the time \`loadAgentData\` runs.

## Test plan
- [ ] Open monitoring tab → confirm Agent and CSP graphs load instantly on second visit.
- [ ] Observe \`[MON-CACHE]\`, \`[CSP-CACHE]\`, \`[CSP-CACHE-WARM]\`, \`[CACHE-WARM:overview]\` log lines at startup.
- [ ] Check \`/api/o11y/monitoring/influxdb/cache/stats\` and \`/api/o11y/monitoring/csp/cache/stats\` hit rates rise after a few tab switches.
- [ ] With agent newly installed on a VM, verify the first-bucket empty cache doesn't block the fresh data from surfacing within ~1 minute.