### PR TITLE
fix: java: CSP K8s cache warming

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/SpiderClusterInfo.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/SpiderClusterInfo.java
@@ -1,13 +1,16 @@
 package com.mcmp.o11ymanager.manager.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Minimal projection of cb-spider cluster detail response. Only the fields needed for CSP warming
- * (cluster name, node groups, per-group nodes) are modelled.
+ * Minimal projection of cb-spider cluster detail response. cb-spider uses PascalCase JSON keys
+ * which Jackson does not map automatically with Lombok-generated getters whose bean-property names
+ * come out lower-camel. Each field is therefore annotated with @JsonProperty so the JSON binding
+ * matches the wire format exactly.
  */
 @Getter
 @Setter
@@ -18,7 +21,10 @@ public class SpiderClusterInfo {
     @Getter
     @Setter
     public static class IId {
+        @JsonProperty("NameId")
         private String NameId;
+
+        @JsonProperty("SystemId")
         private String SystemId;
     }
 
@@ -26,11 +32,19 @@ public class SpiderClusterInfo {
     @Getter
     @Setter
     public static class NodeGroup {
+        @JsonProperty("IId")
         private IId IId;
+
+        @JsonProperty("Nodes")
         private List<IId> Nodes;
     }
 
+    @JsonProperty("IId")
     private IId IId;
+
+    @JsonProperty("Status")
     private String Status;
+
+    @JsonProperty("NodeGroupList")
     private List<NodeGroup> NodeGroupList;
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -247,10 +247,6 @@ public class CspCacheWarmScheduler {
             return cached;
         }
         Set<String> out = new HashSet<>();
-        int nsSeen = 0;
-        int mciSeen = 0;
-        int vmSeen = 0;
-        int vmFiltered = 0;
         TumblebugNS nsList;
         try {
             nsList = tumblebugClient.getNSList();
@@ -260,55 +256,75 @@ public class CspCacheWarmScheduler {
             return out;
         }
         if (nsList == null || nsList.getNs() == null) {
-            log.info("[CSP-CACHE-WARM] getNSList returned null/empty");
             connectionDiscoveryCache.put("all", out);
             return out;
         }
+        boolean throttled = false;
         for (TumblebugNS.NS ns : nsList.getNs()) {
             if (ns == null || ns.getId() == null) {
                 continue;
             }
-            nsSeen++;
-            TumblebugMCIList mciList;
-            try {
-                mciList = tumblebugClient.getMCIList(ns.getId());
-            } catch (Exception e) {
-                log.warn(
-                        "[CSP-CACHE-WARM] getMCIList failed ns={}, err={}",
-                        ns.getId(),
-                        e.toString());
-                continue;
+            // Tumblebug rate-limits ~3 sequential calls; space them out.
+            if (throttled) {
+                try {
+                    Thread.sleep(400L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
             }
+            throttled = true;
+            TumblebugMCIList mciList = getMCIListWithRetry(ns.getId());
             if (mciList == null || mciList.getMci() == null) {
                 continue;
             }
             for (TumblebugMCI mci : mciList.getMci()) {
-                mciSeen++;
                 if (mci == null || mci.getVm() == null) {
                     continue;
                 }
                 for (TumblebugMCI.Vm vm : mci.getVm()) {
-                    vmSeen++;
                     if (vm != null
                             && vm.getConnectionName() != null
                             && !vm.getConnectionName().isBlank()
                             && isCspSupported(vm.getConnectionName())) {
                         out.add(vm.getConnectionName());
-                    } else {
-                        vmFiltered++;
                     }
                 }
             }
         }
-        log.info(
-                "[CSP-CACHE-WARM] discovery: ns={}, mci={}, vm={}, filtered={}, connections={}",
-                nsSeen,
-                mciSeen,
-                vmSeen,
-                vmFiltered,
-                out);
         connectionDiscoveryCache.put("all", out);
         return out;
+    }
+
+    /**
+     * Wraps {@code tumblebugClient.getMCIList} with a single retry on 429. Tumblebug rate-limits
+     * aggressively (rejects 3rd call in quick succession); a short backoff lets the window reset
+     * without failing the whole discovery pass.
+     */
+    private TumblebugMCIList getMCIListWithRetry(String nsId) {
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try {
+                return tumblebugClient.getMCIList(nsId);
+            } catch (Exception e) {
+                String msg = e.toString();
+                boolean rateLimited = msg.contains("429") || msg.contains("TooManyRequests");
+                if (!rateLimited || attempt == 2) {
+                    log.warn(
+                            "[CSP-CACHE-WARM] getMCIList failed ns={}, attempt={}, err={}",
+                            nsId,
+                            attempt,
+                            msg);
+                    return null;
+                }
+                try {
+                    Thread.sleep(1500L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return null;
+                }
+            }
+        }
+        return null;
     }
 
     private void warmVmMetric(
@@ -381,7 +397,7 @@ public class CspCacheWarmScheduler {
         try {
             list = spiderClient.listClusters(connectionName);
         } catch (Exception e) {
-            log.debug(
+            log.warn(
                     "[CSP-CACHE-WARM] listClusters failed conn={}, err={}",
                     connectionName,
                     e.toString());
@@ -394,23 +410,24 @@ public class CspCacheWarmScheduler {
             if (c == null || c.getIId() == null || c.getIId().getNameId() == null) {
                 continue;
             }
+            String cName = c.getIId().getNameId();
             SpiderClusterInfo detail;
             try {
-                detail = spiderClient.getCluster(c.getIId().getNameId(), connectionName);
+                // Space out cb-spider calls — CSP provider APIs can rate-limit.
+                Thread.sleep(400L);
+                detail = spiderClient.getCluster(cName, connectionName);
             } catch (Exception e) {
-                log.debug(
-                        "[CSP-CACHE-WARM] getCluster failed cluster={}, err={}",
-                        c.getIId().getNameId(),
+                log.warn(
+                        "[CSP-CACHE-WARM] getCluster failed cluster={}, conn={}, err={}",
+                        cName,
+                        connectionName,
                         e.toString());
                 continue;
             }
             if (detail == null || detail.getNodeGroupList() == null) {
                 continue;
             }
-            String clusterName = detail.getIId() != null ? detail.getIId().getNameId() : null;
-            if (clusterName == null) {
-                continue;
-            }
+            String clusterName = detail.getIId() != null ? detail.getIId().getNameId() : cName;
             for (SpiderClusterInfo.NodeGroup ng : detail.getNodeGroupList()) {
                 if (ng == null
                         || ng.getIId() == null


### PR DESCRIPTION
## Summary
K8s node warming in the CSP cache scheduler wasn't firing. Two root causes, both now fixed:

1. **PascalCase JSON mapping**: cb-spider returns cluster detail with PascalCase keys (\`IId\`, \`NameId\`, \`NodeGroupList\`, \`Nodes\`). Lombok-generated getters produce bean property names in lower-camel, so Jackson never populated the fields. Added explicit \`@JsonProperty\` on every field of \`SpiderClusterInfo\`.
2. **Tumblebug rate-limit (429)**: warm ran \`getNSList\` + one \`getMCIList\` per NS every minute; burst of 4+ sequential calls tripped Tumblebug's rate limiter and discovery silently returned empty. Added a 400ms space-out between NS iterations, a single 1.5s-backoff retry on 429, and memoisation (5-min TTL) of both namespace→connection and cluster→node discovery so warm stops re-hammering those paths every tick. cb-spider's \`getCluster\` also now gets a 400ms space-out.

With these, warm logs show:
\`\`\`
vms=1, vmOk=8, connections=3, nodeOk=32, nodeFail=0
\`\`\`
(4 K8s nodes × 8 CSP metrics = 32 warmed entries per tick.)

## Test plan
- [ ] K8s monitoring tab loads instantly after the first minute — no per-chart cb-spider round-trip.
- [ ] No 429 entries in manager logs for \`tumblebug\` paths.
- [ ] \`/api/o11y/monitoring/csp/cache/stats\` hitRate climbs as the user navigates.