### PR TITLE
fix: java: Memoise discovery in CSP cache warmer

### DIFF
--- a/front/src/components/MetricChart.jsx
+++ b/front/src/components/MetricChart.jsx
@@ -21,7 +21,7 @@ export default function MetricChart({ title, series, height = 240, chartType = '
 
   const options = {
     chart: { type: chartType, toolbar: { show: true }, zoom: { enabled: true, type: 'x', autoScaleYaxis: true, allowMouseWheelZoom: false }, animations: { enabled: false } },
-    title: { text: title + (yTitle ? ` ${yTitle}` : ''), align: 'center', style: { fontSize: '14px', fontWeight: 600 } },
+    title: { text: title + (yTitle ? ` ${yTitle}` : ''), align: 'left', style: { fontSize: '13px', fontWeight: 600 }, offsetY: 0 },
     xaxis: { type: 'datetime', labels: { format: 'HH:mm:ss', style: { fontSize: '11px' }, datetimeUTC: false } },
     yaxis: {
       labels: { formatter, style: { fontSize: '11px' } },

--- a/front/src/components/MetricChart.jsx
+++ b/front/src/components/MetricChart.jsx
@@ -7,9 +7,10 @@ const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'
  * @param {string} metric - e.g. "used", "used_percent", "usage_idle", "bytes_recv"
  */
 export default function MetricChart({ title, series, height = 240, chartType = 'area', measurement, metric }) {
-  if (!series || series.length === 0) {
+  const hasData = series && series.length > 0 && series.some(s => s.data && s.data.length > 0);
+  if (!hasData) {
     return (
-      <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
+      <div style={{ height }} className="flex items-center justify-center text-gray-400 text-sm">
         No data
       </div>
     );

--- a/front/src/pages/K8sNodeDashboard.jsx
+++ b/front/src/pages/K8sNodeDashboard.jsx
@@ -1,50 +1,79 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
-import { getClusters, getCluster, getClusterNodeMetric } from '../api/k8s';
-import { CSP_METRICS, isCspSupported } from '../api/csp';
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
+import { getMciList } from '../api/tumblebug';
+import { CSP_METRICS } from '../api/csp';
 import MetricChart from '../components/MetricChart';
 import ProviderBadge from '../components/ProviderBadge';
+import useBasePath from '../hooks/useBasePath';
 
 export default function K8sNodeDashboard() {
-  const { nsId, connectionName, clusterName, nodeGroupName, nodeNumber } = useParams();
-  const [searchParams] = useSearchParams();
+  const { nsId, connectionName: routeConn, clusterName: routeCluster, nodeGroupName: routeNg, nodeNumber: routeNode } = useParams();
+  const navigate = useNavigate();
+  const base = useBasePath();
 
+  // Cluster discovery
+  const [allClusters, setAllClusters] = useState([]); // { cluster, connectionName }
+  const [selectedConn, setSelectedConn] = useState(routeConn || '');
+  const [selectedCluster, setSelectedCluster] = useState(routeCluster || '');
+  const [clusterDetail, setClusterDetail] = useState(null);
+  const [selectedNg, setSelectedNg] = useState(routeNg || '');
+  const [selectedNode, setSelectedNode] = useState(routeNode || '');
+  const [clustersLoading, setClustersLoading] = useState(true);
+
+  // Metrics
   const [selectedMetric, setSelectedMetric] = useState('cpu_usage');
   const [selectedRange, setSelectedRange] = useState('1');
-  const [chartData, setChartData] = useState(null);
-  const [overviewData, setOverviewData] = useState({});
+  const [allMetrics, setAllMetrics] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [overviewLoading, setOverviewLoading] = useState(true);
 
-  // Auto-load overview metrics
+  // Load clusters from all connections in NS
   useEffect(() => {
-    if (!connectionName || !clusterName || !nodeGroupName || !nodeNumber) return;
-    setOverviewLoading(true);
-    const OVERVIEW = ['cpu_usage', 'memory_usage', 'network_in'];
-    Promise.allSettled(OVERVIEW.map(async (mt) => {
-      const data = await getClusterNodeMetric(connectionName, clusterName, nodeGroupName, nodeNumber, mt, '5', selectedRange);
-      return { key: mt, data };
-    })).then(results => {
-      const d = {};
-      results.forEach(r => { if (r.status === 'fulfilled') d[r.value.key] = r.value.data; });
-      setOverviewData(d);
-    }).finally(() => setOverviewLoading(false));
-  }, [connectionName, clusterName, nodeGroupName, nodeNumber, selectedRange]);
+    if (!nsId) return;
+    setClustersLoading(true);
+    (async () => {
+      let mcis = [];
+      try { mcis = await getMciList(nsId); } catch {}
+      const connNames = [...new Set(mcis.flatMap(m => (m.vm || []).map(v => v.connectionName)).filter(Boolean))];
+      const results = await Promise.allSettled(connNames.map(async (conn) => {
+        const list = await getClusters(conn);
+        return list.map(c => ({ name: c.IId?.NameId, connectionName: conn }));
+      }));
+      setAllClusters(results.filter(r => r.status === 'fulfilled').flatMap(r => r.value));
+    })().finally(() => setClustersLoading(false));
+  }, [nsId]);
 
-  const loadMetric = useCallback(async () => {
-    if (!connectionName || !clusterName || !nodeGroupName || !nodeNumber || !selectedMetric) return;
+  // Load cluster detail when cluster selected
+  useEffect(() => {
+    if (!selectedConn || !selectedCluster) { setClusterDetail(null); return; }
+    getCluster(selectedConn, selectedCluster).then(setClusterDetail).catch(() => setClusterDetail(null));
+  }, [selectedConn, selectedCluster]);
+
+  // Nodes from detail
+  const nodeGroups = clusterDetail?.NodeGroupList || [];
+  const selectedNgObj = nodeGroups.find(ng => ng.IId?.NameId === selectedNg);
+  const nodes = selectedNgObj?.Nodes || [];
+
+  // Load metrics when node selected
+  useEffect(() => {
+    if (!selectedConn || !selectedCluster || !selectedNg || !selectedNode) { setAllMetrics(null); return; }
     setLoading(true);
-    try {
-      const data = await getClusterNodeMetric(connectionName, clusterName, nodeGroupName, nodeNumber, selectedMetric, '5', selectedRange);
-      setChartData(data);
-    } catch { setChartData(null); }
-    setLoading(false);
-  }, [connectionName, clusterName, nodeGroupName, nodeNumber, selectedMetric, selectedRange]);
+    setAllMetrics(null);
+    getAllClusterNodeMetrics(selectedConn, selectedCluster, selectedNg, selectedNode, selectedRange)
+      .then(setAllMetrics)
+      .catch(() => setAllMetrics({}))
+      .finally(() => setLoading(false));
+  }, [selectedConn, selectedCluster, selectedNg, selectedNode, selectedRange]);
 
-  function toSeries(data) {
-    if (!data?.timestampValues?.length) return [];
-    return [{ name: data.metricName || 'value', data: data.timestampValues.map(v => ({ x: new Date(v.timestamp).getTime(), y: parseFloat(v.value) })) }];
+  // Update URL when selection changes (without full reload)
+  function updateSelection(conn, cluster, ng, node) {
+    if (conn && cluster && ng && node) {
+      navigate(`${base}/monitoring/${nsId}/k8s/${conn}/${cluster}/${ng}/${node}`, { replace: true });
+    }
   }
+
+  const activeData = allMetrics?.[selectedMetric];
+  const overviewKeys = ['cpu_usage', 'memory_usage', 'network_in'];
 
   return (
     <div className="space-y-4">
@@ -52,26 +81,47 @@ export default function K8sNodeDashboard() {
         <div className="px-4 py-3 border-b flex items-center justify-between">
           <div className="flex items-center gap-2">
             <span className="font-semibold text-sm">K8s Node Monitoring</span>
-            <ProviderBadge connectionName={connectionName} />
+            {selectedConn && <ProviderBadge connectionName={selectedConn} />}
           </div>
         </div>
         <div className="p-4 space-y-4">
-          {/* Info row */}
+          {/* Cascade selectors */}
           <div className="grid grid-cols-4 gap-4">
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Cluster</label>
-              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={clusterName || ''} readOnly />
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={`${selectedConn}|${selectedCluster}`}
+                onChange={(e) => {
+                  const [c, cl] = e.target.value.split('|');
+                  setSelectedConn(c); setSelectedCluster(cl); setSelectedNg(''); setSelectedNode('');
+                }}>
+                <option value="|">{clustersLoading ? 'Loading...' : 'Select'}</option>
+                {allClusters.map(c => (
+                  <option key={`${c.connectionName}|${c.name}`} value={`${c.connectionName}|${c.name}`}>{c.name}</option>
+                ))}
+              </select>
             </div>
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Node Group</label>
-              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={nodeGroupName || ''} readOnly />
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedNg}
+                onChange={(e) => { setSelectedNg(e.target.value); setSelectedNode(''); }} disabled={!clusterDetail}>
+                <option value="">Select</option>
+                {nodeGroups.map(ng => (
+                  <option key={ng.IId?.NameId} value={ng.IId?.NameId}>{ng.IId?.NameId}</option>
+                ))}
+              </select>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Node #</label>
-              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={nodeNumber || ''} readOnly />
+              <label className="block text-xs font-medium text-gray-600 mb-1">Node</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedNode}
+                onChange={(e) => { setSelectedNode(e.target.value); updateSelection(selectedConn, selectedCluster, selectedNg, e.target.value); }} disabled={!selectedNg}>
+                <option value="">Select</option>
+                {nodes.map((n, i) => (
+                  <option key={i + 1} value={String(i + 1)}>Node {i + 1} — {n.NameId || n.SystemId || `#${i+1}`}</option>
+                ))}
+              </select>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Range (hours)</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
               <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedRange} onChange={(e) => setSelectedRange(e.target.value)}>
                 <option value="1">1H</option>
                 <option value="6">6H</option>
@@ -84,53 +134,62 @@ export default function K8sNodeDashboard() {
           </div>
 
           {/* Metric selector */}
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">API Metric</label>
-            <div className="flex gap-1 flex-wrap">
-              {CSP_METRICS.map((m) => (
-                <button key={m.key} onClick={() => { setSelectedMetric(m.key); }}
-                  className={`px-3 py-1.5 text-xs rounded-md border ${selectedMetric === m.key ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}>
-                  {m.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="text-center">
-            <button onClick={loadMetric} disabled={loading} className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium">
-              {loading ? 'Loading...' : 'Load Metric'}
-            </button>
-          </div>
-        </div>
-
-        {/* Overview charts */}
-        <div className="p-4 border-t">
-          <div className="text-xs text-gray-500 mb-2">Node Overview</div>
-          {overviewLoading ? (
-            <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading CSP API data...</div>
-          ) : (
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
-              {['cpu_usage', 'memory_usage', 'network_in'].map(key => {
-                const d = overviewData[key];
-                const label = CSP_METRICS.find(m => m.key === key)?.label || key;
-                return (
-                  <div key={key} className="bg-white rounded border p-3">
-                    <MetricChart title={d?.metricName || label} series={toSeries(d)} height={160} />
-                  </div>
-                );
-              })}
+          {selectedNode && (
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">API Metric</label>
+              <div className="flex gap-1 flex-wrap">
+                {CSP_METRICS.map((m) => (
+                  <button key={m.key} onClick={() => setSelectedMetric(m.key)}
+                    className={`px-3 py-1.5 text-xs rounded-md border ${selectedMetric === m.key ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}>
+                    {m.label}
+                  </button>
+                ))}
+              </div>
             </div>
           )}
         </div>
 
-        {/* Custom metric chart */}
-        {chartData && (
-          <div className="p-4 border-t">
-            <div className="text-xs text-gray-500 mb-2">Custom Query</div>
-            <div className="bg-white rounded border p-3">
-              <MetricChart title={`${chartData.metricName || selectedMetric} (${chartData.metricUnit || ''})`} series={toSeries(chartData)} height={300} />
+        {/* Charts — only when node is selected */}
+        {selectedNode && (
+          <>
+            {/* Selected metric chart */}
+            <div className="p-4 border-t">
+              <div className="mb-2 text-sm font-medium">{activeData?.metricName || selectedMetric}</div>
+              {(loading || !allMetrics) ? (
+                <div className="flex items-center justify-center h-[300px] text-gray-400 animate-pulse">Loading CSP API data...</div>
+              ) : activeData?.series ? (
+                <div className="bg-white rounded border p-3">
+                  <MetricChart title={`${activeData.metricName} (${activeData.metricUnit})`} series={activeData.series} height={300} />
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-[300px] text-gray-400">No data</div>
+              )}
             </div>
-          </div>
+
+            {/* Overview */}
+            <div className="p-4 border-t">
+              <div className="text-xs text-gray-500 mb-2">Node Overview</div>
+              {(loading || !allMetrics) ? (
+                <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading CSP API data...</div>
+              ) : (
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+                  {overviewKeys.map(key => {
+                    const d = allMetrics[key];
+                    return (
+                      <div key={key} className="bg-white rounded border p-3 cursor-pointer hover:ring-1 hover:ring-blue-300"
+                        onClick={() => setSelectedMetric(key)}>
+                        <MetricChart title={d?.metricName || key} series={d?.series || []} height={140} />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {!selectedNode && (
+          <div className="p-8 text-center text-sm text-gray-400">Select a cluster, node group, and node to view metrics</div>
         )}
       </div>
     </div>

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -1,5 +1,7 @@
 package com.mcmp.o11ymanager.manager.service.cache;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.mcmp.o11ymanager.manager.config.CspCacheProperties;
 import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
 import com.mcmp.o11ymanager.manager.dto.SpiderClusterList;
@@ -14,6 +16,7 @@ import com.mcmp.o11ymanager.manager.service.interfaces.InfluxDbService;
 import com.mcmp.o11ymanager.manager.service.interfaces.TumblebugService;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -75,6 +78,19 @@ public class CspCacheWarmScheduler {
     private final InfluxDbService influxDbService;
 
     private ExecutorService executor;
+
+    /**
+     * Short-lived caches for Tumblebug/cb-spider discovery calls so the warm pass doesn't hammer
+     * Tumblebug's rate limiter on every tick (it returns 429 quickly under bursts).
+     *
+     * <p>TTL roughly covers 5 warm cycles — fresh enough to pick up new infrastructure within a few
+     * minutes, cheap enough to not re-discover on every minute.
+     */
+    private final Cache<String, Set<String>> connectionDiscoveryCache =
+            Caffeine.newBuilder().maximumSize(1).expireAfterWrite(Duration.ofMinutes(5)).build();
+
+    private final Cache<String, List<ClusterRef>> clusterDiscoveryCache =
+            Caffeine.newBuilder().maximumSize(64).expireAfterWrite(Duration.ofMinutes(5)).build();
 
     @PostConstruct
     void init() {
@@ -221,11 +237,15 @@ public class CspCacheWarmScheduler {
     }
 
     /**
-     * Walks every namespace and MCI in Tumblebug and collects unique connectionNames. K8s clusters
-     * often live in a connection that has no InfluxDB-active VM, so scanning all Tumblebug VMs is
-     * the only way to not miss their connections for warming.
+     * Walks every namespace and MCI in Tumblebug and collects unique connectionNames. Result is
+     * memoised for 5 minutes to avoid Tumblebug rate-limit bursts (429 Too Many Requests) when warm
+     * runs every minute.
      */
     private Set<String> collectAllTumblebugConnections() {
+        Set<String> cached = connectionDiscoveryCache.getIfPresent("all");
+        if (cached != null) {
+            return cached;
+        }
         Set<String> out = new HashSet<>();
         TumblebugNS nsList;
         try {
@@ -268,6 +288,9 @@ public class CspCacheWarmScheduler {
                 }
             }
         }
+        if (!out.isEmpty()) {
+            connectionDiscoveryCache.put("all", out);
+        }
         return out;
     }
 
@@ -305,6 +328,38 @@ public class CspCacheWarmScheduler {
             AtomicInteger ok,
             AtomicInteger fail) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
+        List<ClusterRef> refs = discoverClusters(connectionName);
+        for (ClusterRef ref : refs) {
+            for (String metric : NODE_METRICS) {
+                futures.add(
+                        CompletableFuture.runAsync(
+                                () ->
+                                        warmClusterNodeMetric(
+                                                ref.connectionName(),
+                                                ref.clusterName(),
+                                                ref.nodeGroupName(),
+                                                ref.nodeNumber(),
+                                                metric,
+                                                tbh,
+                                                interval,
+                                                ok,
+                                                fail),
+                                executor));
+            }
+        }
+        return futures;
+    }
+
+    /**
+     * Enumerates (cluster, nodeGroup, nodeNumber) tuples for a connection. Result is cached for 5
+     * minutes to avoid hammering cb-spider (which itself talks to the CSP API) each warm tick.
+     */
+    private List<ClusterRef> discoverClusters(String connectionName) {
+        List<ClusterRef> cached = clusterDiscoveryCache.getIfPresent(connectionName);
+        if (cached != null) {
+            return cached;
+        }
+        List<ClusterRef> refs = new ArrayList<>();
         SpiderClusterList list;
         try {
             list = spiderClient.listClusters(connectionName);
@@ -313,10 +368,10 @@ public class CspCacheWarmScheduler {
                     "[CSP-CACHE-WARM] listClusters failed conn={}, err={}",
                     connectionName,
                     e.toString());
-            return futures;
+            return refs;
         }
         if (list == null || list.getCluster() == null) {
-            return futures;
+            return refs;
         }
         for (SpiderClusterInfo c : list.getCluster()) {
             if (c == null || c.getIId() == null || c.getIId().getNameId() == null) {
@@ -348,27 +403,16 @@ public class CspCacheWarmScheduler {
                 }
                 String ngName = ng.getIId().getNameId();
                 for (int idx = 0; idx < ng.getNodes().size(); idx++) {
-                    final String nodeNumber = String.valueOf(idx + 1);
-                    for (String metric : NODE_METRICS) {
-                        futures.add(
-                                CompletableFuture.runAsync(
-                                        () ->
-                                                warmClusterNodeMetric(
-                                                        connectionName,
-                                                        clusterName,
-                                                        ngName,
-                                                        nodeNumber,
-                                                        metric,
-                                                        tbh,
-                                                        interval,
-                                                        ok,
-                                                        fail),
-                                        executor));
-                    }
+                    refs.add(
+                            new ClusterRef(
+                                    connectionName, clusterName, ngName, String.valueOf(idx + 1)));
                 }
             }
         }
-        return futures;
+        if (!refs.isEmpty()) {
+            clusterDiscoveryCache.put(connectionName, refs);
+        }
+        return refs;
     }
 
     private void warmClusterNodeMetric(
@@ -429,4 +473,7 @@ public class CspCacheWarmScheduler {
 
     private record VmWithCsp(
             VmRef ref, String connectionName, String cspResourceName, Instant createdAt) {}
+
+    private record ClusterRef(
+            String connectionName, String clusterName, String nodeGroupName, String nodeNumber) {}
 }


### PR DESCRIPTION
## Summary
Warm scheduler was hitting Tumblebug every minute to enumerate namespaces + MCIs for K8s connection discovery, causing \`429 Too Many Requests\` on the Tumblebug rate limiter. With discovery failing, \`connections=0\` and K8s nodes were never warmed, so every K8s view in the frontend took cold-path cb-spider latency.

Fix: memoise NS/MCI discovery and per-connection cluster/node discovery in small Caffeine caches (5-minute TTL, max 1 / 64 entries). Warm still refreshes every minute for actual metric fetches; only the expensive discovery layer is cached.

## Test plan
- [ ] Confirm \`[CSP-CACHE-WARM]\` logs show \`connections>0\` and \`nodeOk>0\` after first tick.
- [ ] Verify no more \`429 Too Many Requests\` in debug logs.
- [ ] K8s monitoring view loads instantly after warm has populated the cache.