### PR TITLE
refactor: Rename Tumblebug MCI/VM to Infra/Node per v0.12.8 model

### DIFF
--- a/front/src/api/tumblebug.js
+++ b/front/src/api/tumblebug.js
@@ -7,18 +7,18 @@ export async function getNsList() {
   return res.data?.ns || [];
 }
 
-export async function getMciList(nsId) {
-  const res = await client.get(`${TB_BASE}/ns/${nsId}/mci`);
-  return res.data?.mci || [];
+export async function getInfraList(nsId) {
+  const res = await client.get(`${TB_BASE}/ns/${nsId}/infra`);
+  return res.data?.infra || [];
 }
 
-export async function getMci(nsId, mciId) {
-  const res = await client.get(`${TB_BASE}/ns/${nsId}/mci/${mciId}`);
+export async function getInfra(nsId, infraId) {
+  const res = await client.get(`${TB_BASE}/ns/${nsId}/infra/${infraId}`);
   return res.data || {};
 }
 
-/** Get all MCI list with VM details for a namespace */
-export async function getAllMcisWithVms(nsId) {
-  const mcis = await getMciList(nsId);
-  return mcis || [];
+/** Get all Infra list with Node details for a namespace */
+export async function getAllInfrasWithNodes(nsId) {
+  const infras = await getInfraList(nsId);
+  return infras || [];
 }

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
 import { setApiToken } from '../api/client';
-import { getNsList, getMciList, getMci } from '../api/tumblebug';
+import { getNsList, getInfraList, getInfra } from '../api/tumblebug';
 
 const navItems = [
   { label: 'Monitoring', path: 'monitoring' },
@@ -40,7 +40,7 @@ export default function Layout() {
   const loadMciList = useCallback(async (ns) => {
     if (!ns) { setMciList([]); return []; }
     try {
-      const list = await getMciList(ns);
+      const list = await getInfraList(ns);
       const arr = Array.isArray(list) ? list : [];
       setMciList(arr);
       return arr;
@@ -51,8 +51,8 @@ export default function Layout() {
   const loadVmList = useCallback(async (ns, mci) => {
     if (!ns || !mci) { setVmList([]); return; }
     try {
-      const data = await getMci(ns, mci);
-      setVmList(data.vm || []);
+      const data = await getInfra(ns, mci);
+      setVmList(data.node || []);
     } catch { setVmList([]); }
   }, []);
 

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../context/AppContext';
 import { setApiToken } from '../api/client';
-import { getNsList, getMciList, getMci } from '../api/tumblebug';
+import { getNsList, getInfraList, getInfra } from '../api/tumblebug';
 
 export default function HomePage() {
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ export default function HomePage() {
     setVmId('');
     if (!nsId) return;
     setLoadingMci(true);
-    getMciList(nsId)
+    getInfraList(nsId)
       .then((list) => setMciList(Array.isArray(list) ? list : []))
       .catch(() => setMciList([]))
       .finally(() => setLoadingMci(false));
@@ -61,8 +61,8 @@ export default function HomePage() {
     setVmId('');
     if (!nsId || !mciId) return;
     setLoadingVm(true);
-    getMci(nsId, mciId)
-      .then((data) => setVmList(data.vm || []))
+    getInfra(nsId, mciId)
+      .then((data) => setVmList(data.node || []))
       .catch(() => setVmList([]))
       .finally(() => setLoadingVm(false));
   }, [nsId, mciId]);

--- a/front/src/pages/K8sNodeDashboard.jsx
+++ b/front/src/pages/K8sNodeDashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
-import { getMciList } from '../api/tumblebug';
+import { getInfraList } from '../api/tumblebug';
 import { CSP_METRICS } from '../api/csp';
 import MetricChart from '../components/MetricChart';
 import ProviderBadge from '../components/ProviderBadge';
@@ -33,8 +33,8 @@ export default function K8sNodeDashboard() {
     setClustersLoading(true);
     (async () => {
       let mcis = [];
-      try { mcis = await getMciList(nsId); } catch {}
-      const connNames = [...new Set(mcis.flatMap(m => (m.vm || []).map(v => v.connectionName)).filter(Boolean))];
+      try { mcis = await getInfraList(nsId); } catch {}
+      const connNames = [...new Set(mcis.flatMap(m => (m.node || []).map(v => v.connectionName)).filter(Boolean))];
       const results = await Promise.allSettled(connNames.map(async (conn) => {
         const list = await getClusters(conn);
         return list.map(c => ({ name: c.IId?.NameId, connectionName: conn }));

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { queryLogs } from '../api/logs';
-import { getMci, getMciList } from '../api/tumblebug';
+import { getInfra, getInfraList } from '../api/tumblebug';
 import LogTable from '../components/LogTable';
 
 export default function LogViewer() {
@@ -19,7 +19,7 @@ export default function LogViewer() {
   useEffect(() => {
     if (!nsId) return;
     if (!mciId) {
-      getMciList(nsId).then(setMciList).catch(() => setMciList([]));
+      getInfraList(nsId).then(setMciList).catch(() => setMciList([]));
     } else {
       setSelectedMciId(mciId);
     }
@@ -28,8 +28,8 @@ export default function LogViewer() {
   // MCI 선택 시 VM 목록 로드
   useEffect(() => {
     if (!nsId || !selectedMciId) { setVms([]); return; }
-    getMci(nsId, selectedMciId)
-      .then((data) => setVms(data.vm || []))
+    getInfra(nsId, selectedMciId)
+      .then((data) => setVms(data.node || []))
       .catch(() => setVms([]));
   }, [nsId, selectedMciId]);
 

--- a/front/src/pages/MciOverview.jsx
+++ b/front/src/pages/MciOverview.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
-import { getMci, getMciList } from '../api/tumblebug';
+import { getInfraList } from '../api/tumblebug';
 import { getMetricsByVM } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
 import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
@@ -47,14 +47,14 @@ export default function MciOverview() {
     try {
       if (viewTab === 'k8s') {
         // K8s: load all MCIs to find connections
-        const mcis = await getMciList(nsId);
+        const mcis = await getInfraList(nsId);
         setAllMcis(mcis);
         setVms([]);
       } else {
         // VM: load all MCIs in NS, show grouped
-        const mcis = await getMciList(nsId);
+        const mcis = await getInfraList(nsId);
         setAllMcis(mcis);
-        const allVms = mcis.flatMap(m => m.vm || []);
+        const allVms = mcis.flatMap(m => m.node || []);
         setVms(allVms);
         if (allVms.length > 0) {
           setMetricsLoading(true);
@@ -81,7 +81,7 @@ export default function MciOverview() {
     // since the allMcis state may still be stale (setState is async).
     const mcis = mcisArg || allMcis;
     const vmMciMap = {};
-    mcis.forEach(m => (m.vm || []).forEach(v => { vmMciMap[v.id] = m.id; }));
+    mcis.forEach(m => (m.node || []).forEach(v => { vmMciMap[v.id] = m.id; }));
 
     vmList.forEach(async (vm) => {
       const vmMciId = vmMciMap[vm.id] || mciId;
@@ -114,9 +114,9 @@ export default function MciOverview() {
     (async () => {
       // Get all MCIs in namespace to find all connections
       let mcis = [];
-      try { mcis = await getMciList(nsId); } catch {}
+      try { mcis = await getInfraList(nsId); } catch {}
       setAllMcis(mcis);
-      const allVms = mcis.flatMap(m => m.vm || []);
+      const allVms = mcis.flatMap(m => m.node || []);
       const connNames = [...new Set(allVms.map(v => v.connectionName).filter(Boolean))];
       // Search clusters across all connections
       const results = await Promise.allSettled(connNames.map(async (conn) => {
@@ -184,7 +184,7 @@ export default function MciOverview() {
 
   if (loading) return <p className="text-sm text-gray-400 p-4">Loading...</p>;
 
-  const allVmsFlat = allMcis.flatMap(m => m.vm || []);
+  const allVmsFlat = allMcis.flatMap(m => m.node || []);
   const hasCspVm = allVmsFlat.some((vm) => isCspSupported(vm.connectionName));
   const showDataSourceToggle = (viewTab === 'vm' && hasCspVm) || viewTab === 'k8s';
   const totalVms = allVmsFlat.length;
@@ -313,11 +313,11 @@ export default function MciOverview() {
             <span className={`text-xs px-2 py-0.5 rounded-full ${(mci.status || '').includes('Running') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
               {mci.status || '-'}
             </span>
-            <span className="text-xs text-gray-400 ml-auto">{(mci.vm || []).length} VMs</span>
+            <span className="text-xs text-gray-400 ml-auto">{(mci.node || []).length} VMs</span>
           </div>
           {/* VM cards inside */}
           <div className="p-3 space-y-3">
-            {(mci.vm || []).map((vm) => (
+            {(mci.node || []).map((vm) => (
               <VmCard
                 key={vm.id}
                 vm={vm}

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { getVmList, getVm, getVmItems, installAgent, uninstallAgent, createVmItem, deleteVmItem } from '../api/vm';
 import { getPlugins } from '../api/monitoring';
-import { getMci, getMciList } from '../api/tumblebug';
+import { getInfra, getInfraList } from '../api/tumblebug';
 import ProviderBadge from '../components/ProviderBadge';
 
 export default function MonitoringConfig() {
@@ -27,8 +27,8 @@ export default function MonitoringConfig() {
     try {
       if (mciId) {
         // Single MCI mode
-        const mciData = await getMci(nsId, mciId);
-        const tbVms = mciData.vm || [];
+        const mciData = await getInfra(nsId, mciId);
+        const tbVms = mciData.node || [];
         let o11yVms = [];
         try { o11yVms = await getVmList(nsId, mciId); } catch {}
         const o11yMap = {};
@@ -38,23 +38,23 @@ export default function MonitoringConfig() {
           return { ...vm, mciId, monitoring_agent_status: o.monitoring_agent_status || null, log_agent_status: o.log_agent_status || null, registered: !!o11yMap[vm.id] };
         });
         setVms(merged);
-        setAllMcis([{ id: mciId, name: mciId, vm: merged, status: mciData.status }]);
+        setAllMcis([{ id: mciId, name: mciId, node: merged, status: mciData.status }]);
       } else {
         // NS level: all MCIs
-        const mcis = await getMciList(nsId);
+        const mcis = await getInfraList(nsId);
         const enriched = await Promise.all(mcis.map(async (mci) => {
           let o11yVms = [];
           try { o11yVms = await getVmList(nsId, mci.id); } catch {}
           const o11yMap = {};
           o11yVms.forEach((v) => { o11yMap[v.vm_id || v.id] = v; });
-          const merged = (mci.vm || []).map((vm) => {
+          const merged = (mci.node || []).map((vm) => {
             const o = o11yMap[vm.id] || {};
             return { ...vm, mciId: mci.id, monitoring_agent_status: o.monitoring_agent_status || null, log_agent_status: o.log_agent_status || null, registered: !!o11yMap[vm.id] };
           });
-          return { ...mci, vm: merged };
+          return { ...mci, node: merged };
         }));
         setAllMcis(enriched);
-        setVms(enriched.flatMap(m => m.vm || []));
+        setVms(enriched.flatMap(m => m.node || []));
       }
     } catch { setVms([]); setAllMcis([]); }
     setLoading(false);
@@ -187,13 +187,13 @@ export default function MonitoringConfig() {
       {/* Server list — grouped by MCI */}
       {loading ? <div className="text-sm text-gray-400 p-4 animate-pulse">Loading...</div>
       : allMcis.map((mci) => {
-        const mciVms = filter ? (mci.vm || []).filter((vm) => (vm.name || vm.id || '').toLowerCase().includes(filter.toLowerCase())) : (mci.vm || []);
+        const mciVms = filter ? (mci.node || []).filter((vm) => (vm.name || vm.id || '').toLowerCase().includes(filter.toLowerCase())) : (mci.node || []);
         return (
         <div key={mci.id} className="bg-white rounded-lg shadow">
           <div className="px-4 py-3 border-b flex items-center gap-3">
             <span className="font-semibold text-sm">{mci.name || mci.id}</span>
             <span className={`text-xs px-2 py-0.5 rounded-full ${(mci.status || '').includes('Running') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{mci.status || '-'}</span>
-            <span className="text-xs text-gray-400">{(mci.vm || []).length} VMs</span>
+            <span className="text-xs text-gray-400">{(mci.node || []).length} VMs</span>
             <input type="text" placeholder="Filter..." value={filter} onChange={(e) => setFilter(e.target.value)} className="ml-auto border rounded px-2 py-1 text-xs w-32" />
           </div>
           <div className="overflow-auto">

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { getMeasurementFields, getMetricsByVM } from '../api/monitoring';
-import { getMci } from '../api/tumblebug';
+import { getInfra } from '../api/tumblebug';
 import { getPlugins, getPrediction, getDetectionHistory } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
 import { getVmItems } from '../api/vm';
@@ -84,8 +84,8 @@ export default function MonitoringDashboard() {
   useEffect(() => {
     if (!nsId || !mciId) return;
     setVmsLoaded(false);
-    getMci(nsId, mciId)
-      .then((data) => { setVms(data.vm || []); setVmsLoaded(true); })
+    getInfra(nsId, mciId)
+      .then((data) => { setVms(data.node || []); setVmsLoaded(true); })
       .catch(() => { setVms([]); setVmsLoaded(true); });
   }, [nsId, mciId]);
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/BeylaController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/BeylaController.java
@@ -2,7 +2,7 @@ package com.mcmp.o11ymanager.manager.controller;
 
 import static com.mcmp.o11ymanager.manager.service.domain.SemaphoreDomainService.SEMAPHORE_MAX_PARALLEL_TASKS;
 
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import com.mcmp.o11ymanager.manager.dto.vm.AccessInfoDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.ResultDTO;
@@ -150,8 +150,8 @@ public class BeylaController {
     }
 
     private AccessInfoDTO getAccessInfo(String nsId, String mciId, String vmId) {
-        TumblebugMCI.Vm vm = tumblebugPort.getVM(nsId, mciId, vmId);
-        TumblebugSshKey sshKey = tumblebugPort.getSshKey(nsId, vm.getSshKeyId());
+        TumblebugInfra.Node node = tumblebugPort.getNode(nsId, mciId, vmId);
+        TumblebugSshKey sshKey = tumblebugPort.getSshKey(nsId, node.getSshKeyId());
 
         if (sshKey == null) {
             log.warn("SSH private key not found");
@@ -159,9 +159,9 @@ public class BeylaController {
         }
 
         return AccessInfoDTO.builder()
-                .ip(vm.getPublicIP())
-                .port(Integer.parseInt(vm.getSshPort()))
-                .user(vm.getVmUserName())
+                .ip(node.getPublicIP())
+                .port(Integer.parseInt(node.getSshPort()))
+                .user(node.getNodeUserName())
                 .sshKey(sshKey.getPrivateKey())
                 .build();
     }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugInfra.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugInfra.java
@@ -7,15 +7,15 @@ import lombok.Setter;
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TumblebugMCI {
+public class TumblebugInfra {
     private String id;
 
-    private Vm[] vm;
+    private Node[] node;
 
     @Getter
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Vm {
+    public static class Node {
         private String resourceType;
 
         private String id; // example: "aws-ap-southeast-1"
@@ -30,11 +30,11 @@ public class TumblebugMCI {
 
         private String name; // example: "aws-ap-southeast-1"
 
-        private String subGroupId;
+        private String nodeGroupId;
 
         private String description;
 
-        private String vmUserName;
+        private String nodeUserName;
 
         private String publicIP;
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugInfraList.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugInfraList.java
@@ -6,12 +6,12 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
-/** Response body for {@code GET /tumblebug/ns/{nsId}/mci} (list all MCIs in a namespace). */
+/** Response body for {@code GET /tumblebug/ns/{nsId}/infra} (list all Infras in a namespace). */
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TumblebugMCIList {
+public class TumblebugInfraList {
 
-    @JsonProperty("mci")
-    private List<TumblebugMCI> mci;
+    @JsonProperty("infra")
+    private List<TumblebugInfra> infra;
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
@@ -3,7 +3,7 @@ package com.mcmp.o11ymanager.manager.facade;
 import static com.mcmp.o11ymanager.manager.service.domain.SemaphoreDomainService.SEMAPHORE_MAX_PARALLEL_TASKS;
 
 import com.mcmp.o11ymanager.manager.dto.host.ConfigDTO;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import com.mcmp.o11ymanager.manager.dto.vm.AccessInfoDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.ResultDTO;
@@ -45,8 +45,8 @@ public class AgentFacadeService {
 
     private AccessInfoDTO getAccessInfo(String nsId, String mciId, String vmId) {
 
-        TumblebugMCI.Vm vm = tumblebugPort.getVM(nsId, mciId, vmId);
-        TumblebugSshKey sshKey = tumblebugPort.getSshKey(nsId, vm.getSshKeyId());
+        TumblebugInfra.Node node = tumblebugPort.getNode(nsId, mciId, vmId);
+        TumblebugSshKey sshKey = tumblebugPort.getSshKey(nsId, node.getSshKeyId());
 
         if (sshKey == null) {
             log.warn("SSH private key not found");
@@ -56,9 +56,9 @@ public class AgentFacadeService {
         }
 
         return AccessInfoDTO.builder()
-                .ip(vm.getPublicIP())
-                .port(Integer.parseInt(vm.getSshPort()))
-                .user(vm.getVmUserName())
+                .ip(node.getPublicIP())
+                .port(Integer.parseInt(node.getSshPort()))
+                .user(node.getNodeUserName())
                 .sshKey(sshKey.getPrivateKey())
                 .build();
     }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
@@ -4,7 +4,7 @@ import com.mcmp.o11ymanager.manager.dto.item.MonitoringItemDTO;
 import com.mcmp.o11ymanager.manager.dto.item.MonitoringItemRequestDTO;
 import com.mcmp.o11ymanager.manager.dto.item.MonitoringItemUpdateDTO;
 import com.mcmp.o11ymanager.manager.dto.plugin.PluginDefDTO;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.enums.ResponseCode;
 import com.mcmp.o11ymanager.manager.exception.config.TelegrafConfigException;
 import com.mcmp.o11ymanager.manager.service.interfaces.AgentPluginDefService;
@@ -55,8 +55,8 @@ public class ItemFacadeService {
         try {
             hostLock.lock();
 
-            TumblebugMCI.Vm vm = tumblebugService.getVm(nsId, mciId, vmId);
-            if (vm == null) {
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            if (node == null) {
                 String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);
@@ -131,8 +131,8 @@ public class ItemFacadeService {
         try {
             hostLock.lock();
 
-            TumblebugMCI.Vm vm = tumblebugService.getVm(nsId, mciId, vmId);
-            if (vm == null) {
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            if (node == null) {
                 String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);
@@ -204,8 +204,8 @@ public class ItemFacadeService {
         try {
             hostLock.lock();
 
-            TumblebugMCI.Vm vm = tumblebugService.getVm(nsId, mciId, vmId);
-            if (vm == null) {
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            if (node == null) {
                 String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -1,6 +1,6 @@
 package com.mcmp.o11ymanager.manager.facade;
 
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.vm.VMDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.VMRequestDTO;
 import com.mcmp.o11ymanager.manager.enums.Agent;
@@ -95,12 +95,12 @@ public class VMFacadeService {
             hostLock.lock();
 
             VMDTO savedVM = vmService.get(nsId, mciId, vmId);
-            TumblebugMCI.Vm vm = tumblebugService.getVm(nsId, mciId, vmId);
-            String userName = vm.getVmUserName();
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            String userName = node.getNodeUserName();
             log.info(
                     ">>> VM fetched: id={}, name={} userName={}",
-                    vm.getId(),
-                    vm.getName(),
+                    node.getId(),
+                    node.getName(),
                     userName);
 
             //        log.info(">>> start checking monitoring agent status");
@@ -122,9 +122,9 @@ public class VMFacadeService {
                     agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.BEYLA);
 
             return VMDTO.builder()
-                    .vmId(vm.getId())
+                    .vmId(node.getId())
                     .name(savedVM.getName())
-                    .description(vm.getDescription())
+                    .description(node.getDescription())
                     .nsId(nsId)
                     .mciId(mciId)
                     .monitoringAgentStatus(monitoringAgentStatus)

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
@@ -1,7 +1,8 @@
 package com.mcmp.o11ymanager.manager.infrastructure.tumblebug;
 
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfraList;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -12,9 +13,11 @@ import org.springframework.web.bind.annotation.*;
         url = "${feign.cb-tumblebug.url}",
         configuration = TumblebugFeignConfig.class)
 public interface TumblebugClient {
-    @GetMapping(value = "/tumblebug/ns/{nsId}/mci/{mciId}/vm/{vmId}", produces = "application/json")
-    TumblebugMCI.Vm getVM(
-            @PathVariable String nsId, @PathVariable String mciId, @PathVariable String vmId);
+    @GetMapping(
+            value = "/tumblebug/ns/{nsId}/infra/{infraId}/node/{nodeId}",
+            produces = "application/json")
+    TumblebugInfra.Node getNode(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId);
 
     @GetMapping("/tumblebug/ns/{nsId}/resources/sshKey/{sshKeyId}")
     TumblebugSshKey getSshKey(@PathVariable String nsId, @PathVariable String sshKeyId);
@@ -22,17 +25,16 @@ public interface TumblebugClient {
     @GetMapping("/tumblebug/ns")
     TumblebugNS getNSList();
 
-    @GetMapping("/tumblebug/ns/{nsId}/mci")
-    com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCIList getMCIList(
-            @PathVariable String nsId);
+    @GetMapping("/tumblebug/ns/{nsId}/infra")
+    TumblebugInfraList getInfraList(@PathVariable String nsId);
 
-    @GetMapping("/tumblebug/ns/{nsId}/mci/{mciId}")
-    TumblebugMCI getMCIList(@PathVariable String nsId, @PathVariable String mciId);
+    @GetMapping("/tumblebug/ns/{nsId}/infra/{infraId}")
+    TumblebugInfra getInfra(@PathVariable String nsId, @PathVariable String infraId);
 
-    @PostMapping("/tumblebug/ns/{nsId}/cmd/mci/{mciId}")
+    @PostMapping("/tumblebug/ns/{nsId}/cmd/infra/{infraId}")
     Object sendCommand(
             @PathVariable String nsId,
-            @PathVariable String mciId,
-            @RequestParam String vmId,
+            @PathVariable String infraId,
+            @RequestParam String nodeId,
             @RequestBody TumblebugCmd tumblebugCmd);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClientAdapter.java
@@ -1,7 +1,7 @@
 package com.mcmp.o11ymanager.manager.infrastructure.tumblebug;
 
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import com.mcmp.o11ymanager.manager.port.TumblebugPort;
@@ -17,8 +17,8 @@ public class TumblebugClientAdapter implements TumblebugPort {
     private final TumblebugClient tumblebugClient;
 
     @Override
-    public TumblebugMCI.Vm getVM(String nsId, String mciId, String vmId) {
-        return tumblebugClient.getVM(nsId, mciId, vmId);
+    public TumblebugInfra.Node getNode(String nsId, String infraId, String nodeId) {
+        return tumblebugClient.getNode(nsId, infraId, nodeId);
     }
 
     @Override
@@ -32,12 +32,12 @@ public class TumblebugClientAdapter implements TumblebugPort {
     }
 
     @Override
-    public TumblebugMCI getMCIList(String nsId, String mciId) {
-        return tumblebugClient.getMCIList(nsId, mciId);
+    public TumblebugInfra getInfra(String nsId, String infraId) {
+        return tumblebugClient.getInfra(nsId, infraId);
     }
 
     @Override
-    public Object sendCommand(String nsId, String mciId, String vmId, TumblebugCmd command) {
-        return tumblebugClient.sendCommand(nsId, mciId, vmId, command);
+    public Object sendCommand(String nsId, String infraId, String nodeId, TumblebugCmd command) {
+        return tumblebugClient.sendCommand(nsId, infraId, nodeId, command);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TumblebugPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TumblebugPort.java
@@ -1,19 +1,19 @@
 package com.mcmp.o11ymanager.manager.port;
 
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 
 public interface TumblebugPort {
 
-    TumblebugMCI.Vm getVM(String nsId, String mciId, String vmId);
+    TumblebugInfra.Node getNode(String nsId, String infraId, String nodeId);
 
     TumblebugSshKey getSshKey(String nsId, String sshKeyId);
 
     TumblebugNS getNSList();
 
-    TumblebugMCI getMCIList(String nsId, String mciId);
+    TumblebugInfra getInfra(String nsId, String infraId);
 
-    Object sendCommand(String nsId, String mciId, String vmId, TumblebugCmd command);
+    Object sendCommand(String nsId, String infraId, String nodeId, TumblebugCmd command);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
@@ -3,7 +3,7 @@ package com.mcmp.o11ymanager.manager.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.enums.Agent;
 import com.mcmp.o11ymanager.manager.exception.agent.AgentStatusException;
 import com.mcmp.o11ymanager.manager.port.TumblebugPort;
@@ -26,18 +26,18 @@ public class TumblebugServiceImpl implements TumblebugService {
     private String sitecode;
 
     @Override
-    public String executeCommand(String nsId, String mciId, String vmId, String command) {
+    public String executeCommand(String nsId, String infraId, String nodeId, String command) {
         TumblebugCmd cmd = new TumblebugCmd();
         cmd.setCommand(List.of(command));
 
-        TumblebugMCI.Vm vm = getVm(nsId, mciId, vmId);
-        if (vm == null) {
-            throw new RuntimeException("FAILED TO GET VM");
+        TumblebugInfra.Node node = getNode(nsId, infraId, nodeId);
+        if (node == null) {
+            throw new RuntimeException("FAILED TO GET NODE");
         }
 
-        cmd.setUserName(vm.getVmUserName());
+        cmd.setUserName(node.getNodeUserName());
 
-        Object response = tumblebugPort.sendCommand(nsId, mciId, vmId, cmd);
+        Object response = tumblebugPort.sendCommand(nsId, infraId, nodeId, cmd);
 
         try {
             JsonNode root = objectMapper.valueToTree(response);
@@ -55,9 +55,9 @@ public class TumblebugServiceImpl implements TumblebugService {
     }
 
     @Override
-    public boolean isConnectedVM(String nsId, String mciId, String vmId) {
+    public boolean isConnectedVM(String nsId, String infraId, String nodeId) {
         try {
-            String output = executeCommand(nsId, mciId, vmId, "echo hello");
+            String output = executeCommand(nsId, infraId, nodeId, "echo hello");
             return "hello".equalsIgnoreCase(output.trim());
         } catch (Exception e) {
             return false;
@@ -65,16 +65,16 @@ public class TumblebugServiceImpl implements TumblebugService {
     }
 
     @Override
-    public TumblebugMCI.Vm getVm(String nsId, String mciId, String vmId) {
-        return tumblebugPort.getVM(nsId, mciId, vmId);
+    public TumblebugInfra.Node getNode(String nsId, String infraId, String nodeId) {
+        return tumblebugPort.getNode(nsId, infraId, nodeId);
     }
 
     @Override
-    public boolean isServiceActive(String nsId, String mciId, String vmId, Agent agent) {
+    public boolean isServiceActive(String nsId, String infraId, String nodeId, Agent agent) {
         log.info(
-                ">>> isServiceActive called with nsId: {}, mciId: {}, agent: {}",
+                ">>> isServiceActive called with nsId: {}, infraId: {}, agent: {}",
                 nsId,
-                mciId,
+                infraId,
                 agent);
         String command =
                 String.format(
@@ -83,7 +83,7 @@ public class TumblebugServiceImpl implements TumblebugService {
 
         log.info("==================IS ACTIVE ? INACTIVE CMD : {}", command);
 
-        String result = executeCommand(nsId, mciId, vmId, command);
+        String result = executeCommand(nsId, infraId, nodeId, command);
         String trimmed = result.trim();
 
         log.info(
@@ -102,7 +102,7 @@ public class TumblebugServiceImpl implements TumblebugService {
     }
 
     @Override
-    public String restart(String nsId, String mciId, String vmId, Agent agent) {
+    public String restart(String nsId, String infraId, String nodeId, Agent agent) {
 
         log.info("=================RESTART AGENT======================");
 
@@ -111,7 +111,7 @@ public class TumblebugServiceImpl implements TumblebugService {
                         "systemctl restart cmp-%s-%s.service",
                         agent.name().toLowerCase().replace("_", "-"), sitecode.toLowerCase());
 
-        String result = executeCommand(nsId, mciId, vmId, command).trim();
+        String result = executeCommand(nsId, infraId, nodeId, command).trim();
 
         if (!result.isEmpty()) {
             log.warn("❌ Agent Restart Failed - Agent: {}, Result: {}", agent, result);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -7,8 +7,8 @@ import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
 import com.mcmp.o11ymanager.manager.dto.SpiderClusterList;
 import com.mcmp.o11ymanager.manager.dto.SpiderMonitoringInfo;
 import com.mcmp.o11ymanager.manager.dto.influx.VmRef;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCIList;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfraList;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
 import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
@@ -234,13 +234,14 @@ public class CspCacheWarmScheduler {
         List<VmWithCsp> resolved = new ArrayList<>(active.size());
         for (VmRef ref : active) {
             try {
-                TumblebugMCI.Vm vm = tumblebugService.getVm(ref.nsId(), ref.mciId(), ref.vmId());
-                if (vm == null
-                        || vm.getConnectionName() == null
-                        || vm.getCspResourceName() == null) {
+                TumblebugInfra.Node node =
+                        tumblebugService.getNode(ref.nsId(), ref.mciId(), ref.vmId());
+                if (node == null
+                        || node.getConnectionName() == null
+                        || node.getCspResourceName() == null) {
                     continue;
                 }
-                if (!isCspSupported(vm.getConnectionName())) {
+                if (!isCspSupported(node.getConnectionName())) {
                     continue;
                 }
                 Instant createdAt =
@@ -249,7 +250,10 @@ public class CspCacheWarmScheduler {
                                 .orElse(Instant.EPOCH);
                 resolved.add(
                         new VmWithCsp(
-                                ref, vm.getConnectionName(), vm.getCspResourceName(), createdAt));
+                                ref,
+                                node.getConnectionName(),
+                                node.getCspResourceName(),
+                                createdAt));
             } catch (Exception e) {
                 log.debug(
                         "[CSP-CACHE-WARM] resolve failed ns={}, mci={}, vm={}, err={}",
@@ -275,7 +279,7 @@ public class CspCacheWarmScheduler {
     }
 
     /**
-     * Walks every namespace and MCI in Tumblebug and collects unique connectionNames. Result is
+     * Walks every namespace and Infra in Tumblebug and collects unique connectionNames. Result is
      * memoised for 5 minutes to avoid Tumblebug rate-limit bursts (429 Too Many Requests) when warm
      * runs every minute.
      */
@@ -312,20 +316,20 @@ public class CspCacheWarmScheduler {
                 }
             }
             throttled = true;
-            TumblebugMCIList mciList = getMCIListWithRetry(ns.getId());
-            if (mciList == null || mciList.getMci() == null) {
+            TumblebugInfraList infraList = getInfraListWithRetry(ns.getId());
+            if (infraList == null || infraList.getInfra() == null) {
                 continue;
             }
-            for (TumblebugMCI mci : mciList.getMci()) {
-                if (mci == null || mci.getVm() == null) {
+            for (TumblebugInfra infra : infraList.getInfra()) {
+                if (infra == null || infra.getNode() == null) {
                     continue;
                 }
-                for (TumblebugMCI.Vm vm : mci.getVm()) {
-                    if (vm != null
-                            && vm.getConnectionName() != null
-                            && !vm.getConnectionName().isBlank()
-                            && isCspSupported(vm.getConnectionName())) {
-                        out.add(vm.getConnectionName());
+                for (TumblebugInfra.Node node : infra.getNode()) {
+                    if (node != null
+                            && node.getConnectionName() != null
+                            && !node.getConnectionName().isBlank()
+                            && isCspSupported(node.getConnectionName())) {
+                        out.add(node.getConnectionName());
                     }
                 }
             }
@@ -335,20 +339,20 @@ public class CspCacheWarmScheduler {
     }
 
     /**
-     * Wraps {@code tumblebugClient.getMCIList} with a single retry on 429. Tumblebug rate-limits
+     * Wraps {@code tumblebugClient.getInfraList} with a single retry on 429. Tumblebug rate-limits
      * aggressively (rejects 3rd call in quick succession); a short backoff lets the window reset
      * without failing the whole discovery pass.
      */
-    private TumblebugMCIList getMCIListWithRetry(String nsId) {
+    private TumblebugInfraList getInfraListWithRetry(String nsId) {
         for (int attempt = 1; attempt <= 2; attempt++) {
             try {
-                return tumblebugClient.getMCIList(nsId);
+                return tumblebugClient.getInfraList(nsId);
             } catch (Exception e) {
                 String msg = e.toString();
                 boolean rateLimited = msg.contains("429") || msg.contains("TooManyRequests");
                 if (!rateLimited || attempt == 2) {
                     log.warn(
-                            "[CSP-CACHE-WARM] getMCIList failed ns={}, attempt={}, err={}",
+                            "[CSP-CACHE-WARM] getInfraList failed ns={}, attempt={}, err={}",
                             nsId,
                             attempt,
                             msg);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/VmCreatedTimeResolver.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/VmCreatedTimeResolver.java
@@ -2,7 +2,7 @@ package com.mcmp.o11ymanager.manager.service.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.service.interfaces.TumblebugService;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -57,11 +57,14 @@ public class VmCreatedTimeResolver {
 
     private Optional<Instant> fetchFromTumblebug(String nsId, String mciId, String vmId) {
         try {
-            TumblebugMCI.Vm vm = tumblebugService.getVm(nsId, mciId, vmId);
-            if (vm == null || vm.getCreatedTime() == null || vm.getCreatedTime().isBlank()) {
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            if (node == null
+                    || node.getCreatedTime() == null
+                    || node.getCreatedTime().isBlank()) {
                 return Optional.empty();
             }
-            LocalDateTime ldt = LocalDateTime.parse(vm.getCreatedTime().trim(), TUMBLEBUG_FORMAT);
+            LocalDateTime ldt =
+                    LocalDateTime.parse(node.getCreatedTime().trim(), TUMBLEBUG_FORMAT);
             return Optional.of(ldt.atZone(ZoneId.systemDefault()).toInstant());
         } catch (Exception e) {
             log.debug(

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TumblebugService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TumblebugService.java
@@ -1,17 +1,17 @@
 package com.mcmp.o11ymanager.manager.service.interfaces;
 
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.enums.Agent;
 
 public interface TumblebugService {
 
-    String executeCommand(String nsId, String mciId, String vmId, String command);
+    String executeCommand(String nsId, String infraId, String nodeId, String command);
 
-    boolean isConnectedVM(String nsId, String mciId, String vmId);
+    boolean isConnectedVM(String nsId, String infraId, String nodeId);
 
-    TumblebugMCI.Vm getVm(String nsId, String mciId, String vmId);
+    TumblebugInfra.Node getNode(String nsId, String infraId, String nodeId);
 
-    boolean isServiceActive(String nsId, String mciId, String vmId, Agent agent);
+    boolean isServiceActive(String nsId, String infraId, String nodeId, Agent agent);
 
-    String restart(String nsId, String mciId, String vmId, Agent agent);
+    String restart(String nsId, String infraId, String nodeId, Agent agent);
 }

--- a/java/mc-o11y-manager/src/test/java/com/mcmp/o11ymanager/manager/controller/BeylaControllerTest.java
+++ b/java/mc-o11y-manager/src/test/java/com/mcmp/o11ymanager/manager/controller/BeylaControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugMCI;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import com.mcmp.o11ymanager.manager.dto.vm.ResultDTO;
 import com.mcmp.o11ymanager.manager.enums.Agent;
@@ -55,12 +55,12 @@ class BeylaControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(beylaController).build();
 
-        TumblebugMCI.Vm mockVm = new TumblebugMCI.Vm();
-        mockVm.setPublicIP("192.168.1.1");
-        mockVm.setSshPort("22");
-        mockVm.setVmUserName("ubuntu");
-        mockVm.setSshKeyId("key-1");
-        when(tumblebugPort.getVM("ns-1", "mci-1", "vm-1")).thenReturn(mockVm);
+        TumblebugInfra.Node mockNode = new TumblebugInfra.Node();
+        mockNode.setPublicIP("192.168.1.1");
+        mockNode.setSshPort("22");
+        mockNode.setNodeUserName("ubuntu");
+        mockNode.setSshKeyId("key-1");
+        when(tumblebugPort.getNode("ns-1", "mci-1", "vm-1")).thenReturn(mockNode);
 
         TumblebugSshKey mockSshKey = new TumblebugSshKey();
         mockSshKey.setPrivateKey("ssh-key-content");


### PR DESCRIPTION
cb-tumblebug v0.12.8 wire 모델에 맞춰 MCI/VM 명칭을 Infra/Node 로 정리.

- Java DTO/Client/Port/Service: TumblebugMCI→TumblebugInfra, Vm→Node, subGroupId→nodeGroupId, vmUserName→nodeUserName
- Feign path
  - `/ns/{ns}/mci...` → `/ns/{ns}/infra...`
  - `/cmd/mci/` → `/cmd/infra/`
  - query param `vmId` → `nodeId`
- Front
  - `getMci/getMciList` → `getInfra/getInfraList`
  - 응답 필드 `.vm` → `.node`