### PR TITLE
feat: java: CSP warm covers all frontend ranges

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/CspCacheProperties.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/CspCacheProperties.java
@@ -1,5 +1,6 @@
 package com.mcmp.o11ymanager.manager.config;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,10 +25,11 @@ public class CspCacheProperties {
     private long maxSize = 10_000L;
 
     /**
-     * Entry TTL after write. CSP providers typically publish metrics on a 1–5 minute cadence, so a
-     * 60-second TTL keeps results fresh while still absorbing tab-switch storms.
+     * Entry TTL after write. 5 minutes comfortably outlives the 1-minute warm cadence for the
+     * short-range spec set and the 5-minute cadence for the long-range set, so cached entries stay
+     * valid between refreshes.
      */
-    private long expireAfterWriteSeconds = 60L;
+    private long expireAfterWriteSeconds = 300L;
 
     /** Periodic cache warming. */
     private Warm warm = new Warm();
@@ -36,23 +38,72 @@ public class CspCacheProperties {
     @Setter
     public static class Warm {
         private boolean enabled = true;
-        private String cron = "0 * * * * *";
 
         /**
-         * Worker thread count for parallel warming. Since warm tasks are synchronous cb-spider
-         * calls, this also bounds concurrent outbound requests.
+         * Worker thread count for parallel warming. Each warm tick submits (VMs + K8s nodes) ×
+         * metric × range tasks that call cb-spider; bigger pool → faster overall warm, bounded
+         * cb-spider concurrency.
          */
-        private int threadPoolSize = 10;
-
-        /** Default query parameters for warm fetches. */
-        private String timeBeforeHour = "1";
-
-        private String intervalMinute = "5";
+        private int threadPoolSize = 30;
 
         /**
          * Maximum number of recently-created VMs (per namespace) to warm on each tick. Older VMs
          * are left to load on-demand.
          */
         private int topN = 20;
+
+        /**
+         * Short-range ({@code timeBeforeHour ≤ 12h}) warming — refreshed every minute so the
+         * default monitoring view is always close to live.
+         */
+        private Job realtime =
+                new Job(
+                        "0 * * * * *",
+                        List.of(new Range("1", "5"), new Range("6", "5"), new Range("12", "5")));
+
+        /**
+         * Long-range ({@code timeBeforeHour ≥ 24h}) warming — refreshed every 5 minutes since the
+         * data changes slowly and each call is expensive (more points, more CSP API round-trips).
+         */
+        private Job longrange =
+                new Job(
+                        "0 */5 * * * *",
+                        List.of(
+                                new Range("24", "5"),
+                                new Range("72", "5"),
+                                new Range("120", "5"),
+                                new Range("168", "5")));
+    }
+
+    @Getter
+    @Setter
+    public static class Job {
+        private boolean enabled = true;
+        private String cron;
+        private List<Range> ranges;
+
+        public Job() {}
+
+        public Job(String cron, List<Range> ranges) {
+            this.cron = cron;
+            this.ranges = ranges;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class Range {
+        /** {@code TimeBeforeHour} query param forwarded to cb-spider. */
+        private String timeBeforeHour;
+
+        /** {@code IntervalMinute} query param forwarded to cb-spider. */
+        private String intervalMinute;
+
+        public Range() {}
+
+        public Range(String timeBeforeHour, String intervalMinute) {
+            this.timeBeforeHour = timeBeforeHour;
+            this.intervalMinute = intervalMinute;
+        }
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -104,11 +104,17 @@ public class CspCacheWarmScheduler {
                 };
         this.executor = Executors.newFixedThreadPool(size, factory);
         log.info(
-                "[CSP-CACHE-WARM] initialized threads={}, topN={}, tbh={}, interval={}",
+                "[CSP-CACHE-WARM] initialized threads={}, topN={}, realtimeRanges={}, longrangeRanges={}",
                 size,
                 properties.getWarm().getTopN(),
-                properties.getWarm().getTimeBeforeHour(),
-                properties.getWarm().getIntervalMinute());
+                properties.getWarm().getRealtime() == null
+                                || properties.getWarm().getRealtime().getRanges() == null
+                        ? 0
+                        : properties.getWarm().getRealtime().getRanges().size(),
+                properties.getWarm().getLongrange() == null
+                                || properties.getWarm().getLongrange().getRanges() == null
+                        ? 0
+                        : properties.getWarm().getLongrange().getRanges().size());
     }
 
     @PreDestroy
@@ -118,22 +124,43 @@ public class CspCacheWarmScheduler {
         }
     }
 
-    @Scheduled(cron = "${csp.cache.warm.cron:0 * * * * *}")
-    public void scheduled() {
-        warmNow();
+    @Scheduled(cron = "${csp.cache.warm.realtime.cron:0 * * * * *}")
+    public void scheduledRealtime() {
+        CspCacheProperties.Job job = properties.getWarm().getRealtime();
+        if (job != null && job.isEnabled()) {
+            runJob("realtime", job);
+        }
     }
 
+    @Scheduled(cron = "${csp.cache.warm.longrange.cron:0 */5 * * * *}")
+    public void scheduledLongrange() {
+        CspCacheProperties.Job job = properties.getWarm().getLongrange();
+        if (job != null && job.isEnabled()) {
+            runJob("longrange", job);
+        }
+    }
+
+    /** Triggers both jobs immediately (admin / test hook). */
     public int warmNow() {
-        if (executor == null || !properties.isEnabled()) {
+        CspCacheProperties.Warm w = properties.getWarm();
+        int r = runJob("realtime", w.getRealtime());
+        int l = runJob("longrange", w.getLongrange());
+        return r + l;
+    }
+
+    private int runJob(String jobName, CspCacheProperties.Job job) {
+        if (executor == null
+                || !properties.isEnabled()
+                || job == null
+                || job.getRanges() == null
+                || job.getRanges().isEmpty()) {
             return 0;
         }
         long started = System.currentTimeMillis();
-        CspCacheProperties.Warm w = properties.getWarm();
 
         List<VmWithCsp> cspVms = collectCspVms();
-        // Connection names for cluster discovery come from ALL Tumblebug VMs in all NSs,
-        // not just InfluxDB-active VMs. K8s nodes don't report agent metrics so their
-        // connections would otherwise be missed.
+        // K8s nodes don't report agent metrics, so scan all Tumblebug VMs for their connections
+        // rather than only InfluxDB-active ones.
         Set<String> connectionNames = collectAllTumblebugConnections();
 
         AtomicInteger vmOk = new AtomicInteger();
@@ -142,35 +169,46 @@ public class CspCacheWarmScheduler {
         AtomicInteger nodeFail = new AtomicInteger();
 
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (VmWithCsp v : cspVms) {
-            for (String metric : VM_METRICS) {
-                futures.add(
-                        CompletableFuture.runAsync(
-                                () ->
-                                        warmVmMetric(
-                                                v,
-                                                metric,
-                                                w.getTimeBeforeHour(),
-                                                w.getIntervalMinute(),
-                                                vmOk,
-                                                vmFail),
-                                executor));
+        for (CspCacheProperties.Range r : job.getRanges()) {
+            if (r == null || r.getTimeBeforeHour() == null || r.getIntervalMinute() == null) {
+                continue;
             }
-        }
-        for (String conn : connectionNames) {
-            futures.addAll(
-                    warmClustersForConnection(
-                            conn, w.getTimeBeforeHour(), w.getIntervalMinute(), nodeOk, nodeFail));
+            for (VmWithCsp v : cspVms) {
+                for (String metric : VM_METRICS) {
+                    futures.add(
+                            CompletableFuture.runAsync(
+                                    () ->
+                                            warmVmMetric(
+                                                    v,
+                                                    metric,
+                                                    r.getTimeBeforeHour(),
+                                                    r.getIntervalMinute(),
+                                                    vmOk,
+                                                    vmFail),
+                                    executor));
+                }
+            }
+            for (String conn : connectionNames) {
+                futures.addAll(
+                        warmClustersForConnection(
+                                conn,
+                                r.getTimeBeforeHour(),
+                                r.getIntervalMinute(),
+                                nodeOk,
+                                nodeFail));
+            }
         }
 
         if (futures.isEmpty()) {
-            log.info("[CSP-CACHE-WARM] no CSP VMs or clusters to warm");
+            log.info("[CSP-CACHE-WARM:{}] no CSP VMs or clusters to warm", jobName);
             return 0;
         }
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
 
         log.info(
-                "[CSP-CACHE-WARM] vms={}, vmOk={}, vmFail={}, connections={}, nodeOk={}, nodeFail={}, took={}ms",
+                "[CSP-CACHE-WARM:{}] ranges={}, vms={}, vmOk={}, vmFail={}, connections={}, nodeOk={}, nodeFail={}, took={}ms",
+                jobName,
+                job.getRanges().size(),
                 cspVms.size(),
                 vmOk.get(),
                 vmFail.get(),

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -91,14 +91,27 @@ csp:
   cache:
     enabled: ${CSP_CACHE_ENABLED:true}
     max-size: ${CSP_CACHE_MAX_SIZE:10000}
-    expire-after-write-seconds: ${CSP_CACHE_EXPIRE_SECONDS:60}
+    expire-after-write-seconds: ${CSP_CACHE_EXPIRE_SECONDS:300}
     warm:
       enabled: ${CSP_CACHE_WARM_ENABLED:true}
-      cron: ${CSP_CACHE_WARM_CRON:0 * * * * *}
-      thread-pool-size: ${CSP_CACHE_WARM_THREADS:10}
-      time-before-hour: ${CSP_CACHE_WARM_TIME_BEFORE_HOUR:1}
-      interval-minute: ${CSP_CACHE_WARM_INTERVAL_MINUTE:5}
+      thread-pool-size: ${CSP_CACHE_WARM_THREADS:30}
       top-n: ${CSP_CACHE_WARM_TOP_N:20}
+      realtime:
+        enabled: ${CSP_CACHE_WARM_REALTIME_ENABLED:true}
+        cron: ${CSP_CACHE_WARM_REALTIME_CRON:0 * * * * *}
+        # Covers what the UI sends by default (1h) plus short custom ranges in the VM detail view.
+        ranges:
+          - { time-before-hour: "1",  interval-minute: "5" }
+          - { time-before-hour: "6",  interval-minute: "5" }
+          - { time-before-hour: "12", interval-minute: "5" }
+      longrange:
+        enabled: ${CSP_CACHE_WARM_LONGRANGE_ENABLED:true}
+        cron: ${CSP_CACHE_WARM_LONGRANGE_CRON:0 */5 * * * *}
+        ranges:
+          - { time-before-hour: "24",  interval-minute: "5" }
+          - { time-before-hour: "72",  interval-minute: "5" }
+          - { time-before-hour: "120", interval-minute: "5" }
+          - { time-before-hour: "168", interval-minute: "5" }
 
 monitoring:
   cache:


### PR DESCRIPTION
## Summary
CSP warm only covered \`(timeBeforeHour=1, IntervalMinute=5)\`. Any other range the UI could request (6h/12h/1d/3d/5d/7d) was a cold cb-spider call on first load. Split warming into two jobs:

- **realtime** — \`1h, 6h, 12h\`, every minute. Keeps the default monitoring view hot.
- **longrange** — \`24h, 72h, 120h, 168h\`, every 5 minutes. Long-range data changes slowly so less-frequent refresh is fine and avoids hammering CSP APIs.

Also bumped:
- CSP cache TTL: 60s → 300s (outlives both warm cadences; no expire-before-refresh)
- Warm thread pool: 10 → 30 (parallelises ~280 cb-spider calls per pass)

## Test plan
- [ ] \`[CSP-CACHE-WARM:realtime]\` and \`[CSP-CACHE-WARM:longrange]\` log lines show \`nodeOk > 0\` for each range.
- [ ] K8s monitoring tab with range switched to 3D/7D loads instantly once the first longrange pass has run.
- [ ] \`/api/o11y/monitoring/csp/cache/stats\` shows \`expireAfterWriteSeconds=300\` and a climbing hitRate.