### PR TITLE
fix: java: Restart telegraf after plugin update

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -11,6 +11,7 @@ import LogViewer from './pages/LogViewer';
 import MonitoringConfig from './pages/MonitoringConfig';
 import InsightDashboard from './pages/InsightDashboard';
 import AlertManager from './pages/AlertManager';
+import K8sNodeDashboard from './pages/K8sNodeDashboard';
 import HomePage from './pages/HomePage';
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
       {/* Standalone — full nav + test console */}
       <Route path="/" element={<HomePage />} />
       <Route element={<Layout />}>
+        <Route path="/monitoring/:nsId/k8s/:connectionName/:clusterName/:nodeGroupName/:nodeNumber" element={<K8sNodeDashboard />} />
         <Route path="/monitoring/:nsId/:mciId/:vmId" element={<MonitoringDashboard />} />
         <Route path="/monitoring/:nsId/:mciId" element={<MciOverview />} />
         <Route path="/monitoring/:nsId" element={<MciOverview />} />
@@ -43,6 +45,7 @@ export default function App() {
 
       {/* Embed — no nav, for iframe */}
       <Route element={<EmbedLayout />}>
+        <Route path="/embed/monitoring/:nsId/k8s/:connectionName/:clusterName/:nodeGroupName/:nodeNumber" element={<K8sNodeDashboard />} />
         <Route path="/embed/monitoring/:nsId/:mciId/:vmId" element={<MonitoringDashboard />} />
         <Route path="/embed/monitoring/:nsId/:mciId" element={<MciOverview />} />
         <Route path="/embed/monitoring/:nsId" element={<MciOverview />} />

--- a/front/src/pages/K8sNodeDashboard.jsx
+++ b/front/src/pages/K8sNodeDashboard.jsx
@@ -1,0 +1,138 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { getClusters, getCluster, getClusterNodeMetric } from '../api/k8s';
+import { CSP_METRICS, isCspSupported } from '../api/csp';
+import MetricChart from '../components/MetricChart';
+import ProviderBadge from '../components/ProviderBadge';
+
+export default function K8sNodeDashboard() {
+  const { nsId, connectionName, clusterName, nodeGroupName, nodeNumber } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const [selectedMetric, setSelectedMetric] = useState('cpu_usage');
+  const [selectedRange, setSelectedRange] = useState('1');
+  const [chartData, setChartData] = useState(null);
+  const [overviewData, setOverviewData] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [overviewLoading, setOverviewLoading] = useState(true);
+
+  // Auto-load overview metrics
+  useEffect(() => {
+    if (!connectionName || !clusterName || !nodeGroupName || !nodeNumber) return;
+    setOverviewLoading(true);
+    const OVERVIEW = ['cpu_usage', 'memory_usage', 'network_in'];
+    Promise.allSettled(OVERVIEW.map(async (mt) => {
+      const data = await getClusterNodeMetric(connectionName, clusterName, nodeGroupName, nodeNumber, mt, '5', selectedRange);
+      return { key: mt, data };
+    })).then(results => {
+      const d = {};
+      results.forEach(r => { if (r.status === 'fulfilled') d[r.value.key] = r.value.data; });
+      setOverviewData(d);
+    }).finally(() => setOverviewLoading(false));
+  }, [connectionName, clusterName, nodeGroupName, nodeNumber, selectedRange]);
+
+  const loadMetric = useCallback(async () => {
+    if (!connectionName || !clusterName || !nodeGroupName || !nodeNumber || !selectedMetric) return;
+    setLoading(true);
+    try {
+      const data = await getClusterNodeMetric(connectionName, clusterName, nodeGroupName, nodeNumber, selectedMetric, '5', selectedRange);
+      setChartData(data);
+    } catch { setChartData(null); }
+    setLoading(false);
+  }, [connectionName, clusterName, nodeGroupName, nodeNumber, selectedMetric, selectedRange]);
+
+  function toSeries(data) {
+    if (!data?.timestampValues?.length) return [];
+    return [{ name: data.metricName || 'value', data: data.timestampValues.map(v => ({ x: new Date(v.timestamp).getTime(), y: parseFloat(v.value) })) }];
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">K8s Node Monitoring</span>
+            <ProviderBadge connectionName={connectionName} />
+          </div>
+        </div>
+        <div className="p-4 space-y-4">
+          {/* Info row */}
+          <div className="grid grid-cols-4 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Cluster</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={clusterName || ''} readOnly />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Node Group</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={nodeGroupName || ''} readOnly />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Node #</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={nodeNumber || ''} readOnly />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Range (hours)</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedRange} onChange={(e) => setSelectedRange(e.target.value)}>
+                <option value="1">1H</option>
+                <option value="6">6H</option>
+                <option value="12">12H</option>
+                <option value="24">1D</option>
+                <option value="72">3D</option>
+                <option value="168">7D</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Metric selector */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">API Metric</label>
+            <div className="flex gap-1 flex-wrap">
+              {CSP_METRICS.map((m) => (
+                <button key={m.key} onClick={() => { setSelectedMetric(m.key); }}
+                  className={`px-3 py-1.5 text-xs rounded-md border ${selectedMetric === m.key ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}>
+                  {m.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="text-center">
+            <button onClick={loadMetric} disabled={loading} className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium">
+              {loading ? 'Loading...' : 'Load Metric'}
+            </button>
+          </div>
+        </div>
+
+        {/* Overview charts */}
+        <div className="p-4 border-t">
+          <div className="text-xs text-gray-500 mb-2">Node Overview</div>
+          {overviewLoading ? (
+            <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading CSP API data...</div>
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+              {['cpu_usage', 'memory_usage', 'network_in'].map(key => {
+                const d = overviewData[key];
+                const label = CSP_METRICS.find(m => m.key === key)?.label || key;
+                return (
+                  <div key={key} className="bg-white rounded border p-3">
+                    <MetricChart title={d?.metricName || label} series={toSeries(d)} height={160} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Custom metric chart */}
+        {chartData && (
+          <div className="p-4 border-t">
+            <div className="text-xs text-gray-500 mb-2">Custom Query</div>
+            <div className="bg-white rounded border p-3">
+              <MetricChart title={`${chartData.metricName || selectedMetric} (${chartData.metricUnit || ''})`} series={toSeries(chartData)} height={300} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/MciOverview.jsx
+++ b/front/src/pages/MciOverview.jsx
@@ -293,6 +293,7 @@ export default function MciOverview() {
                       metricsLoading={nodeMetricsLoading}
                       selectedChart={selectedChart}
                       onSelectChart={setSelectedChart}
+                      onClickChart={() => navigate(`${base}/monitoring/${nsId}/k8s/${n.connectionName}/${n.clusterName}/${n.nodeGroupName}/${n.nodeNumber}`)}
                     />
                   ))}
                 </div>
@@ -334,7 +335,7 @@ export default function MciOverview() {
   );
 }
 
-function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart, onSelectChart }) {
+function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart, onSelectChart, onClickChart }) {
   const cspSupported = isCspSupported(info.connectionName);
   const nodeName = info.node?.NameId || info.node?.SystemId || `node-${info.nodeNumber}`;
 
@@ -389,7 +390,7 @@ function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart,
             );
           })}
         </div>
-        <div className="flex-1 px-2 py-1 min-w-0">
+        <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
           {metricsLoading ? (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading CSP API data...</div>
           ) : activeData?.series ? (
@@ -538,10 +539,24 @@ function getLastValue(metricDTOs) {
   if (!metricDTOs || metricDTOs.length === 0) return null;
   const m = metricDTOs[0];
   if (!m.values || m.values.length === 0) return null;
-  const lastRow = m.values[m.values.length - 1];
   const timeIdx = (m.columns || []).indexOf('timestamp');
-  const valIdx = timeIdx === 0 ? 1 : 0;
-  return lastRow[valIdx] != null ? parseFloat(lastRow[valIdx]) : null;
+  const tIdx = timeIdx < 0 ? 0 : timeIdx;
+  const valIdx = tIdx === 0 ? 1 : 0;
+  // Server returns rows `order by time desc`, so values[0] is newest. Scan for
+  // the row with the max timestamp that has a non-null value — handles sparse
+  // series where the most recent bucket might still be null.
+  let bestTs = -Infinity;
+  let bestVal = null;
+  for (const row of m.values) {
+    if (row[valIdx] == null) continue;
+    const raw = row[tIdx];
+    const ts = typeof raw === 'string' ? new Date(raw).getTime() : Number(raw);
+    if (ts > bestTs) {
+      bestTs = ts;
+      bestVal = parseFloat(row[valIdx]);
+    }
+  }
+  return bestVal;
 }
 
 function toSeries(metricDTOs, name, invert) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
@@ -182,6 +182,7 @@ public class ItemFacadeService {
                             updatedConfig.replace("'", "'\"'\"'"), getTelegrafConfigPath());
             tumblebugService.executeCommand(nsId, mciId, vmId, updateCommand);
 
+            telegrafFacadeService.restart(nsId, mciId, vmId);
         } catch (TelegrafConfigException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- \`ItemFacadeService.updateTelegrafPlugin\` wrote the new config to the VM but never called \`telegrafFacadeService.restart()\`, so changes edited through the Monitoring Config UI (updating an existing plugin) were persisted on disk but the running telegraf process kept the old plugin set until the next manual restart. \`addTelegrafPlugin\` and \`deleteTelegrafPlugin\` already restart; this just brings \`update\` into line.

## Test plan
- [ ] Via Monitoring Config, change the config of an existing plugin on a VM; confirm \`systemctl status cmp-telegraf-<site>\` on the VM shows a restart right after.
- [ ] Confirm data for that plugin resumes flowing to InfluxDB within one flush interval (~1 min).