### PR TITLE
feat: Add distributed tracing (Tempo) and rename MCI/VM to Infra/Node

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -11,6 +11,7 @@ import LogViewer from './pages/LogViewer';
 import MonitoringConfig from './pages/MonitoringConfig';
 import InsightDashboard from './pages/InsightDashboard';
 import AlertManager from './pages/AlertManager';
+import TraceViewer from './pages/TraceViewer';
 import K8sNodeDashboard from './pages/K8sNodeDashboard';
 import HomePage from './pages/HomePage';
 
@@ -41,6 +42,8 @@ export default function App() {
         <Route path="/insight/:nsId" element={<InsightDashboard />} />
         <Route path="/alerts/:nsId/:infraId" element={<AlertManager />} />
         <Route path="/alerts/:nsId" element={<AlertManager />} />
+        <Route path="/trace/:nsId/:infraId" element={<TraceViewer />} />
+        <Route path="/trace/:nsId" element={<TraceViewer />} />
       </Route>
 
       {/* Embed — no nav, for iframe */}
@@ -59,6 +62,8 @@ export default function App() {
         <Route path="/embed/insight/:nsId" element={<InsightDashboard />} />
         <Route path="/embed/alerts/:nsId/:infraId" element={<AlertManager />} />
         <Route path="/embed/alerts/:nsId" element={<AlertManager />} />
+        <Route path="/embed/trace/:nsId/:infraId" element={<TraceViewer />} />
+        <Route path="/embed/trace/:nsId" element={<TraceViewer />} />
       </Route>
     </Routes>
     </ErrorBoundary>

--- a/front/src/api/csp.js
+++ b/front/src/api/csp.js
@@ -16,7 +16,7 @@ const CSP_METRICS = [
 export { CSP_METRICS };
 
 export async function getCspMetric(connectionName, cspResourceName, metricType, periodMinute = '5', timeBeforeHour = '1') {
-  const res = await client.get(`/api/o11y/monitoring/csp/vm/${cspResourceName}/${metricType}`, {
+  const res = await client.get(`/api/o11y/monitoring/csp/node/${cspResourceName}/${metricType}`, {
     params: { ConnectionName: connectionName, periodMinute, timeBeforeHour },
   });
   return res.data || {};

--- a/front/src/api/insight.js
+++ b/front/src/api/insight.js
@@ -1,8 +1,7 @@
 import client from './client';
 
-// NOTE: backend URL path still uses /mci/{}/vm/{} literals (Tumblebug renamed
-// to Infra/Node but mc-observability backend URL not yet). JS identifiers
-// reflect the new naming.
+// Backend insight URL paths use /ns/{nsId}/infra/{infraId}/node/{nodeId}
+// (MCI→Infra, VM→Node naming applied).
 
 // Anomaly Detection
 export async function getAnomalySettings() {
@@ -34,8 +33,8 @@ export async function getAnomalyHistory(nsId, infraId, nodeId, measurement, star
   if (startTime) params.start_time = startTime;
   if (endTime) params.end_time = endTime;
   const path = nodeId
-    ? `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${infraId}/vm/${nodeId}/history`
-    : `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${infraId}/history`;
+    ? `/api/o11y/insight/anomaly-detection/ns/${nsId}/infra/${infraId}/node/${nodeId}/history`
+    : `/api/o11y/insight/anomaly-detection/ns/${nsId}/infra/${infraId}/history`;
   const res = await client.get(path, { params });
   return res.data?.data || res.data?.responseData || {};
 }
@@ -51,16 +50,16 @@ export async function getPredictionHistory(nsId, infraId, nodeId, measurement, s
   if (startTime) params.start_time = startTime;
   if (endTime) params.end_time = endTime;
   const path = nodeId
-    ? `/api/o11y/insight/predictions/ns/${nsId}/mci/${infraId}/vm/${nodeId}/history`
-    : `/api/o11y/insight/predictions/ns/${nsId}/mci/${infraId}/history`;
+    ? `/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}/node/${nodeId}/history`
+    : `/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}/history`;
   const res = await client.get(path, { params });
   return res.data?.data || res.data?.responseData || {};
 }
 
 export async function runPrediction(nsId, infraId, nodeId, body) {
   const path = nodeId
-    ? `/api/o11y/insight/predictions/ns/${nsId}/mci/${infraId}/vm/${nodeId}`
-    : `/api/o11y/insight/predictions/ns/${nsId}/mci/${infraId}`;
+    ? `/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}/node/${nodeId}`
+    : `/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}`;
   const res = await client.post(path, body);
   return res.data?.data || res.data?.responseData || {};
 }

--- a/front/src/api/monitoring.js
+++ b/front/src/api/monitoring.js
@@ -1,7 +1,7 @@
 import client from './client';
 
-// NOTE: backend URL path still uses /mci/{}/vm/{} literals (URL segments unchanged).
-// InfluxDB tags and JS identifiers follow the Tumblebug rename (MCI→Infra, VM→Node).
+// Backend URL paths and InfluxDB tags use /infra/{}/node/{} and infra_id/node_id
+// (MCI→Infra, VM→Node naming applied).
 
 export async function getMeasurementFields() {
   const res = await client.get('/api/o11y/monitoring/influxdb/measurement');
@@ -43,7 +43,7 @@ export async function getPrediction(nsId, infraId, nodeId, measurement) {
   const now = new Date();
   const startTime = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString();
   const endTime = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
-  const res = await client.post(`/api/o11y/insight/predictions/ns/${nsId}/mci/${infraId}/vm/${nodeId}`, {
+  const res = await client.post(`/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}/node/${nodeId}`, {
     measurement,
     start_time: startTime,
     end_time: endTime,
@@ -56,7 +56,7 @@ export async function getDetectionHistory(nsId, infraId, nodeId, measurement) {
   const startTime = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString();
   const endTime = now.toISOString();
   const res = await client.get(
-    `/api/o11y/insight/anomaly-detection/ns/${nsId}/mci/${infraId}/vm/${nodeId}/history`,
+    `/api/o11y/insight/anomaly-detection/ns/${nsId}/infra/${infraId}/node/${nodeId}/history`,
     { params: { measurement, start_time: startTime, end_time: endTime } }
   );
   return res.data?.data || res.data?.responseData || {};

--- a/front/src/api/node.js
+++ b/front/src/api/node.js
@@ -1,46 +1,45 @@
 import client from './client';
 
-// NOTE: mc-observability backend API path still uses `/mci/{}/vm/{}` literals
-// even though Tumblebug renamed MCI→Infra / VM→Node. URL segments stay as-is;
-// only JS identifiers reflect the new naming.
+// mc-observability backend API: /api/o11y/monitoring/{nsId}/{infraId}/node/{nodeId}
+// (MCI→Infra, VM→Node naming applied across path segments and identifiers).
 
 export async function getNodeList(nsId, infraId) {
-  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/vm`);
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/node`);
   return res.data?.data || [];
 }
 
 export async function getNode(nsId, infraId, nodeId) {
-  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}`);
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}`);
   return res.data?.data || res.data?.responseData || null;
 }
 
 export async function installAgent(nsId, infraId, nodeId) {
-  const res = await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}`, { name: nodeId });
+  const res = await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}`, { name: nodeId });
   return res.data;
 }
 
 export async function uninstallAgent(nsId, infraId, nodeId) {
-  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}`);
+  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}`);
   return res.data;
 }
 
 export async function getNodeItems(nsId, infraId, nodeId) {
-  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}/item`);
+  const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/item`);
   return res.data?.data || [];
 }
 
 export async function createNodeItem(nsId, infraId, nodeId, item) {
   const body = { pluginSeq: item.pluginSeq, pluginConfig: item.pluginConfig || '' };
-  const res = await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}/item`, body);
+  const res = await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/item`, body);
   return res.data;
 }
 
 export async function updateNodeItem(nsId, infraId, nodeId, item) {
-  const res = await client.put(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}/item`, item);
+  const res = await client.put(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/item`, item);
   return res.data;
 }
 
 export async function deleteNodeItem(nsId, infraId, nodeId, itemSeq) {
-  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/vm/${nodeId}/item/${itemSeq}`);
+  const res = await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/item/${itemSeq}`);
   return res.data;
 }

--- a/front/src/api/trace.js
+++ b/front/src/api/trace.js
@@ -1,11 +1,10 @@
 import client from './client';
 
-// Tempo trace query. The backend builds the TraceQL from service/keyword and a
-// time window; traces are emitted by the Beyla / OTel trace agents and stored
-// in Tempo (OTLP ingest). Mirrors the logs.js shape: thin wrappers over the
-// manager REST API.
+// Tempo trace query. The backend builds the TraceQL from scope/service/keyword and
+// a time window. `scope` splits framework (o11y platform: manager/insight, self-traced
+// via the OTel agent) from vm (target VMs' Beyla/OTel application traces).
 
-export async function searchTraces({ service, keyword, rangeHours = 1, limit = 100 } = {}) {
+export async function searchTraces({ scope, service, keyword, rangeHours = 1, limit = 100 } = {}) {
   const now = new Date();
   const start = new Date(now.getTime() - rangeHours * 60 * 60 * 1000);
   const params = {
@@ -13,10 +12,18 @@ export async function searchTraces({ service, keyword, rangeHours = 1, limit = 1
     end: Math.floor(now.getTime() / 1000).toString(),
     limit: String(limit),
   };
+  if (scope) params.scope = scope;
   if (service) params.service = service;
   if (keyword) params.keyword = keyword;
 
   const res = await client.get('/api/o11y/trace/search', { params });
+  return res.data?.data || [];
+}
+
+export async function getTraceServices(scope) {
+  const params = {};
+  if (scope) params.scope = scope;
+  const res = await client.get('/api/o11y/trace/services', { params });
   return res.data?.data || [];
 }
 

--- a/front/src/api/trace.js
+++ b/front/src/api/trace.js
@@ -1,0 +1,26 @@
+import client from './client';
+
+// Tempo trace query. The backend builds the TraceQL from service/keyword and a
+// time window; traces are emitted by the Beyla / OTel trace agents and stored
+// in Tempo (OTLP ingest). Mirrors the logs.js shape: thin wrappers over the
+// manager REST API.
+
+export async function searchTraces({ service, keyword, rangeHours = 1, limit = 100 } = {}) {
+  const now = new Date();
+  const start = new Date(now.getTime() - rangeHours * 60 * 60 * 1000);
+  const params = {
+    start: Math.floor(start.getTime() / 1000).toString(),
+    end: Math.floor(now.getTime() / 1000).toString(),
+    limit: String(limit),
+  };
+  if (service) params.service = service;
+  if (keyword) params.keyword = keyword;
+
+  const res = await client.get('/api/o11y/trace/search', { params });
+  return res.data?.data || [];
+}
+
+export async function getTrace(traceId) {
+  const res = await client.get(`/api/o11y/trace/${traceId}`);
+  return res.data?.data || null;
+}

--- a/front/src/api/trigger.js
+++ b/front/src/api/trigger.js
@@ -1,8 +1,7 @@
 import client from './client';
 
-// NOTE: backend URL path still uses /vm (e.g. /trigger/policy/{id}/vm) and
-// payload field `targetScope` accepts "vm"|"mci" literals. JS function names
-// reflect Tumblebug Infra/Node naming.
+// Backend trigger path: /trigger/policy/{id}/node. The `targetScope` field accepts
+// "infra"|"node" (→ trigger queries by infra_id/node_id, matching Telegraf/InfluxDB tags).
 
 // Trigger policies
 export async function getPolicies(page = 1, size = 20) {
@@ -20,11 +19,11 @@ export async function deletePolicy(id) {
 }
 
 export async function addNodeToPolicy(policyId, body) {
-  return client.post(`/api/o11y/trigger/policy/${policyId}/vm`, body);
+  return client.post(`/api/o11y/trigger/policy/${policyId}/node`, body);
 }
 
 export async function removeNodeFromPolicy(policyId, body) {
-  return client.delete(`/api/o11y/trigger/policy/${policyId}/vm`, { data: body });
+  return client.delete(`/api/o11y/trigger/policy/${policyId}/node`, { data: body });
 }
 
 export async function updatePolicyChannels(policyId, channels) {

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -10,6 +10,7 @@ const navItems = [
   { label: 'Config', path: 'config' },
   { label: 'Insight', path: 'insight' },
   { label: 'Alerts', path: 'alerts' },
+  { label: 'Tracing', path: 'trace' },
 ];
 
 export default function Layout() {

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -47,8 +47,8 @@ function PoliciesTab({ nsId, infraId }) {
 
   async function handleAddInfra(policyId) {
     if (!nsId || !infraId) { alert('NS/Infra not set'); return; }
-    // NOTE: targetScope literal stays "mci" — backend enum not yet renamed
-    await addNodeToPolicy(policyId, { namespaceId: nsId, targetScope: 'mci', targetId: infraId });
+    // targetScope "infra" → trigger query tags by infra_id (matches Telegraf/InfluxDB tags)
+    await addNodeToPolicy(policyId, { namespaceId: nsId, targetScope: 'infra', targetId: infraId });
     load();
   }
 

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -142,6 +142,9 @@ export default function HomePage() {
           <button onClick={() => go('alerts')} className="bg-red-600 text-white rounded py-2.5 text-sm font-medium hover:bg-red-700">
             Alerts
           </button>
+          <button onClick={() => go('trace')} className="bg-teal-600 text-white rounded py-2.5 text-sm font-medium hover:bg-teal-700">
+            Tracing
+          </button>
           <button onClick={() => {
             if (!nsId || !infraId) { alert('Select NS and Infra first'); return; }
             window.open(nodeId ? `/embed/monitoring/${nsId}/${infraId}/${nodeId}` : `/embed/monitoring/${nsId}/${infraId}`, '_blank');

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -82,7 +82,7 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
                 {settings.map((s, i) => (
                   <tr key={s.settingSeq || s.seq || i} className="hover:bg-gray-50">
                     <td className="px-3 py-2 border-b">{s.settingSeq || s.seq}</td>
-                    <td className="px-3 py-2 border-b">{s.nsId || s.ns_id}/{s.mciId || s.infra_id}/{s.vmId || s.node_id || '-'}</td>
+                    <td className="px-3 py-2 border-b">{s.nsId || s.ns_id}/{s.infraId || s.infra_id}/{s.nodeId || s.node_id || '-'}</td>
                     <td className="px-3 py-2 border-b">{s.measurement || '-'}</td>
                     <td className="px-3 py-2 border-b text-right">
                       <button onClick={() => handleDelete(s.settingSeq || s.seq)} className="text-xs text-red-500 hover:text-red-700">Delete</button>

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { searchTraces, getTrace } from '../api/trace';
+import { searchTraces, getTrace, getTraceServices } from '../api/trace';
 
 const RANGE_OPTIONS = [
   { value: 1, label: '1H' },
@@ -9,9 +9,16 @@ const RANGE_OPTIONS = [
   { value: 24, label: '24H' },
 ];
 
+const SCOPES = [
+  { key: 'framework', label: 'Framework', desc: 'o11y 플랫폼 자체 트레이스 (manager / insight)' },
+  { key: 'vm', label: 'VM', desc: '대상 VM 애플리케이션 트레이스 (Beyla / OTel)' },
+];
+
 export default function TraceViewer() {
   const { infraId } = useParams();
 
+  const [scope, setScope] = useState('framework');
+  const [services, setServices] = useState([]);
   const [service, setService] = useState('');
   const [keyword, setKeyword] = useState('');
   const [rangeHours, setRangeHours] = useState(1);
@@ -23,19 +30,25 @@ export default function TraceViewer() {
   const [spans, setSpans] = useState(null);
   const [spanLoading, setSpanLoading] = useState(false);
 
+  // Load service dropdown whenever scope changes
+  useEffect(() => {
+    setService('');
+    getTraceServices(scope).then(setServices).catch(() => setServices([]));
+  }, [scope]);
+
   const search = useCallback(async () => {
     setLoading(true);
     setSelectedTraceId('');
     setSpans(null);
     try {
-      const result = await searchTraces({ service, keyword, rangeHours });
+      const result = await searchTraces({ scope, service, keyword, rangeHours });
       setTraces(Array.isArray(result) ? result : []);
     } catch (e) {
       console.error('Trace query failed', e);
       setTraces([]);
     }
     setLoading(false);
-  }, [service, keyword, rangeHours]);
+  }, [scope, service, keyword, rangeHours]);
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') search();
@@ -62,21 +75,29 @@ export default function TraceViewer() {
 
   return (
     <div className="space-y-4">
+      {/* Scope tabs */}
+      <div className="flex gap-1 bg-white rounded-lg shadow px-2 py-1 items-center">
+        {SCOPES.map((s) => (
+          <button key={s.key} onClick={() => setScope(s.key)} title={s.desc}
+            className={`px-4 py-2 text-sm rounded ${scope === s.key ? 'bg-teal-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}>
+            {s.label}
+          </button>
+        ))}
+        <span className="text-xs text-gray-400 ml-2">{SCOPES.find((s) => s.key === scope)?.desc}</span>
+      </div>
+
       {/* Control card */}
       <div className="bg-white rounded-lg shadow">
         <div className="px-4 py-3 border-b font-semibold text-sm">Trace Manage</div>
         <div className="p-4">
           <div className="grid grid-cols-4 gap-4 mb-2">
-            {/* Workload context */}
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Workload</label>
-              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={infraId || '-'} readOnly />
-            </div>
-            {/* Service */}
+            {/* Service dropdown */}
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Service</label>
-              <input type="text" placeholder="service.name (optional)" value={service} onChange={(e) => setService(e.target.value)} onKeyDown={handleKeyDown}
-                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" />
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={service} onChange={(e) => setService(e.target.value)}>
+                <option value="">All services ({services.length})</option>
+                {services.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
             </div>
             {/* Keyword */}
             <div>
@@ -84,21 +105,26 @@ export default function TraceViewer() {
               <input type="text" placeholder="span / service keyword..." value={keyword} onChange={(e) => setKeyword(e.target.value)} onKeyDown={handleKeyDown}
                 className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" />
             </div>
-            {/* Range + Search */}
-            <div className="flex items-end gap-2">
-              <div className="flex-1">
-                <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
-                <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={rangeHours} onChange={(e) => setRangeHours(+e.target.value)}>
-                  {RANGE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </div>
+            {/* Range */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
+              <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={rangeHours} onChange={(e) => setRangeHours(+e.target.value)}>
+                {RANGE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            {/* Search */}
+            <div className="flex items-end">
               <button onClick={search} disabled={loading}
                 className="px-4 py-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm">
                 {loading ? 'Searching...' : 'Search'}
               </button>
             </div>
           </div>
-          <p className="text-xs text-gray-400">Traces are collected via the trace agent (Beyla / OTel) and stored in Tempo.</p>
+          <p className="text-xs text-gray-400">
+            {scope === 'vm'
+              ? 'VM 트레이스는 대상 노드에 trace agent(Beyla / OTel)가 설치되어 있어야 수집됩니다.'
+              : 'Framework 트레이스는 o11y 매니저/인사이트가 OTel로 자기계측한 데이터입니다.'}
+          </p>
         </div>
       </div>
 
@@ -136,11 +162,11 @@ export default function TraceViewer() {
         </div>
       </div>
 
-      {/* Span detail */}
+      {/* Span call sequence */}
       {selectedTraceId && (
         <div className="bg-white rounded-lg shadow">
           <div className="px-4 py-3 border-b font-semibold text-sm">
-            Trace Detail — <span className="font-mono text-xs text-gray-500">{selectedTraceId}</span>
+            Call Sequence — <span className="font-mono text-xs text-gray-500">{selectedTraceId}</span>
           </div>
           <div className="p-4 overflow-auto">
             {spanLoading ? (
@@ -148,7 +174,7 @@ export default function TraceViewer() {
             ) : !spans || spans.length === 0 ? (
               <p className="text-sm text-gray-400">No spans found</p>
             ) : (
-              <SpanTable spans={spans} />
+              <CallTree spans={spans} />
             )}
           </div>
         </div>
@@ -157,34 +183,43 @@ export default function TraceViewer() {
   );
 }
 
-function SpanTable({ spans }) {
+/** Renders spans as a parent→child call tree (DFS by start time) — the API call sequence. */
+function CallTree({ spans }) {
+  const ordered = buildCallTree(spans);
   const t0 = spans.reduce((min, s) => (s.startTimeMs < min ? s.startTimeMs : min), spans[0].startTimeMs);
-  const totalDur = spans.reduce((max, s) => Math.max(max, (s.startTimeMs - t0) + (s.durationMs || 0)), 1);
+  const totalDur = Math.max(1, ...spans.map((s) => (s.startTimeMs - t0) + (s.durationMs || 0)));
   return (
     <table className="w-full text-sm">
       <thead><tr className="bg-gray-50 text-left">
+        <th className="px-3 py-2 border-b text-xs text-gray-500 w-8">#</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500">Span (call order)</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500">Service</th>
-        <th className="px-3 py-2 border-b text-xs text-gray-500">Span</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500">Kind</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Offset</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Duration</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500 w-1/3">Timeline</th>
       </tr></thead>
       <tbody>
-        {spans.map((s, i) => {
+        {ordered.map((s, i) => {
           const offset = s.startTimeMs - t0;
           const leftPct = Math.min(100, (offset / totalDur) * 100);
           const widthPct = Math.max(1, Math.min(100 - leftPct, ((s.durationMs || 0) / totalDur) * 100));
           return (
             <tr key={s.spanId || i} className="hover:bg-gray-50">
-              <td className="px-3 py-2 border-b">{s.service || '-'}</td>
-              <td className="px-3 py-2 border-b font-medium">{s.name || '-'}</td>
+              <td className="px-3 py-2 border-b text-xs text-gray-400">{i + 1}</td>
+              <td className="px-3 py-2 border-b font-medium">
+                <span style={{ paddingLeft: `${s.depth * 16}px` }} className="inline-flex items-center gap-1">
+                  {s.depth > 0 && <span className="text-gray-300">└</span>}
+                  {s.name || '-'}
+                </span>
+              </td>
+              <td className="px-3 py-2 border-b text-gray-600">{s.service || '-'}</td>
               <td className="px-3 py-2 border-b text-xs text-gray-500">{fmtKind(s.kind)}</td>
               <td className="px-3 py-2 border-b text-right text-xs">{offset} ms</td>
               <td className="px-3 py-2 border-b text-right text-xs">{fmtDuration(s.durationMs)}</td>
               <td className="px-3 py-2 border-b">
                 <div className="relative h-3 bg-gray-100 rounded">
-                  <div className="absolute h-3 bg-blue-500 rounded" style={{ left: `${leftPct}%`, width: `${widthPct}%` }} />
+                  <div className={`absolute h-3 rounded ${kindColor(s.kind)}`} style={{ left: `${leftPct}%`, width: `${widthPct}%` }} />
                 </div>
               </td>
             </tr>
@@ -193,6 +228,25 @@ function SpanTable({ spans }) {
       </tbody>
     </table>
   );
+}
+
+// Build a parent→child tree and flatten it depth-first ordered by start time.
+function buildCallTree(spans) {
+  const byId = {};
+  spans.forEach((s) => { byId[s.spanId] = { ...s, children: [] }; });
+  const roots = [];
+  spans.forEach((s) => {
+    const node = byId[s.spanId];
+    if (s.parentSpanId && byId[s.parentSpanId]) byId[s.parentSpanId].children.push(node);
+    else roots.push(node);
+  });
+  const sortRec = (n) => { n.children.sort((a, b) => a.startTimeMs - b.startTimeMs); n.children.forEach(sortRec); };
+  roots.sort((a, b) => a.startTimeMs - b.startTimeMs);
+  roots.forEach(sortRec);
+  const out = [];
+  const walk = (n, depth) => { out.push({ ...n, depth }); n.children.forEach((c) => walk(c, depth + 1)); };
+  roots.forEach((r) => walk(r, 0));
+  return out;
 }
 
 function fmtTime(ms) {
@@ -215,4 +269,12 @@ function shortId(id) {
 function fmtKind(kind) {
   if (!kind) return '-';
   return String(kind).replace('SPAN_KIND_', '');
+}
+
+function kindColor(kind) {
+  const k = (kind || '').replace('SPAN_KIND_', '');
+  if (k === 'SERVER') return 'bg-emerald-500';
+  if (k === 'CLIENT') return 'bg-indigo-500';
+  if (k === 'PRODUCER' || k === 'CONSUMER') return 'bg-amber-500';
+  return 'bg-blue-500';
 }

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -1,0 +1,218 @@
+import { useState, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { searchTraces, getTrace } from '../api/trace';
+
+const RANGE_OPTIONS = [
+  { value: 1, label: '1H' },
+  { value: 6, label: '6H' },
+  { value: 12, label: '12H' },
+  { value: 24, label: '24H' },
+];
+
+export default function TraceViewer() {
+  const { infraId } = useParams();
+
+  const [service, setService] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [rangeHours, setRangeHours] = useState(1);
+  const [traces, setTraces] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  // expanded trace detail
+  const [selectedTraceId, setSelectedTraceId] = useState('');
+  const [spans, setSpans] = useState(null);
+  const [spanLoading, setSpanLoading] = useState(false);
+
+  const search = useCallback(async () => {
+    setLoading(true);
+    setSelectedTraceId('');
+    setSpans(null);
+    try {
+      const result = await searchTraces({ service, keyword, rangeHours });
+      setTraces(Array.isArray(result) ? result : []);
+    } catch (e) {
+      console.error('Trace query failed', e);
+      setTraces([]);
+    }
+    setLoading(false);
+  }, [service, keyword, rangeHours]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') search();
+  };
+
+  async function selectTrace(traceId) {
+    if (selectedTraceId === traceId) {
+      setSelectedTraceId('');
+      setSpans(null);
+      return;
+    }
+    setSelectedTraceId(traceId);
+    setSpanLoading(true);
+    setSpans(null);
+    try {
+      const detail = await getTrace(traceId);
+      setSpans(detail?.spans || []);
+    } catch (e) {
+      console.error('Trace detail failed', e);
+      setSpans([]);
+    }
+    setSpanLoading(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Control card */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">Trace Manage</div>
+        <div className="p-4">
+          <div className="grid grid-cols-4 gap-4 mb-2">
+            {/* Workload context */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Workload</label>
+              <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={infraId || '-'} readOnly />
+            </div>
+            {/* Service */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Service</label>
+              <input type="text" placeholder="service.name (optional)" value={service} onChange={(e) => setService(e.target.value)} onKeyDown={handleKeyDown}
+                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" />
+            </div>
+            {/* Keyword */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Keyword</label>
+              <input type="text" placeholder="span / service keyword..." value={keyword} onChange={(e) => setKeyword(e.target.value)} onKeyDown={handleKeyDown}
+                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" />
+            </div>
+            {/* Range + Search */}
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
+                <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={rangeHours} onChange={(e) => setRangeHours(+e.target.value)}>
+                  {RANGE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </div>
+              <button onClick={search} disabled={loading}
+                className="px-4 py-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm">
+                {loading ? 'Searching...' : 'Search'}
+              </button>
+            </div>
+          </div>
+          <p className="text-xs text-gray-400">Traces are collected via the trace agent (Beyla / OTel) and stored in Tempo.</p>
+        </div>
+      </div>
+
+      {/* Trace list */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b font-semibold text-sm">List of Trace</div>
+        <div className="p-4 overflow-auto">
+          {traces === null ? (
+            <p className="text-sm text-gray-400">Click Search to query traces</p>
+          ) : traces.length === 0 ? (
+            <p className="text-sm text-gray-400">No traces found</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Start Time</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Root Service</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Root Name</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Duration</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Trace ID</th>
+              </tr></thead>
+              <tbody>
+                {traces.map((t) => (
+                  <tr key={t.traceId} onClick={() => selectTrace(t.traceId)}
+                    className={`cursor-pointer hover:bg-blue-50 ${selectedTraceId === t.traceId ? 'bg-blue-100' : ''}`}>
+                    <td className="px-3 py-2 border-b whitespace-nowrap">{fmtTime(t.startTimeMs)}</td>
+                    <td className="px-3 py-2 border-b font-medium">{t.rootService || '-'}</td>
+                    <td className="px-3 py-2 border-b">{t.rootName || '-'}</td>
+                    <td className="px-3 py-2 border-b text-right">{fmtDuration(t.durationMs)}</td>
+                    <td className="px-3 py-2 border-b font-mono text-xs text-gray-500">{shortId(t.traceId)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* Span detail */}
+      {selectedTraceId && (
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-4 py-3 border-b font-semibold text-sm">
+            Trace Detail — <span className="font-mono text-xs text-gray-500">{selectedTraceId}</span>
+          </div>
+          <div className="p-4 overflow-auto">
+            {spanLoading ? (
+              <p className="text-sm text-gray-400 animate-pulse">Loading spans...</p>
+            ) : !spans || spans.length === 0 ? (
+              <p className="text-sm text-gray-400">No spans found</p>
+            ) : (
+              <SpanTable spans={spans} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SpanTable({ spans }) {
+  const t0 = spans.reduce((min, s) => (s.startTimeMs < min ? s.startTimeMs : min), spans[0].startTimeMs);
+  const totalDur = spans.reduce((max, s) => Math.max(max, (s.startTimeMs - t0) + (s.durationMs || 0)), 1);
+  return (
+    <table className="w-full text-sm">
+      <thead><tr className="bg-gray-50 text-left">
+        <th className="px-3 py-2 border-b text-xs text-gray-500">Service</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500">Span</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500">Kind</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Offset</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Duration</th>
+        <th className="px-3 py-2 border-b text-xs text-gray-500 w-1/3">Timeline</th>
+      </tr></thead>
+      <tbody>
+        {spans.map((s, i) => {
+          const offset = s.startTimeMs - t0;
+          const leftPct = Math.min(100, (offset / totalDur) * 100);
+          const widthPct = Math.max(1, Math.min(100 - leftPct, ((s.durationMs || 0) / totalDur) * 100));
+          return (
+            <tr key={s.spanId || i} className="hover:bg-gray-50">
+              <td className="px-3 py-2 border-b">{s.service || '-'}</td>
+              <td className="px-3 py-2 border-b font-medium">{s.name || '-'}</td>
+              <td className="px-3 py-2 border-b text-xs text-gray-500">{fmtKind(s.kind)}</td>
+              <td className="px-3 py-2 border-b text-right text-xs">{offset} ms</td>
+              <td className="px-3 py-2 border-b text-right text-xs">{fmtDuration(s.durationMs)}</td>
+              <td className="px-3 py-2 border-b">
+                <div className="relative h-3 bg-gray-100 rounded">
+                  <div className="absolute h-3 bg-blue-500 rounded" style={{ left: `${leftPct}%`, width: `${widthPct}%` }} />
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function fmtTime(ms) {
+  if (!ms) return '-';
+  try { return new Date(ms).toLocaleString(); } catch { return String(ms); }
+}
+
+function fmtDuration(ms) {
+  if (ms == null) return '-';
+  if (ms < 1) return `${ms.toFixed(2)} ms`;
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function shortId(id) {
+  if (!id) return '-';
+  return id.length > 16 ? `${id.slice(0, 16)}…` : id;
+}
+
+function fmtKind(kind) {
+  if (!kind) return '-';
+  return String(kind).replace('SPAN_KIND_', '');
+}

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Fragment } from 'react';
 import { useParams } from 'react-router-dom';
 import { searchTraces, getTrace, getTraceServices } from '../api/trace';
 
@@ -25,20 +25,23 @@ export default function TraceViewer() {
   const [traces, setTraces] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  // expanded trace detail
-  const [selectedTraceId, setSelectedTraceId] = useState('');
+  // inline-expanded trace detail
+  const [expandedId, setExpandedId] = useState('');
   const [spans, setSpans] = useState(null);
   const [spanLoading, setSpanLoading] = useState(false);
 
-  // Load service dropdown whenever scope changes
+  // Load service dropdown + reset list whenever scope changes (avoid stale list from other scope)
   useEffect(() => {
     setService('');
+    setTraces(null);
+    setExpandedId('');
+    setSpans(null);
     getTraceServices(scope).then(setServices).catch(() => setServices([]));
   }, [scope]);
 
   const search = useCallback(async () => {
     setLoading(true);
-    setSelectedTraceId('');
+    setExpandedId('');
     setSpans(null);
     try {
       const result = await searchTraces({ scope, service, keyword, rangeHours });
@@ -54,13 +57,13 @@ export default function TraceViewer() {
     if (e.key === 'Enter') search();
   };
 
-  async function selectTrace(traceId) {
-    if (selectedTraceId === traceId) {
-      setSelectedTraceId('');
+  async function toggleTrace(traceId) {
+    if (expandedId === traceId) {
+      setExpandedId('');
       setSpans(null);
       return;
     }
-    setSelectedTraceId(traceId);
+    setExpandedId(traceId);
     setSpanLoading(true);
     setSpans(null);
     try {
@@ -91,7 +94,6 @@ export default function TraceViewer() {
         <div className="px-4 py-3 border-b font-semibold text-sm">Trace Manage</div>
         <div className="p-4">
           <div className="grid grid-cols-4 gap-4 mb-2">
-            {/* Service dropdown */}
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Service</label>
               <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={service} onChange={(e) => setService(e.target.value)}>
@@ -99,20 +101,17 @@ export default function TraceViewer() {
                 {services.map((s) => <option key={s} value={s}>{s}</option>)}
               </select>
             </div>
-            {/* Keyword */}
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Keyword</label>
               <input type="text" placeholder="span / service keyword..." value={keyword} onChange={(e) => setKeyword(e.target.value)} onKeyDown={handleKeyDown}
                 className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" />
             </div>
-            {/* Range */}
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Range</label>
               <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={rangeHours} onChange={(e) => setRangeHours(+e.target.value)}>
                 {RANGE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
               </select>
             </div>
-            {/* Search */}
             <div className="flex items-end">
               <button onClick={search} disabled={loading}
                 className="px-4 py-1.5 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm">
@@ -123,12 +122,12 @@ export default function TraceViewer() {
           <p className="text-xs text-gray-400">
             {scope === 'vm'
               ? 'VM 트레이스는 대상 노드에 trace agent(Beyla / OTel)가 설치되어 있어야 수집됩니다.'
-              : 'Framework 트레이스는 o11y 매니저/인사이트가 OTel로 자기계측한 데이터입니다.'}
+              : 'Framework 트레이스는 o11y 매니저/인사이트가 OTel로 자기계측한 데이터입니다. 행을 클릭하면 API 호출 흐름이 펼쳐집니다.'}
           </p>
         </div>
       </div>
 
-      {/* Trace list */}
+      {/* Trace list with inline expand */}
       <div className="bg-white rounded-lg shadow">
         <div className="px-4 py-3 border-b font-semibold text-sm">List of Trace</div>
         <div className="p-4 overflow-auto">
@@ -139,6 +138,7 @@ export default function TraceViewer() {
           ) : (
             <table className="w-full text-sm">
               <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500 w-6" />
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Start Time</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Root Service</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Root Name</th>
@@ -146,39 +146,41 @@ export default function TraceViewer() {
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Trace ID</th>
               </tr></thead>
               <tbody>
-                {traces.map((t) => (
-                  <tr key={t.traceId} onClick={() => selectTrace(t.traceId)}
-                    className={`cursor-pointer hover:bg-blue-50 ${selectedTraceId === t.traceId ? 'bg-blue-100' : ''}`}>
-                    <td className="px-3 py-2 border-b whitespace-nowrap">{fmtTime(t.startTimeMs)}</td>
-                    <td className="px-3 py-2 border-b font-medium">{t.rootService || '-'}</td>
-                    <td className="px-3 py-2 border-b">{t.rootName || '-'}</td>
-                    <td className="px-3 py-2 border-b text-right">{fmtDuration(t.durationMs)}</td>
-                    <td className="px-3 py-2 border-b font-mono text-xs text-gray-500">{shortId(t.traceId)}</td>
-                  </tr>
-                ))}
+                {traces.map((t) => {
+                  const open = expandedId === t.traceId;
+                  return (
+                    <Fragment key={t.traceId}>
+                      <tr onClick={() => toggleTrace(t.traceId)}
+                        className={`cursor-pointer hover:bg-blue-50 ${open ? 'bg-blue-100' : ''}`}>
+                        <td className="px-3 py-2 border-b text-gray-400">{open ? '▼' : '▶'}</td>
+                        <td className="px-3 py-2 border-b whitespace-nowrap">{fmtTime(t.startTimeMs)}</td>
+                        <td className="px-3 py-2 border-b font-medium">{t.rootService || '-'}</td>
+                        <td className="px-3 py-2 border-b">{t.rootName || '-'}</td>
+                        <td className="px-3 py-2 border-b text-right">{fmtDuration(t.durationMs)}</td>
+                        <td className="px-3 py-2 border-b font-mono text-xs text-gray-500">{shortId(t.traceId)}</td>
+                      </tr>
+                      {open && (
+                        <tr>
+                          <td colSpan={6} className="border-b bg-gray-50 p-3">
+                            <div className="text-xs font-semibold text-gray-500 mb-2">API Call Sequence</div>
+                            {spanLoading ? (
+                              <p className="text-sm text-gray-400 animate-pulse">Loading spans...</p>
+                            ) : !spans || spans.length === 0 ? (
+                              <p className="text-sm text-gray-400">No spans found</p>
+                            ) : (
+                              <CallTree spans={spans} />
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
               </tbody>
             </table>
           )}
         </div>
       </div>
-
-      {/* Span call sequence */}
-      {selectedTraceId && (
-        <div className="bg-white rounded-lg shadow">
-          <div className="px-4 py-3 border-b font-semibold text-sm">
-            Call Sequence — <span className="font-mono text-xs text-gray-500">{selectedTraceId}</span>
-          </div>
-          <div className="p-4 overflow-auto">
-            {spanLoading ? (
-              <p className="text-sm text-gray-400 animate-pulse">Loading spans...</p>
-            ) : !spans || spans.length === 0 ? (
-              <p className="text-sm text-gray-400">No spans found</p>
-            ) : (
-              <CallTree spans={spans} />
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -189,8 +191,8 @@ function CallTree({ spans }) {
   const t0 = spans.reduce((min, s) => (s.startTimeMs < min ? s.startTimeMs : min), spans[0].startTimeMs);
   const totalDur = Math.max(1, ...spans.map((s) => (s.startTimeMs - t0) + (s.durationMs || 0)));
   return (
-    <table className="w-full text-sm">
-      <thead><tr className="bg-gray-50 text-left">
+    <table className="w-full text-sm bg-white rounded border">
+      <thead><tr className="bg-gray-100 text-left">
         <th className="px-3 py-2 border-b text-xs text-gray-500 w-8">#</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500">Span (call order)</th>
         <th className="px-3 py-2 border-b text-xs text-gray-500">Service</th>

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/BeylaController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/BeylaController.java
@@ -51,7 +51,7 @@ public class BeylaController {
     private final VmAccessInfoResolver vmAccessInfoResolver;
     private final SemaphoreInstallTemplateCounter templateCounter;
 
-    @PostMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/install")
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/install")
     @Operation(
             summary = "Install Beyla trace agent (Linux only)",
             operationId = "InstallTraceAgent",
@@ -60,77 +60,77 @@ public class BeylaController {
                             + " Windows에는 /windows-trace-agent/install을 사용하라.")
     public ResBody<Void> install(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId)
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId)
             throws Exception {
 
-        ensureLinux(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureLinux(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        beylaFacadeService.install(nsId, mciId, vmId, accessInfo, templateCount);
+        beylaFacadeService.install(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
-    @PutMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/update")
+    @PutMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/update")
     @Operation(summary = "Update Beyla trace agent (Linux only)", operationId = "UpdateTraceAgent")
     public ResBody<Void> update(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId)
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId)
             throws Exception {
 
-        ensureLinux(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureLinux(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        beylaFacadeService.update(nsId, mciId, vmId, accessInfo, templateCount);
+        beylaFacadeService.update(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
-    @DeleteMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/uninstall")
+    @DeleteMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/uninstall")
     @Operation(
             summary = "Uninstall Beyla trace agent (Linux only)",
             operationId = "UninstallTraceAgent")
     public ResBody<Void> uninstall(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId) {
 
-        ensureLinux(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureLinux(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        beylaFacadeService.uninstall(nsId, mciId, vmId, accessInfo, templateCount);
+        beylaFacadeService.uninstall(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
-    @PostMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/restart")
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/restart")
     @Operation(
             summary = "Restart Beyla trace agent (Linux only)",
             operationId = "RestartTraceAgent")
     public ResBody<List<ResultDTO>> restart(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId) {
 
-        ensureLinux(nsId, mciId, vmId);
-        List<ResultDTO> results = beylaFacadeService.restart(nsId, mciId, vmId);
+        ensureLinux(nsId, infraId, nodeId);
+        List<ResultDTO> results = beylaFacadeService.restart(nsId, infraId, nodeId);
         return new ResBody<>(results);
     }
 
-    @GetMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/status")
+    @GetMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/status")
     @Operation(
             summary = "Get Beyla Agent Status",
             operationId = "GetBeylaAgentStatus",
             description = "Get Beyla APM/Trace agent status on the target VM")
     public ResBody<AgentStatus> getStatus(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId) {
 
-        AgentStatus status = agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.BEYLA);
+        AgentStatus status = agentFacadeService.getAgentStatus(nsId, infraId, nodeId, Agent.BEYLA);
         return new ResBody<>(status);
     }
 
-    @GetMapping("/{nsId}/{mciId}/vm/{vmId}/beyla/system-check")
+    @GetMapping("/{nsId}/{infraId}/node/{nodeId}/beyla/system-check")
     @Operation(
             summary = "Check Beyla System Requirements (Linux only)",
             operationId = "CheckBeylaSystemRequirements",
@@ -138,16 +138,17 @@ public class BeylaController {
                     "Check if the target VM meets Beyla system requirements (kernel version, BTF support)")
     public ResBody<BeylaSystemCheckResult> checkSystemRequirements(
             @Parameter(description = "Namespace ID", example = "ns-1") @PathVariable String nsId,
-            @Parameter(description = "MCI ID", example = "mci-1") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "vm-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "infra-1") @PathVariable String infraId,
+            @Parameter(description = "Node ID", example = "node-1") @PathVariable String nodeId) {
 
-        BeylaSystemCheckResult result = beylaSystemRequirementValidator.validate(nsId, mciId, vmId);
+        BeylaSystemCheckResult result =
+                beylaSystemRequirementValidator.validate(nsId, infraId, nodeId);
         return new ResBody<>(result);
     }
 
     /** Linux 전용 엔드포인트. Windows node면 400 BAD_REQUEST로 caller에 올바른 endpoint 안내. */
-    private void ensureLinux(String nsId, String mciId, String vmId) {
-        if (vmAccessInfoResolver.isWindowsNode(nsId, mciId, vmId)) {
+    private void ensureLinux(String nsId, String infraId, String nodeId) {
+        if (vmAccessInfoResolver.isWindowsNode(nsId, infraId, nodeId)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "This endpoint is for Linux nodes only. For Windows nodes, use"

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
@@ -32,14 +32,14 @@ public class CspMonitoringController {
     private final SpiderClient spiderClient;
     private final CspCacheService cspCacheService;
 
-    @GetMapping("/vm/{vmName}/{measurement}")
+    @GetMapping("/node/{nodeName}/{measurement}")
     @Operation(
             summary = "GetVMMonitoring",
             operationId = "GetVMMonitoringCached",
             description =
                     "Proxy cb-spider /spider/monitoring/vm/{vmName}/{measurement} with Caffeine caching.")
     public SpiderMonitoringInfo.Data getVmMetric(
-            @Parameter(description = "CSP resource name of the VM") @PathVariable String vmName,
+            @Parameter(description = "CSP resource name of the VM") @PathVariable String nodeName,
             @Parameter(description = "Metric type (e.g. cpu_usage, memory_usage)") @PathVariable
                     String measurement,
             @RequestParam("ConnectionName") String connectionName,
@@ -49,10 +49,12 @@ public class CspMonitoringController {
             @RequestParam(value = "periodMinute", required = false) String periodMinute) {
         String tbh = firstNonBlank(timeBeforeHour, timeBeforeHourAlt, "1");
         String ivm = firstNonBlank(intervalMinute, periodMinute, "5");
-        CspCacheKey key = CspCacheKey.forVm(vmName, measurement, connectionName, tbh, ivm);
+        CspCacheKey key = CspCacheKey.forVm(nodeName, measurement, connectionName, tbh, ivm);
         return cspCacheService.getOrLoad(
                 key,
-                () -> spiderClient.getVMMonitoring(vmName, measurement, connectionName, tbh, ivm));
+                () ->
+                        spiderClient.getVMMonitoring(
+                                nodeName, measurement, connectionName, tbh, ivm));
     }
 
     @GetMapping("/cluster/{clusterName}/{nodeGroupName}/{nodeNumber}/{measurement}")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/GpuMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/GpuMonitoringController.java
@@ -42,7 +42,7 @@ public class GpuMonitoringController {
         return new ResBody<>(gpuMonitoringFacadeService.getGpuMetricKeys());
     }
 
-    @GetMapping("/field/check/{nsId}/{mciId}/{vmId}")
+    @GetMapping("/field/check/{nsId}/{infraId}/{nodeId}")
     @Operation(
             summary = "CheckGpuMetricFields",
             operationId = "CheckGpuMetricFields",
@@ -51,14 +51,15 @@ public class GpuMonitoringController {
     public ResBody<List<GpuMetricFieldCheckDTO>> checkGpuMetricFields(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId) {
-        return new ResBody<>(gpuMonitoringFacadeService.checkGpuMetricFields(nsId, mciId, vmId));
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId) {
+        return new ResBody<>(
+                gpuMonitoringFacadeService.checkGpuMetricFields(nsId, infraId, nodeId));
     }
 
-    @PostMapping("/metric/{nsId}/{mciId}/{vmId}")
+    @PostMapping("/metric/{nsId}/{infraId}/{nodeId}")
     @Operation(
             summary = "GetGpuMetrics",
             operationId = "GetGpuMetrics",
@@ -67,11 +68,11 @@ public class GpuMonitoringController {
     public ResBody<List<MetricDTO>> getGpuMetrics(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody MetricRequestDTO req) {
-        return new ResBody<>(gpuMonitoringFacadeService.getGpuMetrics(nsId, mciId, vmId, req));
+        return new ResBody<>(gpuMonitoringFacadeService.getGpuMetrics(nsId, infraId, nodeId, req));
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InfluxDBController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InfluxDBController.java
@@ -61,21 +61,21 @@ public class InfluxDBController {
         return new ResBody<>(influxDbFacadeService.getTags());
     }
 
-    @PostMapping("/metric/{nsId}/{mciId}")
+    @PostMapping("/metric/{nsId}/{infraId}")
     @Operation(
-            summary = "GetMetricsByNsIdAndMciId",
-            operationId = "GetMetricsByNsIdAndMciId",
+            summary = "GetMetricsByNsIdAndInfraId",
+            operationId = "GetMetricsByNsIdAndInfraId",
             description = "Retrieve InfluxDB metrics")
-    public ResBody<List<MetricDTO>> MetricByNsIdAndMciId(
+    public ResBody<List<MetricDTO>> MetricByNsIdAndInfraId(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
             @RequestBody MetricRequestDTO req) {
-        return new ResBody<>(influxDbFacadeService.postMetricsByNsMci(nsId, mciId, req));
+        return new ResBody<>(influxDbFacadeService.postMetricsByNsMci(nsId, infraId, req));
     }
 
-    @PostMapping("/metric/{nsId}/{mciId}/{vmId}")
+    @PostMapping("/metric/{nsId}/{infraId}/{nodeId}")
     @Operation(
             summary = "GetMetricsByVMId",
             operationId = "GetMetricsByVMId",
@@ -83,12 +83,12 @@ public class InfluxDBController {
     public ResBody<List<MetricDTO>> MetricByVMId(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody MetricRequestDTO req) {
-        return new ResBody<>(influxDbFacadeService.postMetricsByVM(nsId, mciId, vmId, req));
+        return new ResBody<>(influxDbFacadeService.postMetricsByVM(nsId, infraId, nodeId, req));
     }
 
     @GetMapping("/cache/stats")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InsightController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InsightController.java
@@ -95,19 +95,20 @@ public class InsightController {
             summary = "GetMCIAnomalyDetectionSettings",
             operationId = "GetMCIAnomalyDetectionSettings",
             description = "Fetch the current anomaly detection settings for a specific mci group.")
-    @GetMapping("/anomaly-detection/settings/ns/{nsId}/mci/{mciId}")
-    public Object getAnomalySettingsForMci(@PathVariable String nsId, @PathVariable String mciId) {
-        return insightPort.getAnomalySettingsForMci(nsId, mciId);
+    @GetMapping("/anomaly-detection/settings/ns/{nsId}/infra/{infraId}")
+    public Object getAnomalySettingsForInfra(
+            @PathVariable String nsId, @PathVariable String infraId) {
+        return insightPort.getAnomalySettingsForInfra(nsId, infraId);
     }
 
     @Operation(
             summary = "GetVMAnomalyDetectionSettings",
             operationId = "GetVMAnomalyDetectionSettings",
             description = "Fetch the current anomaly detection settings for a specific vm.")
-    @GetMapping("/anomaly-detection/settings/ns/{nsId}/mci/{mciId}/vm/{vmId}")
-    public Object getAnomalySettingsForVm(
-            @PathVariable String nsId, @PathVariable String mciId, @PathVariable String vmId) {
-        return insightPort.getAnomalySettingsForVm(nsId, mciId, vmId);
+    @GetMapping("/anomaly-detection/settings/ns/{nsId}/infra/{infraId}/node/{nodeId}")
+    public Object getAnomalySettingsForNode(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId) {
+        return insightPort.getAnomalySettingsForNode(nsId, infraId, nodeId);
     }
 
     @Operation(
@@ -115,14 +116,15 @@ public class InsightController {
             operationId = "GetAnomalyDetectionMCIHistory",
             description =
                     "Fetch the results of anomaly detection for mci group within a given time range.")
-    @GetMapping("/anomaly-detection/ns/{nsId}/mci/{mciId}/history")
-    public Object getAnomalyHistoryForMci(
+    @GetMapping("/anomaly-detection/ns/{nsId}/infra/{infraId}/history")
+    public Object getAnomalyHistoryForInfra(
             @PathVariable String nsId,
-            @PathVariable String mciId,
+            @PathVariable String infraId,
             @RequestParam String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime) {
-        return insightPort.getAnomalyHistoryForMci(nsId, mciId, measurement, startTime, endTime);
+        return insightPort.getAnomalyHistoryForInfra(
+                nsId, infraId, measurement, startTime, endTime);
     }
 
     @Operation(
@@ -130,16 +132,16 @@ public class InsightController {
             operationId = "GetAnomalyDetectionVMHistory",
             description =
                     "Fetch the results of anomaly detection for a specific vm within a given time range.")
-    @GetMapping("/anomaly-detection/ns/{nsId}/mci/{mciId}/vm/{vmId}/history")
-    public Object getAnomalyHistoryForVm(
+    @GetMapping("/anomaly-detection/ns/{nsId}/infra/{infraId}/node/{nodeId}/history")
+    public Object getAnomalyHistoryForNode(
             @PathVariable String nsId,
-            @PathVariable String mciId,
-            @PathVariable String vmId,
+            @PathVariable String infraId,
+            @PathVariable String nodeId,
             @RequestParam String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime) {
-        return insightPort.getAnomalyHistoryForVm(
-                nsId, mciId, vmId, measurement, startTime, endTime);
+        return insightPort.getAnomalyHistoryForNode(
+                nsId, infraId, nodeId, measurement, startTime, endTime);
     }
 
     /* ===================== ALERT ===================== */
@@ -281,52 +283,53 @@ public class InsightController {
             summary = "PostPredictionMCI",
             operationId = "PostPredictionMCI",
             description = "Predict future metrics (cpu, mem, disk, system) for a given mci group.")
-    @PostMapping("/predictions/ns/{nsId}/mci/{mciId}")
-    public Object predictMonitoringDataForMci(
-            @PathVariable String nsId, @PathVariable String mciId, @RequestBody Object body) {
-        return insightPort.predictMonitoringDataForMci(nsId, mciId, body);
+    @PostMapping("/predictions/ns/{nsId}/infra/{infraId}")
+    public Object predictMonitoringDataForInfra(
+            @PathVariable String nsId, @PathVariable String infraId, @RequestBody Object body) {
+        return insightPort.predictMonitoringDataForInfra(nsId, infraId, body);
     }
 
     @Operation(
             summary = "PostPredictionVM",
             operationId = "PostPredictionVM",
             description = "Predict future metrics (cpu, mem, disk, system) for a given vm.")
-    @PostMapping("/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}")
-    public Object predictMonitoringDataForVm(
+    @PostMapping("/predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}")
+    public Object predictMonitoringDataForNode(
             @PathVariable String nsId,
-            @PathVariable String mciId,
-            @PathVariable String vmId,
+            @PathVariable String infraId,
+            @PathVariable String nodeId,
             @RequestBody Object body) {
-        return insightPort.predictMonitoringDataForVm(nsId, mciId, vmId, body);
+        return insightPort.predictMonitoringDataForNode(nsId, infraId, nodeId, body);
     }
 
     @Operation(
             summary = "GetPredictionMCIHistory",
             operationId = "GetPredictionMCIHistory",
             description = "Get previously stored prediction data for a specific mci group.")
-    @GetMapping("/predictions/ns/{nsId}/mci/{mciId}/history")
-    public Object getPredictionHistoryForMci(
+    @GetMapping("/predictions/ns/{nsId}/infra/{infraId}/history")
+    public Object getPredictionHistoryForInfra(
             @PathVariable String nsId,
-            @PathVariable String mciId,
+            @PathVariable String infraId,
             @RequestParam String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime) {
-        return insightPort.getPredictionHistoryForMci(nsId, mciId, measurement, startTime, endTime);
+        return insightPort.getPredictionHistoryForInfra(
+                nsId, infraId, measurement, startTime, endTime);
     }
 
     @Operation(
             summary = "GetPredictionVMHistory",
             operationId = "GetPredictionVMHistory",
             description = "Get previously stored prediction data for a specific vm.")
-    @GetMapping("/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}/history")
-    public Object getPredictionHistoryForVm(
+    @GetMapping("/predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}/history")
+    public Object getPredictionHistoryForNode(
             @PathVariable String nsId,
-            @PathVariable String mciId,
-            @PathVariable String vmId,
+            @PathVariable String infraId,
+            @PathVariable String nodeId,
             @RequestParam String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime) {
-        return insightPort.getPredictionHistoryForVm(
-                nsId, mciId, vmId, measurement, startTime, endTime);
+        return insightPort.getPredictionHistoryForNode(
+                nsId, infraId, nodeId, measurement, startTime, endTime);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/ItemController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/ItemController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/o11y/monitoring/{nsId}/{mciId}/vm/{vmId}/item")
+@RequestMapping("/api/o11y/monitoring/{nsId}/{infraId}/node/{nodeId}/item")
 @Tag(name = "[Manager] Monitoring VM Item Management")
 public class ItemController {
     private final ItemFacadeService itemFacadeService;
@@ -30,11 +30,11 @@ public class ItemController {
     public ResBody<List<MonitoringItemDTO>> getItems(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId) {
-        return new ResBody<>(itemFacadeService.getTelegrafItems(nsId, mciId, vmId));
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId) {
+        return new ResBody<>(itemFacadeService.getTelegrafItems(nsId, infraId, nodeId));
     }
 
     @PostMapping
@@ -45,12 +45,12 @@ public class ItemController {
     public ResBody<Void> postItem(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody @Valid MonitoringItemRequestDTO dto) {
-        itemFacadeService.addTelegrafPlugin(nsId, mciId, vmId, dto);
+        itemFacadeService.addTelegrafPlugin(nsId, infraId, nodeId, dto);
         return ResBody.success(null);
     }
 
@@ -62,12 +62,12 @@ public class ItemController {
     public ResBody<Void> putItem(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody @Valid MonitoringItemUpdateDTO dto) {
-        itemFacadeService.updateTelegrafPlugin(nsId, mciId, vmId, dto);
+        itemFacadeService.updateTelegrafPlugin(nsId, infraId, nodeId, dto);
         return ResBody.success(null);
     }
 
@@ -79,13 +79,13 @@ public class ItemController {
     public ResBody<Void> deleteItem(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @Parameter(description = "Item Seq (e.g., 1)", example = "1") @PathVariable
                     Long itemSeq) {
-        itemFacadeService.deleteTelegrafPlugin(nsId, mciId, vmId, itemSeq);
+        itemFacadeService.deleteTelegrafPlugin(nsId, infraId, nodeId, itemSeq);
         return ResBody.success(null);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/OtelJavaController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/OtelJavaController.java
@@ -50,7 +50,7 @@ public class OtelJavaController {
     private final VmAccessInfoResolver vmAccessInfoResolver;
     private final SemaphoreInstallTemplateCounter templateCounter;
 
-    @PostMapping("/{nsId}/{mciId}/vm/{vmId}/windows-trace-agent/install")
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/windows-trace-agent/install")
     @Operation(
             summary = "Install Windows OTel Java Auto-Instrumentation agent",
             operationId = "InstallWindowsTraceAgent",
@@ -60,36 +60,38 @@ public class OtelJavaController {
     public ResBody<Void> install(
             @Parameter(description = "Namespace ID", example = "testns01") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID", example = "win2019-os01") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "win-1") @PathVariable String vmId)
+            @Parameter(description = "Infra ID", example = "win2019-os01") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID", example = "win-1") @PathVariable String nodeId)
             throws Exception {
 
-        ensureWindows(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureWindows(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        otelJavaFacadeService.install(nsId, mciId, vmId, accessInfo, templateCount);
+        otelJavaFacadeService.install(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
-    @PutMapping("/{nsId}/{mciId}/vm/{vmId}/windows-trace-agent/update")
+    @PutMapping("/{nsId}/{infraId}/node/{nodeId}/windows-trace-agent/update")
     @Operation(
             summary = "Update Windows OTel Java agent (jar 재다운로드)",
             operationId = "UpdateWindowsTraceAgent")
     public ResBody<Void> update(
             @Parameter(description = "Namespace ID", example = "testns01") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID", example = "win2019-os01") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "win-1") @PathVariable String vmId)
+            @Parameter(description = "Infra ID", example = "win2019-os01") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID", example = "win-1") @PathVariable String nodeId)
             throws Exception {
 
-        ensureWindows(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureWindows(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        otelJavaFacadeService.update(nsId, mciId, vmId, accessInfo, templateCount);
+        otelJavaFacadeService.update(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
-    @DeleteMapping("/{nsId}/{mciId}/vm/{vmId}/windows-trace-agent/uninstall")
+    @DeleteMapping("/{nsId}/{infraId}/node/{nodeId}/windows-trace-agent/uninstall")
     @Operation(
             summary = "Uninstall Windows OTel Java agent",
             operationId = "UninstallWindowsTraceAgent",
@@ -97,13 +99,14 @@ public class OtelJavaController {
     public ResBody<Void> uninstall(
             @Parameter(description = "Namespace ID", example = "testns01") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID", example = "win2019-os01") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "win-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "win2019-os01") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID", example = "win-1") @PathVariable String nodeId) {
 
-        ensureWindows(nsId, mciId, vmId);
-        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, mciId, vmId);
+        ensureWindows(nsId, infraId, nodeId);
+        AccessInfoDTO accessInfo = vmAccessInfoResolver.resolve(nsId, infraId, nodeId);
         int templateCount = templateCounter.next();
-        otelJavaFacadeService.uninstall(nsId, mciId, vmId, accessInfo, templateCount);
+        otelJavaFacadeService.uninstall(nsId, infraId, nodeId, accessInfo, templateCount);
         return new ResBody<>();
     }
 
@@ -111,7 +114,7 @@ public class OtelJavaController {
      * Windows OTel Java agent는 호스트 단위 환경변수 주입 방식이라 service 단위 restart 의미 없음. {@link
      * OtelJavaFacadeService#restart} 내부에서 미지원 throw하지만 caller에 명확하게 ERROR 결과로 응답한다.
      */
-    @PostMapping("/{nsId}/{mciId}/vm/{vmId}/windows-trace-agent/restart")
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/windows-trace-agent/restart")
     @Operation(
             summary = "Restart Windows OTel Java agent (미지원)",
             operationId = "RestartWindowsTraceAgent",
@@ -119,32 +122,34 @@ public class OtelJavaController {
     public ResBody<List<ResultDTO>> restart(
             @Parameter(description = "Namespace ID", example = "testns01") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID", example = "win2019-os01") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "win-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "win2019-os01") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID", example = "win-1") @PathVariable String nodeId) {
 
-        ensureWindows(nsId, mciId, vmId);
-        List<ResultDTO> results = otelJavaFacadeService.restart(nsId, mciId, vmId);
+        ensureWindows(nsId, infraId, nodeId);
+        List<ResultDTO> results = otelJavaFacadeService.restart(nsId, infraId, nodeId);
         return new ResBody<>(results);
     }
 
-    @GetMapping("/{nsId}/{mciId}/vm/{vmId}/windows-trace-agent/status")
+    @GetMapping("/{nsId}/{infraId}/node/{nodeId}/windows-trace-agent/status")
     @Operation(
             summary = "Get Windows OTel Java agent status",
             operationId = "GetWindowsTraceAgentStatus")
     public ResBody<AgentStatus> getStatus(
             @Parameter(description = "Namespace ID", example = "testns01") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID", example = "win2019-os01") @PathVariable String mciId,
-            @Parameter(description = "VM ID", example = "win-1") @PathVariable String vmId) {
+            @Parameter(description = "Infra ID", example = "win2019-os01") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID", example = "win-1") @PathVariable String nodeId) {
 
         AgentStatus status =
-                agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.OTEL_JAVA_AGENT);
+                agentFacadeService.getAgentStatus(nsId, infraId, nodeId, Agent.OTEL_JAVA_AGENT);
         return new ResBody<>(status);
     }
 
     /** 잘못된 endpoint 사용 가드. Windows node가 아니면 명시적으로 throw해서 caller가 /beyla/...로 가도록 안내. */
-    private void ensureWindows(String nsId, String mciId, String vmId) {
-        if (!vmAccessInfoResolver.isWindowsNode(nsId, mciId, vmId)) {
+    private void ensureWindows(String nsId, String infraId, String nodeId) {
+        if (!vmAccessInfoResolver.isWindowsNode(nsId, infraId, nodeId)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "This endpoint is for Windows nodes only. For Linux nodes, use /beyla/...");

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/TraceController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/TraceController.java
@@ -1,0 +1,63 @@
+package com.mcmp.o11ymanager.manager.controller;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import com.mcmp.o11ymanager.manager.facade.TraceFacadeService;
+import com.mcmp.o11ymanager.manager.global.vm.ResBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/o11y/trace")
+@Tag(name = "[Manager] Monitoring Trace")
+public class TraceController {
+
+    private final TraceFacadeService traceFacadeService;
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "TraceSearch",
+            operationId = "TraceSearch",
+            description =
+                    "Search Tempo trace summaries. Provide a raw TraceQL `query`, or filter with"
+                            + " `service` / `keyword` over a time window.")
+    public ResBody<List<TraceResponseDto.TraceSummary>> searchTraces(
+            @Parameter(
+                            description =
+                                    "Raw TraceQL (e.g. { resource.service.name=\"svc\" }). Overrides service/keyword.")
+                    @RequestParam(required = false)
+                    String query,
+            @Parameter(description = "Service name filter (resource.service.name)")
+                    @RequestParam(required = false)
+                    String service,
+            @Parameter(description = "Free-text keyword (matches span name or service name)")
+                    @RequestParam(required = false)
+                    String keyword,
+            @Parameter(description = "Start time (RFC3339 or unix epoch). Defaults to 1h ago.")
+                    @RequestParam(required = false)
+                    String start,
+            @Parameter(description = "End time (RFC3339 or unix epoch). Defaults to now.")
+                    @RequestParam(required = false)
+                    String end,
+            @Parameter(description = "Maximum number of traces") @RequestParam(defaultValue = "100")
+                    int limit) {
+
+        return new ResBody<>(
+                traceFacadeService.searchTraces(query, service, keyword, start, end, limit));
+    }
+
+    @GetMapping("/{traceId}")
+    @Operation(
+            summary = "TraceDetail",
+            operationId = "TraceDetail",
+            description = "Retrieve the flattened span list of a single trace (no flame graph).")
+    public ResBody<TraceResponseDto.TraceDetail> getTrace(
+            @Parameter(description = "Trace ID") @PathVariable String traceId) {
+
+        return new ResBody<>(traceFacadeService.getTraceDetail(traceId));
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/TraceController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/TraceController.java
@@ -37,6 +37,11 @@ public class TraceController {
             @Parameter(description = "Free-text keyword (matches span name or service name)")
                     @RequestParam(required = false)
                     String keyword,
+            @Parameter(
+                            description =
+                                    "Trace scope: framework (o11y platform) | vm (target VMs) | all")
+                    @RequestParam(required = false)
+                    String scope,
             @Parameter(description = "Start time (RFC3339 or unix epoch). Defaults to 1h ago.")
                     @RequestParam(required = false)
                     String start,
@@ -47,7 +52,22 @@ public class TraceController {
                     int limit) {
 
         return new ResBody<>(
-                traceFacadeService.searchTraces(query, service, keyword, start, end, limit));
+                traceFacadeService.searchTraces(query, service, keyword, scope, start, end, limit));
+    }
+
+    @GetMapping("/services")
+    @Operation(
+            summary = "TraceServiceList",
+            operationId = "TraceServiceList",
+            description =
+                    "List service.name values in Tempo, optionally narrowed by scope"
+                            + " (framework | vm | all). Drives the UI service dropdown.")
+    public ResBody<List<String>> getServices(
+            @Parameter(description = "Trace scope: framework | vm | all")
+                    @RequestParam(required = false)
+                    String scope) {
+
+        return new ResBody<>(traceFacadeService.getServiceNames(scope));
     }
 
     @GetMapping("/{traceId}")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMController.java
@@ -24,64 +24,64 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/o11y/monitoring")
-@Tag(name = "[Manager] Monitoring VM Management")
+@Tag(name = "[Manager] Monitoring Node Management")
 public class VMController {
 
     private final VMFacadeService vmFacadeService;
 
-    @GetMapping("/{nsId}/{mciId}/vm/{vmId}")
+    @GetMapping("/{nsId}/{infraId}/node/{nodeId}")
     @Operation(summary = "GetVM", operationId = "GetVM", description = "Get target (VM)")
     public ResBody<VMDTO> getVM(
             @Parameter(description = "Namespace ID (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "VM ID (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId) {
-        return new ResBody<>(vmFacadeService.getVM(nsId, mciId, vmId));
+            @Parameter(description = "Infra ID (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId) {
+        return new ResBody<>(vmFacadeService.getVM(nsId, infraId, nodeId));
     }
 
-    @PostMapping("/{nsId}/{mciId}/vm/{vmId}")
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}")
     @Operation(summary = "PostVM", operationId = "PostVM", description = "Create target (VM)")
     public ResBody<Void> postVM(
             @Parameter(description = "Namespace ID (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "MCI ID (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "VM ID (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "Infra ID (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "Node ID (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody @Valid VMRequestDTO dto) {
-        vmFacadeService.postVM(nsId, mciId, vmId, dto);
+        vmFacadeService.postVM(nsId, infraId, nodeId, dto);
         return new ResBody<>();
     }
 
-    @PutMapping("/{nsId}/{mciId}/vm/{vmId}")
+    @PutMapping("/{nsId}/{infraId}/node/{nodeId}")
     @Operation(summary = "PutVM", operationId = "PutVM", description = "Update target")
     public ResBody<VMDTO> putVM(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId,
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId,
             @RequestBody VMRequestDTO dto) {
-        return new ResBody<>(vmFacadeService.putVM(nsId, mciId, vmId, dto));
+        return new ResBody<>(vmFacadeService.putVM(nsId, infraId, nodeId, dto));
     }
 
-    @DeleteMapping("/{nsId}/{mciId}/vm/{vmId}")
+    @DeleteMapping("/{nsId}/{infraId}/node/{nodeId}")
     @Operation(summary = "DeleteVM", operationId = "DeleteVM", description = "Delete target")
     public ResBody<Void> deleteVM(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId,
-            @Parameter(description = "vmId (e.g., vm-1)", example = "vm-1") @PathVariable
-                    String vmId) {
-        vmFacadeService.deleteVM(nsId, mciId, vmId);
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId,
+            @Parameter(description = "nodeId (e.g., node-1)", example = "node-1") @PathVariable
+                    String nodeId) {
+        vmFacadeService.deleteVM(nsId, infraId, nodeId);
         return new ResBody<>();
     }
 
-    @GetMapping("/{nsId}/{mciId}/vm")
+    @GetMapping("/{nsId}/{infraId}/node")
     @Operation(
             summary = "GetVMByNsMci",
             operationId = "GetVMByNsMci",
@@ -89,12 +89,12 @@ public class VMController {
     public ResBody<List<VMDTO>> getVMByNsMci(
             @Parameter(description = "nsId (e.g., ns-1)", example = "ns-1") @PathVariable
                     String nsId,
-            @Parameter(description = "mciId (e.g., mci-1)", example = "mci-1") @PathVariable
-                    String mciId) {
-        return new ResBody<>(vmFacadeService.getVMsNsMci(nsId, mciId));
+            @Parameter(description = "infraId (e.g., infra-1)", example = "infra-1") @PathVariable
+                    String infraId) {
+        return new ResBody<>(vmFacadeService.getVMsNsMci(nsId, infraId));
     }
 
-    @GetMapping("/vm")
+    @GetMapping("/node")
     @Operation(
             summary = "GetAllVMs",
             operationId = "GetAllVMs",

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMWebSocketController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMWebSocketController.java
@@ -16,17 +16,17 @@ public class VMWebSocketController {
 
     private final VMFacadeService vmFacadeService;
 
-    @MessageMapping("/vm/{nsId}/{mciId]/{vmId}")
-    @SendTo("/topic/vm/{nsId}/{mciId]/{vmId}")
+    @MessageMapping("/node/{nsId}/{infraId}/{nodeId}")
+    @SendTo("/topic/node/{nsId}/{infraId}/{nodeId}")
     public VMDTO subscribeVMInfo(
             @DestinationVariable String nsId,
-            @DestinationVariable String mciId,
-            @DestinationVariable String vmId) {
-        return vmFacadeService.getVM(nsId, mciId, vmId);
+            @DestinationVariable String infraId,
+            @DestinationVariable String nodeId) {
+        return vmFacadeService.getVM(nsId, infraId, nodeId);
     }
 
-    @MessageMapping("/vms")
-    @SendTo("/topic/vms")
+    @MessageMapping("/nodes")
+    @SendTo("/topic/nodes")
     public Object subscribeAllVMs() {
         return vmFacadeService.getVMs();
     }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/host/ConfigDTO.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/host/ConfigDTO.java
@@ -13,11 +13,11 @@ import lombok.*;
 @Schema(description = "DTO for updating configuration")
 public class ConfigDTO {
 
-    private String vmId;
+    private String nodeId;
 
     private String nsId;
 
-    private String mciId;
+    private String infraId;
 
     @Schema(description = "File path", example = "telegraf.conf")
     @NotBlank private String path;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/influx/VmRef.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/influx/VmRef.java
@@ -1,4 +1,4 @@
 package com.mcmp.o11ymanager.manager.dto.influx;
 
 /** Lightweight identifier for a VM that has metric data in InfluxDB. */
-public record VmRef(String nsId, String mciId, String vmId) {}
+public record VmRef(String nsId, String infraId, String nodeId) {}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/item/MonitoringItemDTO.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/item/MonitoringItemDTO.java
@@ -17,11 +17,11 @@ public class MonitoringItemDTO {
     @Schema(description = "Namespace ID", example = "ns-1")
     private String nsId;
 
-    @Schema(description = "MCI ID", example = "mci-1")
-    private String mciId;
+    @Schema(description = "Infra ID", example = "infra-1")
+    private String infraId;
 
-    @Schema(description = "VM ID", example = "vm-1")
-    private String vmId;
+    @Schema(description = "Node ID", example = "node-1")
+    private String nodeId;
 
     @Schema(description = "VM name", example = "mcmp-vm")
     private String name;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/trace/TraceResponseDto.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/trace/TraceResponseDto.java
@@ -1,0 +1,79 @@
+package com.mcmp.o11ymanager.manager.dto.trace;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Trace responses surfaced to the UI. {@link TraceSummary} backs the list view; {@link TraceDetail}
+ * is the flattened span list for a single trace (no flame graph in MVP).
+ */
+public class TraceResponseDto {
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TraceSummary {
+        @Schema(description = "Trace ID")
+        private String traceId;
+
+        @Schema(description = "Root span service name")
+        private String rootService;
+
+        @Schema(description = "Root span name")
+        private String rootName;
+
+        @Schema(description = "Trace start time (epoch ms)")
+        private long startTimeMs;
+
+        @Schema(description = "Trace duration (ms)")
+        private long durationMs;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SpanRow {
+        @Schema(description = "Span ID")
+        private String spanId;
+
+        @Schema(description = "Parent span ID")
+        private String parentSpanId;
+
+        @Schema(description = "Service name")
+        private String service;
+
+        @Schema(description = "Span name")
+        private String name;
+
+        @Schema(description = "Span kind")
+        private String kind;
+
+        @Schema(description = "Span start time (epoch ms)")
+        private long startTimeMs;
+
+        @Schema(description = "Span duration (ms, fractional)")
+        private double durationMs;
+
+        @Schema(description = "Span attributes")
+        private Map<String, String> attributes;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TraceDetail {
+        @Schema(description = "Trace ID")
+        private String traceId;
+
+        @Schema(description = "Spans in the trace, sorted by start time")
+        private List<SpanRow> spans;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/VMInfo.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/VMInfo.java
@@ -14,7 +14,7 @@ public class VMInfo {
     private String nsId;
 
     @JsonProperty("infra_id")
-    private String mciId;
+    private String infraId;
 
     @JsonProperty("id")
     private String id;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/vm/ResultDTO.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/vm/ResultDTO.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 public class ResultDTO {
 
     private String nsId;
-    private String mciId;
-    private String vmId;
+    private String infraId;
+    private String nodeId;
     private ResponseStatus status;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/vm/VMDTO.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/vm/VMDTO.java
@@ -24,9 +24,9 @@ import lombok.Setter;
 @JsonInclude(Include.NON_NULL)
 public class VMDTO {
 
-    @Schema(description = "VM ID", example = "vm-1")
+    @Schema(description = "Node ID", example = "node-1")
     @JsonProperty("node_id")
-    private String vmId;
+    private String nodeId;
 
     @Schema(description = "VM name", example = "mcmp-vm")
     private String name;
@@ -77,9 +77,9 @@ public class VMDTO {
     @JsonProperty("ns_id")
     private String nsId;
 
-    @Schema(description = "MCI ID", example = "mci-1")
+    @Schema(description = "Infra ID", example = "infra-1")
     @JsonProperty("infra_id")
-    private String mciId;
+    private String infraId;
 
     @Schema(description = "Monitoring agent status", example = "SUCCESS")
     @JsonProperty("monitoring_agent_status")
@@ -95,7 +95,7 @@ public class VMDTO {
 
     public static VMDTO fromEntity(VMEntity entity) {
         return VMDTO.builder()
-                .vmId(entity.getVmId())
+                .nodeId(entity.getNodeId())
                 .name(entity.getName())
                 .description(entity.getDescription())
                 .influxSeq(entity.getInfluxSeq())
@@ -111,13 +111,13 @@ public class VMDTO {
                 .logAgentStatus(entity.getLogAgentStatus())
                 .traceAgentStatus(entity.getTraceAgentStatus())
                 .nsId(entity.getNsId())
-                .mciId(entity.getMciId())
+                .infraId(entity.getInfraId())
                 .build();
     }
 
     public VMEntity toEntity() {
         return VMEntity.builder()
-                .vmId(this.getVmId())
+                .nodeId(this.getNodeId())
                 .name(this.name)
                 .influxSeq(this.getInfluxSeq())
                 .vmStatus(this.getVmStatus())
@@ -135,7 +135,7 @@ public class VMDTO {
                 .logAgentStatus(this.logAgentStatus)
                 .traceAgentStatus(this.traceAgentStatus)
                 .nsId(this.nsId)
-                .mciId(this.mciId)
+                .infraId(this.infraId)
                 .build();
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/NodeId.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/NodeId.java
@@ -8,8 +8,8 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-public class VmId implements Serializable {
+public class NodeId implements Serializable {
     private String nsId;
-    private String mciId;
-    private String vmId;
+    private String infraId;
+    private String nodeId;
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/VMEntity.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/VMEntity.java
@@ -10,22 +10,22 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@Table(name = "vm")
+@Table(name = "node")
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @DynamicUpdate
-@IdClass(VmId.class)
+@IdClass(NodeId.class)
 @EntityListeners(AuditingEntityListener.class)
 public class VMEntity {
 
     @Id private String nsId;
 
-    @Id private String mciId;
+    @Id private String infraId;
 
-    @Id private String vmId;
+    @Id private String nodeId;
 
     @Column(name = "influx_id", nullable = false)
     private Long influxSeq;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/exception/target/VMAgentTaskProcessingException.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/exception/target/VMAgentTaskProcessingException.java
@@ -9,13 +9,13 @@ import lombok.Getter;
 public class VMAgentTaskProcessingException extends BaseException {
 
     public VMAgentTaskProcessingException(
-            String requestId, String vmId, String agentTypeName, VMAgentTaskStatus status) {
+            String requestId, String nodeId, String agentTypeName, VMAgentTaskStatus status) {
         super(
                 requestId,
                 ErrorCode.AGENT_TASK_IN_PROGRESS,
                 String.format(
                         "Agent task %s is in progress on host (ID: %s). (Current status: %s)",
-                        agentTypeName, vmId, status));
+                        agentTypeName, nodeId, status));
     }
 
     public VMAgentTaskProcessingException(String requestId, String idsSummary) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
@@ -43,9 +43,9 @@ public class AgentFacadeService {
     private final TumblebugService tumblebugService;
     private final VMService vmService;
 
-    private AccessInfoDTO getAccessInfo(String nsId, String mciId, String vmId) {
+    private AccessInfoDTO getAccessInfo(String nsId, String infraId, String nodeId) {
 
-        TumblebugInfra.Node node = tumblebugPort.getNode(nsId, mciId, vmId);
+        TumblebugInfra.Node node = tumblebugPort.getNode(nsId, infraId, nodeId);
         TumblebugSshKey sshKey = tumblebugPort.getSshKey(nsId, node.getSshKeyId());
 
         if (sshKey == null) {
@@ -64,27 +64,27 @@ public class AgentFacadeService {
     }
 
     public AgentServiceStatus getAgentServiceStatus(
-            String nsId, String mciId, String vmId, Agent agent) {
-        boolean isActive = tumblebugService.isServiceActive(nsId, mciId, vmId, agent);
+            String nsId, String infraId, String nodeId, Agent agent) {
+        boolean isActive = tumblebugService.isServiceActive(nsId, infraId, nodeId, agent);
         return isActive ? AgentServiceStatus.ACTIVE : AgentServiceStatus.INACTIVE;
     }
 
-    public List<ResultDTO> install(String nsId, String mciId, String vmId) {
-        return install(nsId, mciId, vmId, false);
+    public List<ResultDTO> install(String nsId, String infraId, String nodeId) {
+        return install(nsId, infraId, nodeId, false);
     }
 
     // gpu: NVIDIA GPU 노드 여부. true면 telegraf 설치 시 DCGM Exporter 설치 +
     // GPU 메트릭 수집(prometheus input + starlark processor) 설정이 포함된다.
-    public List<ResultDTO> install(String nsId, String mciId, String vmId, boolean gpu) {
+    public List<ResultDTO> install(String nsId, String infraId, String nodeId, boolean gpu) {
 
         log.info(
-                "=================================== Start Agent Installation - vmId: {} ===========================================",
-                vmId);
+                "=================================== Start Agent Installation - nodeId: {} ===========================================",
+                nodeId);
 
         List<ResultDTO> results = new ArrayList<>();
 
         try {
-            AccessInfoDTO accessInfo = getAccessInfo(nsId, mciId, vmId);
+            AccessInfoDTO accessInfo = getAccessInfo(nsId, infraId, nodeId);
 
             // 1) Acquire lock
             int templateCount;
@@ -97,16 +97,16 @@ public class AgentFacadeService {
 
             // 2) Install agent
             // 2-1) Install Telegraf
-            telegrafFacadeService.install(nsId, mciId, vmId, accessInfo, templateCount, gpu);
+            telegrafFacadeService.install(nsId, infraId, nodeId, accessInfo, templateCount, gpu);
 
             // 2-2) Install FluentBit
-            fluentBitFacadeService.install(nsId, mciId, vmId, accessInfo, templateCount);
+            fluentBitFacadeService.install(nsId, infraId, nodeId, accessInfo, templateCount);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
 
@@ -114,8 +114,8 @@ public class AgentFacadeService {
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());
@@ -125,11 +125,11 @@ public class AgentFacadeService {
     }
 
     @Transactional
-    public List<ResultDTO> update(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> update(String nsId, String infraId, String nodeId) {
         List<ResultDTO> results = new ArrayList<>();
 
         try {
-            AccessInfoDTO accessInfo = getAccessInfo(nsId, mciId, vmId);
+            AccessInfoDTO accessInfo = getAccessInfo(nsId, infraId, nodeId);
 
             // 1) Lock 걸기
             int templateCount;
@@ -142,24 +142,24 @@ public class AgentFacadeService {
 
             // 2 ) 에이전트 업데이트
             // 2-1 ) Telegraf 업데이트
-            telegrafFacadeService.update(nsId, mciId, vmId, accessInfo, templateCount);
+            telegrafFacadeService.update(nsId, infraId, nodeId, accessInfo, templateCount);
 
             // 2-1 ) FluentBit 업데이트
-            fluentBitFacadeService.update(nsId, mciId, vmId, accessInfo, templateCount);
+            fluentBitFacadeService.update(nsId, infraId, nodeId, accessInfo, templateCount);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
         } catch (Exception e) {
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());
@@ -191,16 +191,16 @@ public class AgentFacadeService {
         return semaphoreConfigUpdateTemplateCurrentCount;
     }
 
-    public AgentStatus getAgentStatus(String nsId, String mciId, String vmId, Agent agent) {
+    public AgentStatus getAgentStatus(String nsId, String infraId, String nodeId, Agent agent) {
         VMAgentTaskStatus taskStatus;
 
         if (agent == Agent.TELEGRAF) {
-            taskStatus = vmService.getMonitoringAgentTaskStatus(nsId, mciId, vmId);
+            taskStatus = vmService.getMonitoringAgentTaskStatus(nsId, infraId, nodeId);
         } else if (agent == Agent.FLUENT_BIT) {
-            taskStatus = vmService.getLogAgentTaskStatus(nsId, mciId, vmId);
+            taskStatus = vmService.getLogAgentTaskStatus(nsId, infraId, nodeId);
         } else if (agent == Agent.BEYLA || agent == Agent.OTEL_JAVA_AGENT) {
             // 두 agent 모두 동일한 vmTraceAgentTaskStatus 컬럼을 공유한다 (Linux Beyla / Windows OTel Java).
-            taskStatus = vmService.getTraceAgentTaskStatus(nsId, mciId, vmId);
+            taskStatus = vmService.getTraceAgentTaskStatus(nsId, infraId, nodeId);
         } else {
             throw new IllegalArgumentException("Unknown agent type: " + agent);
         }
@@ -212,7 +212,7 @@ public class AgentFacadeService {
             return AgentStatus.FAILED;
         }
 
-        AgentServiceStatus serviceStatus = getAgentServiceStatus(nsId, mciId, vmId, agent);
+        AgentServiceStatus serviceStatus = getAgentServiceStatus(nsId, infraId, nodeId, agent);
 
         if (serviceStatus == AgentServiceStatus.ACTIVE) {
             return AgentStatus.SUCCESS;
@@ -223,11 +223,11 @@ public class AgentFacadeService {
 
     @Transactional
     @Base64Decode(ConfigDTO.class)
-    public List<ResultDTO> uninstall(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> uninstall(String nsId, String infraId, String nodeId) {
 
         List<ResultDTO> results = new ArrayList<>();
 
-        AccessInfoDTO accessInfo = getAccessInfo(nsId, mciId, vmId);
+        AccessInfoDTO accessInfo = getAccessInfo(nsId, infraId, nodeId);
 
         try {
             int templateCount;
@@ -240,24 +240,24 @@ public class AgentFacadeService {
 
             // 4 ) 에이전트 제거
             // 4-1 ) Telegraf 제거
-            telegrafFacadeService.uninstall(nsId, mciId, vmId, accessInfo, templateCount);
+            telegrafFacadeService.uninstall(nsId, infraId, nodeId, accessInfo, templateCount);
 
             // 4-1 ) FluentBit 제거
-            fluentBitFacadeService.uninstall(nsId, mciId, vmId, accessInfo, templateCount);
+            fluentBitFacadeService.uninstall(nsId, infraId, nodeId, accessInfo, templateCount);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
         } catch (Exception e) {
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaConfigFacadeService.java
@@ -37,7 +37,7 @@ public class BeylaConfigFacadeService {
             new ClassPathResource("beyla_template.yaml");
 
     /** install 시점에 호출되어, target VM에 배포할 beyla.yaml 내용을 문자열로 반환한다. */
-    public String initBeylaConfig(String nsId, String mciId, String vmId) {
+    public String initBeylaConfig(String nsId, String infraId, String nodeId) {
         if (!beylaConfigTemplate.exists()) {
             String errMsg = "Invalid filePath : beylaConfigTemplate (beyla_template.yaml)";
             log.error(errMsg);
@@ -48,14 +48,14 @@ public class BeylaConfigFacadeService {
         fileService.appendConfig(beylaConfigTemplate, sb);
 
         String finalNsId = (nsId != null) ? nsId : "";
-        String finalMciId = (mciId != null) ? mciId : "";
-        String finalVmId = (vmId != null) ? vmId : "";
+        String finalInfraId = (infraId != null) ? infraId : "";
+        String finalNodeId = (nodeId != null) ? nodeId : "";
 
         return sb.toString()
                 .replace("@SITE_CODE", deploySiteCode)
                 .replace("@NS_ID", finalNsId)
-                .replace("@INFRA_ID", finalMciId)
-                .replace("@NODE_ID", finalVmId)
+                .replace("@INFRA_ID", finalInfraId)
+                .replace("@NODE_ID", finalNodeId)
                 .replace("@OTEL_ENDPOINT", otelEndpoint);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaFacadeService.java
@@ -38,24 +38,24 @@ public class BeylaFacadeService {
 
     public void install(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
         log.info("==========================beyla idle start===============================");
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
         log.info("==========================beyla idle finish===============================");
 
         log.info(
                 "==========================beyla system requirement check start===============================");
-        beylaSystemRequirementValidator.validateAndThrow(nsId, mciId, vmId);
+        beylaSystemRequirementValidator.validateAndThrow(nsId, infraId, nodeId);
         // 해당 vm에서 Beyla를 설치하기 위해 커널 버전 및 BTF 파일 존재 유뮤 확인
         log.info(
                 "==========================beyla system requirement check finish===============================");
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING);
         // 특정 VM의 작업 상태를 DB에 업데이트 (작업 생태를 INSTALLING으로 변환)
         log.info("==========================update vm status===============================");
 
@@ -65,7 +65,7 @@ public class BeylaFacadeService {
         // BeylaConfigFacadeService에서 ClassPath의 beyla_template.yaml + application.yaml의
         // beyla.otel-endpoint를 합쳐 최종 yaml 생성. install 직후 chained config-update가
         // 이 conf로 원격의 정적 placeholder yaml을 덮어씀.
-        String configContent = beylaConfigFacadeService.initBeylaConfig(nsId, mciId, vmId);
+        String configContent = beylaConfigFacadeService.initBeylaConfig(nsId, infraId, nodeId);
         log.info("Beyla config: {}", configContent);
 
         Task task;
@@ -79,7 +79,7 @@ public class BeylaFacadeService {
                             templateCount);
         } catch (Exception e) {
             // Semaphore 호출 실패 시 상태를 IDLE로 되돌려 재시도가 가능하도록 함
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
@@ -87,7 +87,7 @@ public class BeylaFacadeService {
                 "=========================FINISH BEYLA INSTALL REQUEST============================");
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
 
         log.info(
                 "==========================update vm status task ID: {}============================",
@@ -99,23 +99,23 @@ public class BeylaFacadeService {
                 // 스레드에서 꺼낼 수 없기 때문입니다. (RequestIdAspect 참고)
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.INSTALL,
                 Agent.BEYLA);
     }
 
     public void update(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.UPDATING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING);
 
         Task task;
         try {
@@ -128,29 +128,33 @@ public class BeylaFacadeService {
                             templateCount);
         } catch (Exception e) {
             // Semaphore 호출 실패 시 상태를 IDLE로 되돌려 재시도가 가능하도록 함
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UPDATE,
                 Agent.BEYLA);
     }
 
     public void uninstall(
-            String nsId, String mciId, String vmId, AccessInfoDTO accessInfo, int templateCount) {
+            String nsId,
+            String infraId,
+            String nodeId,
+            AccessInfoDTO accessInfo,
+            int templateCount) {
 
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.PREPARING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.PREPARING);
 
         Task task;
         try {
@@ -163,57 +167,62 @@ public class BeylaFacadeService {
                             templateCount);
         } catch (Exception e) {
             // Semaphore 호출 실패 시 상태를 IDLE로 되돌려 재시도가 가능하도록 함
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UNINSTALLING, String.valueOf(task.getId()));
+                nsId,
+                infraId,
+                nodeId,
+                VMAgentTaskStatus.UNINSTALLING,
+                String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UNINSTALL,
                 Agent.BEYLA);
     }
 
     @Transactional
-    public List<ResultDTO> restart(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> restart(String nsId, String infraId, String nodeId) {
 
         List<ResultDTO> results = new ArrayList<>();
 
         try {
             agentTaskStatusLock.lock();
 
-            vmService.isIdleTraceAgent(nsId, mciId, vmId);
+            vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.RESTARTING);
+            vmService.updateTraceAgentTaskStatus(
+                    nsId, infraId, nodeId, VMAgentTaskStatus.RESTARTING);
 
-            tumblebugService.restart(nsId, mciId, vmId, Agent.BEYLA);
+            tumblebugService.restart(nsId, infraId, nodeId, Agent.BEYLA);
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
             agentTaskStatusLock.unlock();
         } catch (Exception e) {
             agentTaskStatusLock.unlock();
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitConfigFacadeService.java
@@ -20,7 +20,7 @@ public class FluentBitConfigFacadeService {
     private final ClassPathResource fluentBitVariables =
             new ClassPathResource("fluent-bit_variables");
 
-    public String initFluentbitConfig(String nsId, String mciId, String vmId) {
+    public String initFluentbitConfig(String nsId, String infraId, String nodeId) {
         String template = fileService.getFileContent(fluentBitVariables);
 
         String[] lokiURLSplit = lokiURL.split("://");
@@ -39,15 +39,15 @@ public class FluentBitConfigFacadeService {
         fileService.appendConfig(fluentBitVariables, sb);
 
         nsId = nsId != null ? nsId : "";
-        mciId = mciId != null ? mciId : "";
-        vmId = vmId != null ? vmId : "";
+        infraId = infraId != null ? infraId : "";
+        nodeId = nodeId != null ? nodeId : "";
         lokiHost = lokiHost != null ? lokiHost : "";
 
-        log.debug("VM={}/{}/{}", nsId, mciId, vmId);
+        log.debug("VM={}/{}/{}", nsId, infraId, nodeId);
 
         return template.replace("@NS_ID", nsId)
-                .replace("@INFRA_ID", mciId)
-                .replace("@NODE_ID", vmId)
+                .replace("@INFRA_ID", infraId)
+                .replace("@NODE_ID", nodeId)
                 .replace("@LOKI_HOST", lokiHost);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitFacadeService.java
@@ -34,19 +34,20 @@ public class FluentBitFacadeService {
 
     public void install(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
         // 1. Check if host is in IDLE state
-        vmService.isIdleLogAgent(nsId, mciId, vmId);
+        vmService.isIdleLogAgent(nsId, infraId, nodeId);
 
         // 2. Update host status
-        vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING);
+        vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING);
 
-        String configContent = fluentBitConfigFacadeService.initFluentbitConfig(nsId, mciId, vmId);
+        String configContent =
+                fluentBitConfigFacadeService.initFluentbitConfig(nsId, infraId, nodeId);
 
         log.info(String.format("Fluent-Bit config: %s", configContent));
 
@@ -61,32 +62,32 @@ public class FluentBitFacadeService {
 
         // 5. Update task ID and task status
         vmService.updateLogAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
 
         // 7. Register scheduler
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.INSTALL,
                 Agent.FLUENT_BIT);
     }
 
     public void update(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
         // 1. Check if host is in IDLE state
-        vmService.isIdleLogAgent(nsId, mciId, vmId);
+        vmService.isIdleLogAgent(nsId, infraId, nodeId);
 
         // 2. Update host status
-        vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.UPDATING);
+        vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING);
 
         // 3. Send (via semaphore) - update request
         Task task =
@@ -99,27 +100,31 @@ public class FluentBitFacadeService {
 
         // 4. Update task ID and task status
         vmService.updateLogAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
 
         // 6. Register scheduler
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UPDATE,
                 Agent.FLUENT_BIT);
     }
 
     public void uninstall(
-            String nsId, String mciId, String vmId, AccessInfoDTO accessInfo, int templateCount) {
+            String nsId,
+            String infraId,
+            String nodeId,
+            AccessInfoDTO accessInfo,
+            int templateCount) {
 
         // 1) Check current status
-        vmService.isIdleLogAgent(nsId, mciId, vmId);
+        vmService.isIdleLogAgent(nsId, infraId, nodeId);
 
         // 2) Update status
-        vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.PREPARING);
+        vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.PREPARING);
 
         // 3. Send (via semaphore) - uninstall request
         Task task =
@@ -132,54 +137,58 @@ public class FluentBitFacadeService {
 
         // 5. Update task ID and task status
         vmService.updateLogAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UNINSTALLING, String.valueOf(task.getId()));
+                nsId,
+                infraId,
+                nodeId,
+                VMAgentTaskStatus.UNINSTALLING,
+                String.valueOf(task.getId()));
 
         // 6) Register scheduler
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UNINSTALL,
                 Agent.FLUENT_BIT);
     }
 
     @Transactional
-    public List<ResultDTO> restart(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> restart(String nsId, String infraId, String nodeId) {
         List<ResultDTO> results = new ArrayList<>();
 
         try {
             agentTaskStatusLock.lock();
 
             // 1. Check if host is in IDLE state
-            vmService.isIdleLogAgent(nsId, mciId, vmId);
+            vmService.isIdleLogAgent(nsId, infraId, nodeId);
 
             // 2. Change status to RESTARTING
-            vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.RESTARTING);
+            vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.RESTARTING);
 
             // TODO: Use Tumblebug CMD - 3. Execute restart
 
-            vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
             agentTaskStatusLock.unlock();
         } catch (Exception e) {
             agentTaskStatusLock.unlock();
 
-            vmService.updateLogAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateLogAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/GpuMonitoringFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/GpuMonitoringFacadeService.java
@@ -62,7 +62,7 @@ public class GpuMonitoringFacadeService {
 
     /** 각 GPU 메트릭 필드에 최근(5분) 데이터가 쌓이고 있는지 확인 */
     public List<GpuMetricFieldCheckDTO> checkGpuMetricFields(
-            String nsId, String mciId, String vmId) {
+            String nsId, String infraId, String nodeId) {
 
         List<GpuMetricFieldCheckDTO> results = new ArrayList<>();
 
@@ -79,7 +79,8 @@ public class GpuMonitoringFacadeService {
 
             boolean hasData;
             try {
-                List<MetricDTO> metrics = influxDbService.getMetricsByVM(nsId, mciId, vmId, req);
+                List<MetricDTO> metrics =
+                        influxDbService.getMetricsByVM(nsId, infraId, nodeId, req);
                 hasData =
                         metrics != null
                                 && metrics.stream()
@@ -101,8 +102,8 @@ public class GpuMonitoringFacadeService {
                         "Failed to check GPU metric field {} for {}/{}/{}: {}",
                         field.getFieldName(),
                         nsId,
-                        mciId,
-                        vmId,
+                        infraId,
+                        nodeId,
                         e.getMessage());
                 hasData = false;
             }
@@ -119,7 +120,7 @@ public class GpuMonitoringFacadeService {
 
     /** GPU 메트릭 조회: 요청 필드를 검증하고 measurement를 dcgm으로 고정해 조회 */
     public List<MetricDTO> getGpuMetrics(
-            String nsId, String mciId, String vmId, MetricRequestDTO req) {
+            String nsId, String infraId, String nodeId, MetricRequestDTO req) {
 
         // 요청 필드가 정의된 GPU 메트릭 필드인지 검증
         if (req.getFields() != null) {
@@ -131,6 +132,6 @@ public class GpuMonitoringFacadeService {
         // GPU 메트릭은 항상 dcgm measurement에서 조회
         req.setMeasurement(GpuMetricKeyField.GPU_MEASUREMENT);
 
-        return influxDbService.getMetricsByVM(nsId, mciId, vmId, req);
+        return influxDbService.getMetricsByVM(nsId, infraId, nodeId, req);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/InfluxDbFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/InfluxDbFacadeService.java
@@ -20,8 +20,8 @@ public class InfluxDbFacadeService {
     private final InfluxDbService influxDbService;
 
     @Transactional(readOnly = true)
-    public InfluxDTO resolveForVM(String nsId, String mciId) {
-        return influxDbService.resolveInfluxDto(nsId, mciId);
+    public InfluxDTO resolveForVM(String nsId, String infraId) {
+        return influxDbService.resolveInfluxDto(nsId, infraId);
     }
 
     public List<TagDTO> getTags() {
@@ -32,13 +32,13 @@ public class InfluxDbFacadeService {
         return influxDbService.getFields().getData();
     }
 
-    public List<MetricDTO> postMetricsByNsMci(String nsId, String mciId, MetricRequestDTO req) {
-        return influxDbService.getMetricsByNsMci(nsId, mciId, req);
+    public List<MetricDTO> postMetricsByNsMci(String nsId, String infraId, MetricRequestDTO req) {
+        return influxDbService.getMetricsByNsMci(nsId, infraId, req);
     }
 
     public List<MetricDTO> postMetricsByVM(
-            String nsId, String mciId, String vmId, MetricRequestDTO req) {
-        return influxDbService.getMetricsByVM(nsId, mciId, vmId, req);
+            String nsId, String infraId, String nodeId, MetricRequestDTO req) {
+        return influxDbService.getMetricsByVM(nsId, infraId, nodeId, req);
     }
 
     public List<InfluxDTO> getInfluxDbs() {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/ItemFacadeService.java
@@ -48,23 +48,24 @@ public class ItemFacadeService {
     }
 
     public void addTelegrafPlugin(
-            String nsId, String mciId, String vmId, MonitoringItemRequestDTO dto) {
+            String nsId, String infraId, String nodeId, MonitoringItemRequestDTO dto) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             if (node == null) {
-                String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                String errorMsg =
+                        String.format("VM not found for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);
             }
 
-            if (!tumblebugService.isConnectedVM(nsId, mciId, vmId)) {
+            if (!tumblebugService.isConnectedVM(nsId, infraId, nodeId)) {
                 String errorMsg =
-                        String.format("VM not connected for vm: %s/%s/%s", nsId, mciId, vmId);
+                        String.format("VM not connected for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.VM_CONNECTION_FAILED, errorMsg);
             }
@@ -83,12 +84,13 @@ public class ItemFacadeService {
             // read config
             String configContent =
                     tumblebugService.executeCommand(
-                            nsId, mciId, vmId, "sudo cat " + getTelegrafConfigPath());
+                            nsId, infraId, nodeId, "sudo cat " + getTelegrafConfigPath());
 
             if (configContent == null || configContent.isEmpty()) {
                 String errorMsg =
                         String.format(
-                                "Telegraf config not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                                "Telegraf config not found for vm: %s/%s/%s",
+                                nsId, infraId, nodeId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.TELEGRAF_CONFIG_NOT_FOUND, errorMsg);
             }
@@ -105,16 +107,17 @@ public class ItemFacadeService {
                     String.format(
                             "echo '%s' | sudo tee %s > /dev/null",
                             updatedConfig.replace("'", "'\"'\"'"), getTelegrafConfigPath());
-            tumblebugService.executeCommand(nsId, mciId, vmId, updateCommand);
+            tumblebugService.executeCommand(nsId, infraId, nodeId, updateCommand);
 
-            telegrafFacadeService.restart(nsId, mciId, vmId);
+            telegrafFacadeService.restart(nsId, infraId, nodeId);
 
         } catch (TelegrafConfigException e) {
             throw e;
         } catch (Exception e) {
             String errorMsg =
                     String.format(
-                            "Failed to add telegraf plugin for vm: %s/%s/%s", nsId, mciId, vmId);
+                            "Failed to add telegraf plugin for vm: %s/%s/%s",
+                            nsId, infraId, nodeId);
             log.error(errorMsg, e);
             throw new TelegrafConfigException(
                     ResponseCode.INTERNAL_SERVER_ERROR, errorMsg + ": " + e.getMessage());
@@ -124,23 +127,24 @@ public class ItemFacadeService {
     }
 
     public void updateTelegrafPlugin(
-            String nsId, String mciId, String vmId, MonitoringItemUpdateDTO dto) {
+            String nsId, String infraId, String nodeId, MonitoringItemUpdateDTO dto) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             if (node == null) {
-                String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                String errorMsg =
+                        String.format("VM not found for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);
             }
 
-            if (!tumblebugService.isConnectedVM(nsId, mciId, vmId)) {
+            if (!tumblebugService.isConnectedVM(nsId, infraId, nodeId)) {
                 String errorMsg =
-                        String.format("VM not connected for vm: %s/%s/%s", nsId, mciId, vmId);
+                        String.format("VM not connected for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.VM_CONNECTION_FAILED, errorMsg);
             }
@@ -148,18 +152,19 @@ public class ItemFacadeService {
             // read config and parsing
             String configContent =
                     tumblebugService.executeCommand(
-                            nsId, mciId, vmId, "sudo cat " + getTelegrafConfigPath());
+                            nsId, infraId, nodeId, "sudo cat " + getTelegrafConfigPath());
 
             if (configContent == null || configContent.isEmpty()) {
                 String errorMsg =
                         String.format(
-                                "Telegraf config not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                                "Telegraf config not found for vm: %s/%s/%s",
+                                nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.TELEGRAF_CONFIG_NOT_FOUND, errorMsg);
             }
 
             // update plugin
-            List<MonitoringItemDTO> currentItems = getTelegrafItems(nsId, mciId, vmId);
+            List<MonitoringItemDTO> currentItems = getTelegrafItems(nsId, infraId, nodeId);
             MonitoringItemDTO vmItem =
                     currentItems.stream()
                             .filter(item -> item.getSeq().equals(dto.getSeq()))
@@ -180,15 +185,16 @@ public class ItemFacadeService {
                     String.format(
                             "echo '%s' | sudo tee %s > /dev/null",
                             updatedConfig.replace("'", "'\"'\"'"), getTelegrafConfigPath());
-            tumblebugService.executeCommand(nsId, mciId, vmId, updateCommand);
+            tumblebugService.executeCommand(nsId, infraId, nodeId, updateCommand);
 
-            telegrafFacadeService.restart(nsId, mciId, vmId);
+            telegrafFacadeService.restart(nsId, infraId, nodeId);
         } catch (TelegrafConfigException e) {
             throw e;
         } catch (Exception e) {
             String errorMsg =
                     String.format(
-                            "Failed to update telegraf plugin for vm: %s/%s/%s", nsId, mciId, vmId);
+                            "Failed to update telegraf plugin for vm: %s/%s/%s",
+                            nsId, infraId, nodeId);
             log.error(errorMsg, e);
             throw new TelegrafConfigException(
                     ResponseCode.INTERNAL_SERVER_ERROR, errorMsg + ": " + e.getMessage());
@@ -197,40 +203,42 @@ public class ItemFacadeService {
         }
     }
 
-    public void deleteTelegrafPlugin(String nsId, String mciId, String vmId, Long itemSeq) {
+    public void deleteTelegrafPlugin(String nsId, String infraId, String nodeId, Long itemSeq) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             if (node == null) {
-                String errorMsg = String.format("VM not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                String errorMsg =
+                        String.format("VM not found for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.error(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.NOT_FOUND, errorMsg);
             }
 
-            if (!tumblebugService.isConnectedVM(nsId, mciId, vmId)) {
+            if (!tumblebugService.isConnectedVM(nsId, infraId, nodeId)) {
                 String errorMsg =
-                        String.format("VM not connected for vm: %s/%s/%s", nsId, mciId, vmId);
+                        String.format("VM not connected for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.VM_CONNECTION_FAILED, errorMsg);
             }
 
             String configContent =
                     tumblebugService.executeCommand(
-                            nsId, mciId, vmId, "sudo cat " + getTelegrafConfigPath());
+                            nsId, infraId, nodeId, "sudo cat " + getTelegrafConfigPath());
 
             if (configContent == null || configContent.isEmpty()) {
                 String errorMsg =
                         String.format(
-                                "Telegraf config not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                                "Telegraf config not found for vm: %s/%s/%s",
+                                nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.TELEGRAF_CONFIG_NOT_FOUND, errorMsg);
             }
 
-            List<MonitoringItemDTO> currentItems = getTelegrafItems(nsId, mciId, vmId);
+            List<MonitoringItemDTO> currentItems = getTelegrafItems(nsId, infraId, nodeId);
             MonitoringItemDTO vmItem =
                     currentItems.stream()
                             .filter(item -> item.getSeq().equals(itemSeq))
@@ -247,15 +255,16 @@ public class ItemFacadeService {
                     String.format(
                             "echo '%s' | sudo tee %s > /dev/null",
                             updatedConfig.replace("'", "'\"'\"'"), getTelegrafConfigPath());
-            tumblebugService.executeCommand(nsId, mciId, vmId, updateCommand);
+            tumblebugService.executeCommand(nsId, infraId, nodeId, updateCommand);
 
-            telegrafFacadeService.restart(nsId, mciId, vmId);
+            telegrafFacadeService.restart(nsId, infraId, nodeId);
         } catch (TelegrafConfigException e) {
             throw e;
         } catch (Exception e) {
             String errorMsg =
                     String.format(
-                            "Failed to delete telegraf plugin for vm: %s/%s/%s", nsId, mciId, vmId);
+                            "Failed to delete telegraf plugin for vm: %s/%s/%s",
+                            nsId, infraId, nodeId);
             log.error(errorMsg, e);
             throw new TelegrafConfigException(
                     ResponseCode.INTERNAL_SERVER_ERROR, errorMsg + ": " + e.getMessage());
@@ -268,28 +277,29 @@ public class ItemFacadeService {
         return "[[inputs." + name + "]]";
     }
 
-    public List<MonitoringItemDTO> getTelegrafItems(String nsId, String mciId, String vmId) {
+    public List<MonitoringItemDTO> getTelegrafItems(String nsId, String infraId, String nodeId) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            if (!tumblebugService.isConnectedVM(nsId, mciId, vmId)) {
+            if (!tumblebugService.isConnectedVM(nsId, infraId, nodeId)) {
                 String errorMsg =
-                        String.format("VM not connected for vm: %s/%s/%s", nsId, mciId, vmId);
+                        String.format("VM not connected for vm: %s/%s/%s", nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.VM_CONNECTION_FAILED, errorMsg);
             }
 
             String configContent =
                     tumblebugService.executeCommand(
-                            nsId, mciId, vmId, "sudo cat " + getTelegrafConfigPath());
+                            nsId, infraId, nodeId, "sudo cat " + getTelegrafConfigPath());
 
             if (configContent == null || configContent.isEmpty()) {
                 String errorMsg =
                         String.format(
-                                "Telegraf config not found for vm: %s/%s/%s", nsId, mciId, vmId);
+                                "Telegraf config not found for vm: %s/%s/%s",
+                                nsId, infraId, nodeId);
                 log.warn(errorMsg);
                 throw new TelegrafConfigException(ResponseCode.TELEGRAF_CONFIG_NOT_FOUND, errorMsg);
             }
@@ -317,8 +327,8 @@ public class ItemFacadeService {
                         MonitoringItemDTO.builder()
                                 .seq((long) seq++)
                                 .nsId(nsId)
-                                .mciId(mciId)
-                                .vmId(vmId)
+                                .infraId(infraId)
+                                .nodeId(nodeId)
                                 .name(plugin.getName())
                                 .state("ACTIVE")
                                 .pluginSeq(pluginDef != null ? pluginDef.getSeq() : null)
@@ -337,7 +347,8 @@ public class ItemFacadeService {
         } catch (Exception e) {
             String errorMsg =
                     String.format(
-                            "Failed to read telegraf config for vm: %s/%s/%s", nsId, mciId, vmId);
+                            "Failed to read telegraf config for vm: %s/%s/%s",
+                            nsId, infraId, nodeId);
             log.error(errorMsg, e);
             throw new TelegrafConfigException(
                     ResponseCode.INTERNAL_SERVER_ERROR, errorMsg + ": " + e.getMessage());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/OtelJavaConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/OtelJavaConfigFacadeService.java
@@ -44,7 +44,7 @@ public class OtelJavaConfigFacadeService {
             new ClassPathResource("otel_java_template.properties");
 
     /** install 시점에 호출되어, target VM에 배포할 OTel Java 환경변수 묶음을 문자열로 반환한다. */
-    public String initOtelJavaConfig(String nsId, String mciId, String vmId) {
+    public String initOtelJavaConfig(String nsId, String infraId, String nodeId) {
         if (!otelJavaConfigTemplate.exists()) {
             String errMsg =
                     "Invalid filePath : otelJavaConfigTemplate (otel_java_template.properties)";
@@ -56,14 +56,14 @@ public class OtelJavaConfigFacadeService {
         fileService.appendConfig(otelJavaConfigTemplate, sb);
 
         String finalNsId = (nsId != null) ? nsId : "";
-        String finalMciId = (mciId != null) ? mciId : "";
-        String finalVmId = (vmId != null) ? vmId : "";
+        String finalInfraId = (infraId != null) ? infraId : "";
+        String finalNodeId = (nodeId != null) ? nodeId : "";
 
         return sb.toString()
                 .replace("@SITE_CODE", deploySiteCode)
                 .replace("@NS_ID", finalNsId)
-                .replace("@INFRA_ID", finalMciId)
-                .replace("@NODE_ID", finalVmId)
+                .replace("@INFRA_ID", finalInfraId)
+                .replace("@NODE_ID", finalNodeId)
                 .replace("@OTEL_ENDPOINT", otelEndpoint)
                 .replace("@JAR_URL", jarUrl)
                 .replace("@JAR_PATH", jarPath);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/OtelJavaFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/OtelJavaFacadeService.java
@@ -49,17 +49,18 @@ public class OtelJavaFacadeService {
 
     public void install(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING);
 
-        String configContent = otelJavaConfigFacadeService.initOtelJavaConfig(nsId, mciId, vmId);
+        String configContent =
+                otelJavaConfigFacadeService.initOtelJavaConfig(nsId, infraId, nodeId);
         log.info("OTel Java config: {}", configContent);
 
         Task task;
@@ -72,34 +73,34 @@ public class OtelJavaFacadeService {
                             Agent.OTEL_JAVA_AGENT,
                             templateCount);
         } catch (Exception e) {
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.INSTALL,
                 Agent.OTEL_JAVA_AGENT);
     }
 
     public void update(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.UPDATING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING);
 
         Task task;
         try {
@@ -111,29 +112,33 @@ public class OtelJavaFacadeService {
                             Agent.OTEL_JAVA_AGENT,
                             templateCount);
         } catch (Exception e) {
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UPDATE,
                 Agent.OTEL_JAVA_AGENT);
     }
 
     public void uninstall(
-            String nsId, String mciId, String vmId, AccessInfoDTO accessInfo, int templateCount) {
+            String nsId,
+            String infraId,
+            String nodeId,
+            AccessInfoDTO accessInfo,
+            int templateCount) {
 
-        vmService.isIdleTraceAgent(nsId, mciId, vmId);
+        vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-        vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.PREPARING);
+        vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.PREPARING);
 
         Task task;
         try {
@@ -145,57 +150,62 @@ public class OtelJavaFacadeService {
                             Agent.OTEL_JAVA_AGENT,
                             templateCount);
         } catch (Exception e) {
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
             throw e;
         }
 
         vmService.updateTraceAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UNINSTALLING, String.valueOf(task.getId()));
+                nsId,
+                infraId,
+                nodeId,
+                VMAgentTaskStatus.UNINSTALLING,
+                String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UNINSTALL,
                 Agent.OTEL_JAVA_AGENT);
     }
 
     @Transactional
-    public List<ResultDTO> restart(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> restart(String nsId, String infraId, String nodeId) {
 
         List<ResultDTO> results = new ArrayList<>();
 
         try {
             agentTaskStatusLock.lock();
 
-            vmService.isIdleTraceAgent(nsId, mciId, vmId);
+            vmService.isIdleTraceAgent(nsId, infraId, nodeId);
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.RESTARTING);
+            vmService.updateTraceAgentTaskStatus(
+                    nsId, infraId, nodeId, VMAgentTaskStatus.RESTARTING);
 
-            tumblebugService.restart(nsId, mciId, vmId, Agent.OTEL_JAVA_AGENT);
+            tumblebugService.restart(nsId, infraId, nodeId, Agent.OTEL_JAVA_AGENT);
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
             agentTaskStatusLock.unlock();
         } catch (Exception e) {
             agentTaskStatusLock.unlock();
 
-            vmService.updateTraceAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateTraceAgentTaskStatus(nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/SchedulerFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/SchedulerFacadeService.java
@@ -63,8 +63,8 @@ public class SchedulerFacadeService {
             String requestId,
             Integer taskId,
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             SemaphoreInstallMethod method,
             Agent agent) {
 
@@ -94,8 +94,8 @@ public class SchedulerFacadeService {
                                         "Task Status - Request ID: {}, VM: {}/{}/{}, Agent: {}, Method: {}, Task ID: {}, Status: {}",
                                         requestId,
                                         nsId,
-                                        mciId,
-                                        vmId,
+                                        infraId,
+                                        nodeId,
                                         agent,
                                         method,
                                         currentTask.getId(),
@@ -117,20 +117,20 @@ public class SchedulerFacadeService {
                                             "Task timed out after {} minutes. Resetting to IDLE. VM: {}/{}/{}, Agent: {}",
                                             maxWaitMinutes,
                                             nsId,
-                                            mciId,
-                                            vmId,
+                                            infraId,
+                                            nodeId,
                                             agent);
 
                                     if (agent == Agent.TELEGRAF) {
                                         vmService.updateMonitoringAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
                                     } else if (agent == Agent.FLUENT_BIT) {
                                         vmService.updateLogAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
                                     } else if (agent == Agent.BEYLA
                                             || agent == Agent.OTEL_JAVA_AGENT) {
                                         vmService.updateTraceAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
                                     }
 
                                     log.warn("Timeout occurred for agent {}", agent);
@@ -148,14 +148,14 @@ public class SchedulerFacadeService {
                                     log.debug("Task successful for agent {}", agent);
                                     if (agent == Agent.TELEGRAF) {
                                         vmService.updateMonitoringAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
                                     } else if (agent == Agent.FLUENT_BIT) {
                                         vmService.updateLogAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
                                     } else if (agent == Agent.BEYLA
                                             || agent == Agent.OTEL_JAVA_AGENT) {
                                         vmService.updateTraceAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
                                     }
 
                                     ScheduledFuture<?> scheduledFuture = futureRef.get();
@@ -173,14 +173,14 @@ public class SchedulerFacadeService {
 
                                     if (agent == Agent.TELEGRAF) {
                                         vmService.updateMonitoringAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FAILED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FAILED);
                                     } else if (agent == Agent.FLUENT_BIT) {
                                         vmService.updateLogAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FAILED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FAILED);
                                     } else if (agent == Agent.BEYLA
                                             || agent == Agent.OTEL_JAVA_AGENT) {
                                         vmService.updateTraceAgentTaskStatus(
-                                                nsId, mciId, vmId, VMAgentTaskStatus.FAILED);
+                                                nsId, infraId, nodeId, VMAgentTaskStatus.FAILED);
                                     }
 
                                     ScheduledFuture<?> scheduledFuture = futureRef.get();

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TelegrafConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TelegrafConfigFacadeService.java
@@ -84,17 +84,18 @@ public class TelegrafConfigFacadeService {
                     + ","
                     + CONFIG_METRIC_SYSTEM;
 
-    public String initTelegrafConfig(String nsId, String mciId, String vmId) {
-        return generateTelegrafConfig(nsId, mciId, vmId, CONFIG_DEFAULT_METRICS);
+    public String initTelegrafConfig(String nsId, String infraId, String nodeId) {
+        return generateTelegrafConfig(nsId, infraId, nodeId, CONFIG_DEFAULT_METRICS);
     }
 
-    public String initTelegrafConfig(String nsId, String mciId, String vmId, boolean gpu) {
+    public String initTelegrafConfig(String nsId, String infraId, String nodeId, boolean gpu) {
         String metrics =
                 gpu ? CONFIG_DEFAULT_METRICS + "," + CONFIG_METRIC_GPU : CONFIG_DEFAULT_METRICS;
-        return generateTelegrafConfig(nsId, mciId, vmId, metrics);
+        return generateTelegrafConfig(nsId, infraId, nodeId, metrics);
     }
 
-    public String generateTelegrafConfig(String nsId, String mciId, String vmId, String metrics) {
+    public String generateTelegrafConfig(
+            String nsId, String infraId, String nodeId, String metrics) {
         String errMsg;
 
         if (!telegrafConfigGlobal.exists()) {
@@ -240,23 +241,23 @@ public class TelegrafConfigFacadeService {
 
         fileService.appendConfig(telegrafConfigOutputsInfluxDB, sb);
 
-        var out = influxDbFacadeService.resolveForVM(nsId, mciId);
+        var out = influxDbFacadeService.resolveForVM(nsId, infraId);
 
         String finalNsId = (nsId != null) ? nsId : "";
         log.debug(finalNsId);
 
-        String finalMciId = (mciId != null) ? mciId : "";
-        log.debug(finalMciId);
+        String finalInfraId = (infraId != null) ? infraId : "";
+        log.debug(finalInfraId);
 
-        String finalVmId = (vmId != null) ? vmId : "";
-        log.debug(finalVmId);
+        String finalNodeId = (nodeId != null) ? nodeId : "";
+        log.debug(finalNodeId);
 
         return sb.toString()
                 .replace("@DCGM_EXPORTER_URL", dcgmExporterUrl)
                 .replace("@SITE_CODE", deploySiteCode)
                 .replace("@NS_ID", finalNsId)
-                .replace("@INFRA_ID", finalMciId)
-                .replace("@NODE_ID", finalVmId)
+                .replace("@INFRA_ID", finalInfraId)
+                .replace("@NODE_ID", finalNodeId)
                 .replace("@URL", out.getUrl())
                 .replace("@DATABASE", out.getDatabase())
                 .replace("@USERNAME", out.getUsername())

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TelegrafFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TelegrafFacadeService.java
@@ -36,34 +36,35 @@ public class TelegrafFacadeService {
 
     public void install(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
-        install(nsId, mciId, vmId, accessInfo, templateCount, false);
+        install(nsId, infraId, nodeId, accessInfo, templateCount, false);
     }
 
     // gpu: true면 telegraf config에 GPU(DCGM) 수집 블록을 포함하고,
     // Ansible enable_gpu 변수로 DCGM Exporter 설치까지 함께 수행한다.
     public void install(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount,
             boolean gpu)
             throws Exception {
 
         log.info("==========================telegraf idle start===============================");
-        vmService.isIdleMonitoringAgent(nsId, mciId, vmId);
+        vmService.isIdleMonitoringAgent(nsId, infraId, nodeId);
         log.info("==========================telegraf idle finish===============================");
 
-        vmService.updateMonitoringAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING);
+        vmService.updateMonitoringAgentTaskStatus(
+                nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING);
         log.info("==========================update vm status===============================");
 
         String configContent =
-                telegrafConfigFacadeService.initTelegrafConfig(nsId, mciId, vmId, gpu);
+                telegrafConfigFacadeService.initTelegrafConfig(nsId, infraId, nodeId, gpu);
 
         log.info("Telegraf config: {}", configContent);
 
@@ -81,7 +82,7 @@ public class TelegrafFacadeService {
         log.info("=========================FINISH INSTALL REQUEST============================");
 
         vmService.updateMonitoringAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.INSTALLING, String.valueOf(task.getId()));
 
         log.info(
                 "==========================update vm status task ID: {}============================",
@@ -91,23 +92,24 @@ public class TelegrafFacadeService {
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.INSTALL,
                 Agent.TELEGRAF);
     }
 
     public void update(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             AccessInfoDTO accessInfo,
             @NotBlank int templateCount)
             throws Exception {
 
-        vmService.isIdleMonitoringAgent(nsId, mciId, vmId);
+        vmService.isIdleMonitoringAgent(nsId, infraId, nodeId);
 
-        vmService.updateMonitoringAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.UPDATING);
+        vmService.updateMonitoringAgentTaskStatus(
+                nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING);
 
         Task task =
                 semaphoreDomainService.install(
@@ -118,24 +120,29 @@ public class TelegrafFacadeService {
                         templateCount);
 
         vmService.updateMonitoringAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
+                nsId, infraId, nodeId, VMAgentTaskStatus.UPDATING, String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UPDATE,
                 Agent.TELEGRAF);
     }
 
     public void uninstall(
-            String nsId, String mciId, String vmId, AccessInfoDTO accessInfo, int templateCount) {
+            String nsId,
+            String infraId,
+            String nodeId,
+            AccessInfoDTO accessInfo,
+            int templateCount) {
 
-        vmService.isIdleMonitoringAgent(nsId, mciId, vmId);
+        vmService.isIdleMonitoringAgent(nsId, infraId, nodeId);
 
-        vmService.updateMonitoringAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.PREPARING);
+        vmService.updateMonitoringAgentTaskStatus(
+                nsId, infraId, nodeId, VMAgentTaskStatus.PREPARING);
 
         Task task =
                 semaphoreDomainService.install(
@@ -146,53 +153,59 @@ public class TelegrafFacadeService {
                         templateCount);
 
         vmService.updateMonitoringAgentTaskStatusAndTaskId(
-                nsId, mciId, vmId, VMAgentTaskStatus.UNINSTALLING, String.valueOf(task.getId()));
+                nsId,
+                infraId,
+                nodeId,
+                VMAgentTaskStatus.UNINSTALLING,
+                String.valueOf(task.getId()));
 
         schedulerFacadeService.scheduleTaskStatusCheck(
                 requestInfo.getRequestId(),
                 task.getId(),
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 SemaphoreInstallMethod.UNINSTALL,
                 Agent.TELEGRAF);
     }
 
     @Transactional
-    public List<ResultDTO> restart(String nsId, String mciId, String vmId) {
+    public List<ResultDTO> restart(String nsId, String infraId, String nodeId) {
 
         List<ResultDTO> results = new ArrayList<>();
 
         try {
             agentTaskStatusLock.lock();
 
-            vmService.isIdleMonitoringAgent(nsId, mciId, vmId);
+            vmService.isIdleMonitoringAgent(nsId, infraId, nodeId);
 
             vmService.updateMonitoringAgentTaskStatus(
-                    nsId, mciId, vmId, VMAgentTaskStatus.RESTARTING);
+                    nsId, infraId, nodeId, VMAgentTaskStatus.RESTARTING);
 
-            tumblebugService.restart(nsId, mciId, vmId, Agent.TELEGRAF);
+            tumblebugService.restart(nsId, infraId, nodeId, Agent.TELEGRAF);
 
-            vmService.updateMonitoringAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateMonitoringAgentTaskStatus(
+                    nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.SUCCESS)
                             .build());
             agentTaskStatusLock.unlock();
         } catch (Exception e) {
             agentTaskStatusLock.unlock();
 
-            vmService.updateMonitoringAgentTaskStatus(nsId, mciId, vmId, VMAgentTaskStatus.IDLE);
+            vmService.updateMonitoringAgentTaskStatus(
+                    nsId, infraId, nodeId, VMAgentTaskStatus.IDLE);
 
             results.add(
                     ResultDTO.builder()
                             .nsId(nsId)
-                            .mciId(mciId)
-                            .vmId(vmId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
                             .status(ResponseStatus.ERROR)
                             .errorMessage(e.getMessage())
                             .build());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TraceFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TraceFacadeService.java
@@ -1,0 +1,95 @@
+package com.mcmp.o11ymanager.manager.facade;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import com.mcmp.o11ymanager.manager.service.interfaces.TraceService;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Builds the TraceQL expression and resolves the time window for trace queries, then relays to the
+ * Tempo-backed {@link TraceService}. Mirrors the log facade's role: keep query construction out of
+ * the controller and the infrastructure adapter.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TraceFacadeService {
+
+    private static final long DEFAULT_RANGE_SEC = 60L * 60L; // last 1 hour
+
+    private final TraceService traceService;
+
+    public List<TraceResponseDto.TraceSummary> searchTraces(
+            String query, String service, String keyword, String start, String end, int limit) {
+        long[] window = resolveWindow(start, end);
+        String traceQl =
+                (query != null && !query.isBlank()) ? query.trim() : buildTraceQl(service, keyword);
+        return traceService.searchTraces(traceQl, limit, window[0], window[1]);
+    }
+
+    public TraceResponseDto.TraceDetail getTraceDetail(String traceId) {
+        return traceService.getTraceDetail(traceId);
+    }
+
+    /**
+     * Builds a TraceQL selector from a service filter and a free-text keyword. An empty selector
+     * ({@code { }}) matches all traces in the window.
+     */
+    private String buildTraceQl(String service, String keyword) {
+        StringBuilder sb = new StringBuilder("{ ");
+        boolean hasCondition = false;
+        if (service != null && !service.isBlank()) {
+            sb.append("resource.service.name=\"").append(service.trim()).append("\"");
+            hasCondition = true;
+        }
+        if (keyword != null && !keyword.isBlank()) {
+            // Escape regex specials so the user can search literal characters. (?i) for
+            // case-insensitive matching against span name OR service name.
+            String esc = keyword.trim().replaceAll("[\\\\.\\[\\](){}*+?^$|]", "\\\\$0");
+            if (hasCondition) {
+                sb.append(" && ");
+            }
+            sb.append("(name =~ \"(?i).*")
+                    .append(esc)
+                    .append(".*\" || resource.service.name =~ \"(?i).*")
+                    .append(esc)
+                    .append(".*\")");
+        }
+        sb.append(" }");
+        return sb.toString();
+    }
+
+    /**
+     * Resolves a [start, end] window in unix seconds. Accepts RFC3339 or unix epoch (seconds/ms)
+     * strings; defaults to the last hour when both bounds are absent.
+     */
+    private long[] resolveWindow(String start, String end) {
+        long nowSec = System.currentTimeMillis() / 1000L;
+        long endSec = parseToSeconds(end, nowSec);
+        long startSec = parseToSeconds(start, endSec - DEFAULT_RANGE_SEC);
+        return new long[] {startSec, endSec};
+    }
+
+    private long parseToSeconds(String value, long fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        String v = value.trim();
+        // Unix epoch: 13 digits = ms, 10 digits = seconds.
+        if (v.matches("\\d{13}")) {
+            return Long.parseLong(v) / 1000L;
+        }
+        if (v.matches("\\d{10}")) {
+            return Long.parseLong(v);
+        }
+        try {
+            return Instant.parse(v).getEpochSecond();
+        } catch (Exception e) {
+            log.warn("trace window parse failed value={} -> fallback", v);
+            return fallback;
+        }
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TraceFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/TraceFacadeService.java
@@ -4,14 +4,20 @@ import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
 import com.mcmp.o11ymanager.manager.service.interfaces.TraceService;
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
  * Builds the TraceQL expression and resolves the time window for trace queries, then relays to the
  * Tempo-backed {@link TraceService}. Mirrors the log facade's role: keep query construction out of
  * the controller and the infrastructure adapter.
+ *
+ * <p>{@code scope} splits the trace store into "framework" (the o11y platform's own services, whose
+ * service.name starts with {@code framework-service-prefix}) and "vm" (everything else — the target
+ * VMs' Beyla/OTel application traces), so the two are never mixed in one list.
  */
 @Slf4j
 @Service
@@ -20,13 +26,27 @@ public class TraceFacadeService {
 
     private static final long DEFAULT_RANGE_SEC = 60L * 60L; // last 1 hour
 
+    public static final String SCOPE_FRAMEWORK = "framework";
+    public static final String SCOPE_VM = "vm";
+
     private final TraceService traceService;
 
+    @Value("${tempo.framework-service-prefix:mc-observability}")
+    private String frameworkServicePrefix;
+
     public List<TraceResponseDto.TraceSummary> searchTraces(
-            String query, String service, String keyword, String start, String end, int limit) {
+            String query,
+            String service,
+            String keyword,
+            String scope,
+            String start,
+            String end,
+            int limit) {
         long[] window = resolveWindow(start, end);
         String traceQl =
-                (query != null && !query.isBlank()) ? query.trim() : buildTraceQl(service, keyword);
+                (query != null && !query.isBlank())
+                        ? query.trim()
+                        : buildTraceQl(service, keyword, scope);
         return traceService.searchTraces(traceQl, limit, window[0], window[1]);
     }
 
@@ -34,15 +54,44 @@ public class TraceFacadeService {
         return traceService.getTraceDetail(traceId);
     }
 
+    /** Service names known to Tempo, optionally narrowed to a scope (framework / vm). */
+    public List<String> getServiceNames(String scope) {
+        return traceService.getServiceNames().stream()
+                .filter(s -> s != null && !s.isBlank())
+                .filter(s -> matchesScope(s, scope))
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private boolean isFrameworkService(String serviceName) {
+        return serviceName.startsWith(frameworkServicePrefix);
+    }
+
+    private boolean matchesScope(String serviceName, String scope) {
+        if (SCOPE_FRAMEWORK.equalsIgnoreCase(scope)) {
+            return isFrameworkService(serviceName);
+        }
+        if (SCOPE_VM.equalsIgnoreCase(scope)) {
+            return !isFrameworkService(serviceName);
+        }
+        return true; // null/all
+    }
+
     /**
-     * Builds a TraceQL selector from a service filter and a free-text keyword. An empty selector
-     * ({@code { }}) matches all traces in the window.
+     * Builds a TraceQL selector from a service filter, scope, and a free-text keyword. An empty
+     * selector ({@code { }}) matches all traces in the window.
      */
-    private String buildTraceQl(String service, String keyword) {
+    private String buildTraceQl(String service, String keyword, String scope) {
         StringBuilder sb = new StringBuilder("{ ");
         boolean hasCondition = false;
         if (service != null && !service.isBlank()) {
             sb.append("resource.service.name=\"").append(service.trim()).append("\"");
+            hasCondition = true;
+        } else if (SCOPE_FRAMEWORK.equalsIgnoreCase(scope)) {
+            sb.append("resource.service.name=~\"").append(frameworkServicePrefix).append(".*\"");
+            hasCondition = true;
+        } else if (SCOPE_VM.equalsIgnoreCase(scope)) {
+            sb.append("resource.service.name!~\"").append(frameworkServicePrefix).append(".*\"");
             hasCondition = true;
         }
         if (keyword != null && !keyword.isBlank()) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -38,15 +38,15 @@ public class VMFacadeService {
     private final TumblebugService tumblebugService;
     private final InfluxDbService influxDbService;
 
-    public VMDTO postVM(String nsId, String mciId, String vmId, VMRequestDTO dto) {
+    public VMDTO postVM(String nsId, String infraId, String nodeId, VMRequestDTO dto) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
             VMStatus status =
-                    tumblebugService.isConnectedVM(nsId, mciId, vmId)
+                    tumblebugService.isConnectedVM(nsId, infraId, nodeId)
                             ? VMStatus.RUNNING
                             : VMStatus.FAILED;
 
@@ -54,31 +54,31 @@ public class VMFacadeService {
                 throw new RuntimeException("FAILED TO CONNECT VM");
             }
 
-            Long influxSeq = influxDbService.resolveInfluxDb(nsId, mciId);
+            Long influxSeq = influxDbService.resolveInfluxDb(nsId, infraId);
 
-            VMDTO savedVM = vmService.post(nsId, mciId, vmId, status, dto, influxSeq);
+            VMDTO savedVM = vmService.post(nsId, infraId, nodeId, status, dto, influxSeq);
 
             vmService.updateMonitoringAgentTaskStatusAndTaskId(
                     savedVM.getNsId(),
-                    savedVM.getMciId(),
-                    savedVM.getVmId(),
+                    savedVM.getInfraId(),
+                    savedVM.getNodeId(),
                     VMAgentTaskStatus.IDLE,
                     "");
             vmService.updateLogAgentTaskStatusAndTaskId(
                     savedVM.getNsId(),
-                    savedVM.getMciId(),
-                    savedVM.getVmId(),
+                    savedVM.getInfraId(),
+                    savedVM.getNodeId(),
                     VMAgentTaskStatus.IDLE,
                     "");
             vmService.updateTraceAgentTaskStatusAndTaskId(
                     savedVM.getNsId(),
-                    savedVM.getMciId(),
-                    savedVM.getVmId(),
+                    savedVM.getInfraId(),
+                    savedVM.getNodeId(),
                     VMAgentTaskStatus.IDLE,
                     "");
 
             // dto.gpu=true면 DCGM Exporter 설치 + telegraf GPU(dcgm) 수집 설정 포함
-            agentFacadeService.install(nsId, mciId, vmId, Boolean.TRUE.equals(dto.getGpu()));
+            agentFacadeService.install(nsId, infraId, nodeId, Boolean.TRUE.equals(dto.getGpu()));
 
             return savedVM;
         } finally {
@@ -86,17 +86,18 @@ public class VMFacadeService {
         }
     }
 
-    public VMDTO getVM(String nsId, String mciId, String vmId) {
+    public VMDTO getVM(String nsId, String infraId, String nodeId) {
 
-        log.info(">>> getVM() called with nsId: {}, mciId: {}, vmId: {}", nsId, mciId, vmId);
+        log.info(
+                ">>> getVM() called with nsId: {}, infraId: {}, nodeId: {}", nsId, infraId, nodeId);
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            VMDTO savedVM = vmService.get(nsId, mciId, vmId);
-            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            VMDTO savedVM = vmService.get(nsId, infraId, nodeId);
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             String userName = node.getNodeUserName();
             log.info(
                     ">>> VM fetched: id={}, name={} userName={}",
@@ -106,28 +107,28 @@ public class VMFacadeService {
 
             //        log.info(">>> start checking monitoring agent status");
             //        AgentServiceStatus monitoringStatus =
-            //                agentFacadeService.getAgentServiceStatus(nsId, mciId, vmId,
+            //                agentFacadeService.getAgentServiceStatus(nsId, infraId, nodeId,
             // Agent.TELEGRAF);
             //        log.info(">>> start checking log agent status");
             //        AgentServiceStatus logStatus =
-            //                agentFacadeService.getAgentServiceStatus(nsId, mciId, vmId,
+            //                agentFacadeService.getAgentServiceStatus(nsId, infraId, nodeId,
             // Agent.FLUENT_BIT);
 
             AgentStatus monitoringAgentStatus =
-                    agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.TELEGRAF);
+                    agentFacadeService.getAgentStatus(nsId, infraId, nodeId, Agent.TELEGRAF);
 
             AgentStatus logAgentStatus =
-                    agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.FLUENT_BIT);
+                    agentFacadeService.getAgentStatus(nsId, infraId, nodeId, Agent.FLUENT_BIT);
 
             AgentStatus traceAgentStatus =
-                    agentFacadeService.getAgentStatus(nsId, mciId, vmId, Agent.BEYLA);
+                    agentFacadeService.getAgentStatus(nsId, infraId, nodeId, Agent.BEYLA);
 
             return VMDTO.builder()
-                    .vmId(node.getId())
+                    .nodeId(node.getId())
                     .name(savedVM.getName())
                     .description(node.getDescription())
                     .nsId(nsId)
-                    .mciId(mciId)
+                    .infraId(infraId)
                     .monitoringAgentStatus(monitoringAgentStatus)
                     .logAgentStatus(logAgentStatus)
                     .traceAgentStatus(traceAgentStatus)
@@ -151,14 +152,14 @@ public class VMFacadeService {
                                 try {
                                     return getVM(
                                             baseDto.getNsId(),
-                                            baseDto.getMciId(),
-                                            baseDto.getVmId());
+                                            baseDto.getInfraId(),
+                                            baseDto.getNodeId());
                                 } catch (Exception e) {
                                     log.error(
-                                            ">>> getVM() failed for: nsId={}, mciId={}, vmId={}",
+                                            ">>> getVM() failed for: nsId={}, infraId={}, nodeId={}",
                                             baseDto.getNsId(),
-                                            baseDto.getMciId(),
-                                            baseDto.getVmId(),
+                                            baseDto.getInfraId(),
+                                            baseDto.getNodeId(),
                                             e);
                                     return null;
                                 }
@@ -180,9 +181,9 @@ public class VMFacadeService {
         return result;
     }
 
-    public List<VMDTO> getVMsNsMci(String nsId, String mciId) {
+    public List<VMDTO> getVMsNsMci(String nsId, String infraId) {
 
-        List<VMDTO> rawList = vmService.getByNsMci(nsId, mciId);
+        List<VMDTO> rawList = vmService.getByNsMci(nsId, infraId);
 
         return fetchVM(rawList);
     }
@@ -194,28 +195,28 @@ public class VMFacadeService {
         return fetchVM(rawList);
     }
 
-    public VMDTO putVM(String nsId, String mciId, String vmId, VMRequestDTO dto) {
+    public VMDTO putVM(String nsId, String infraId, String nodeId, VMRequestDTO dto) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            return vmService.put(nsId, mciId, vmId, dto);
+            return vmService.put(nsId, infraId, nodeId, dto);
         } finally {
             hostLock.unlock();
         }
     }
 
-    public void deleteVM(String nsId, String mciId, String vmId) {
+    public void deleteVM(String nsId, String infraId, String nodeId) {
 
-        ReentrantLock hostLock = vmService.getHostLock(nsId, mciId, vmId);
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
 
         try {
             hostLock.lock();
 
-            vmService.delete(nsId, mciId, vmId);
-            agentFacadeService.uninstall(nsId, mciId, vmId);
+            vmService.delete(nsId, infraId, nodeId);
+            agentFacadeService.uninstall(nsId, infraId, nodeId);
         } finally {
             hostLock.unlock();
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClient.java
@@ -37,29 +37,29 @@ public interface InsightClient {
     @DeleteMapping(ANOMALY + "/settings/{settingSeq}")
     Object deleteAnomalySetting(@PathVariable("settingSeq") int settingSeq);
 
-    @GetMapping(ANOMALY + "/settings/ns/{nsId}/mci/{mciId}")
-    Object getAnomalySettingsForMci(
-            @PathVariable("nsId") String nsId, @PathVariable("mciId") String mciId);
+    @GetMapping(ANOMALY + "/settings/ns/{nsId}/infra/{infraId}")
+    Object getAnomalySettingsForInfra(
+            @PathVariable("nsId") String nsId, @PathVariable("infraId") String infraId);
 
-    @GetMapping(ANOMALY + "/settings/ns/{nsId}/mci/{mciId}/vm/{vmId}")
-    Object getAnomalySettingsForVm(
+    @GetMapping(ANOMALY + "/settings/ns/{nsId}/infra/{infraId}/node/{nodeId}")
+    Object getAnomalySettingsForNode(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
-            @PathVariable("vmId") String vmId);
+            @PathVariable("infraId") String infraId,
+            @PathVariable("nodeId") String nodeId);
 
-    @GetMapping(ANOMALY + "/ns/{nsId}/mci/{mciId}/history")
-    Object getAnomalyHistoryForMci(
+    @GetMapping(ANOMALY + "/ns/{nsId}/infra/{infraId}/history")
+    Object getAnomalyHistoryForInfra(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
+            @PathVariable("infraId") String infraId,
             @RequestParam("measurement") String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime);
 
-    @GetMapping(ANOMALY + "/ns/{nsId}/mci/{mciId}/vm/{vmId}/history")
-    Object getAnomalyHistoryForVm(
+    @GetMapping(ANOMALY + "/ns/{nsId}/infra/{infraId}/node/{nodeId}/history")
+    Object getAnomalyHistoryForNode(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
-            @PathVariable("vmId") String vmId,
+            @PathVariable("infraId") String infraId,
+            @PathVariable("nodeId") String nodeId,
             @RequestParam("measurement") String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime);
@@ -108,36 +108,36 @@ public interface InsightClient {
     @GetMapping(PREDICTION + "/options")
     Object getPredictionOptions();
 
-    /** POST /predictions/ns/{nsId}/mci/{mciId} */
-    @PostMapping(PREDICTION + "/ns/{nsId}/mci/{mciId}")
-    Object predictMonitoringDataForMci(
+    /** POST /predictions/ns/{nsId}/infra/{infraId} */
+    @PostMapping(PREDICTION + "/ns/{nsId}/infra/{infraId}")
+    Object predictMonitoringDataForInfra(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
+            @PathVariable("infraId") String infraId,
             @RequestBody Object body);
 
-    /** POST /predictions/ns/{nsId}/mci/{mciId}/vm/{vmId} */
-    @PostMapping(PREDICTION + "/ns/{nsId}/mci/{mciId}/vm/{vmId}")
-    Object predictMonitoringDataForVm(
+    /** POST /predictions/ns/{nsId}/infra/{infraId}/node/{nodeId} */
+    @PostMapping(PREDICTION + "/ns/{nsId}/infra/{infraId}/node/{nodeId}")
+    Object predictMonitoringDataForNode(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
-            @PathVariable("vmId") String vmId,
+            @PathVariable("infraId") String infraId,
+            @PathVariable("nodeId") String nodeId,
             @RequestBody Object body);
 
-    /** GET /predictions/ns/{nsId}/mci/{mciId}/history */
-    @GetMapping(PREDICTION + "/ns/{nsId}/mci/{mciId}/history")
-    Object getPredictionHistoryForMci(
+    /** GET /predictions/ns/{nsId}/infra/{infraId}/history */
+    @GetMapping(PREDICTION + "/ns/{nsId}/infra/{infraId}/history")
+    Object getPredictionHistoryForInfra(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
+            @PathVariable("infraId") String infraId,
             @RequestParam("measurement") String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime);
 
-    /** GET /predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}/history */
-    @GetMapping(PREDICTION + "/ns/{nsId}/mci/{mciId}/vm/{vmId}/history")
-    Object getPredictionHistoryForVm(
+    /** GET /predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}/history */
+    @GetMapping(PREDICTION + "/ns/{nsId}/infra/{infraId}/node/{nodeId}/history")
+    Object getPredictionHistoryForNode(
             @PathVariable("nsId") String nsId,
-            @PathVariable("mciId") String mciId,
-            @PathVariable("vmId") String vmId,
+            @PathVariable("infraId") String infraId,
+            @PathVariable("nodeId") String nodeId,
             @RequestParam("measurement") String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClientAdapter.java
@@ -28,32 +28,33 @@ public class InsightClientAdapter implements InsightPort {
     }
 
     @Override
-    public Object predictMonitoringDataForMci(String nsId, String mciId, Object body) {
-        return insightClient.predictMonitoringDataForMci(nsId, mciId, body);
+    public Object predictMonitoringDataForInfra(String nsId, String infraId, Object body) {
+        return insightClient.predictMonitoringDataForInfra(nsId, infraId, body);
     }
 
     @Override
-    public Object predictMonitoringDataForVm(String nsId, String mciId, String vmId, Object body) {
-        return insightClient.predictMonitoringDataForVm(nsId, mciId, vmId, body);
+    public Object predictMonitoringDataForNode(
+            String nsId, String infraId, String nodeId, Object body) {
+        return insightClient.predictMonitoringDataForNode(nsId, infraId, nodeId, body);
     }
 
     @Override
-    public Object getPredictionHistoryForMci(
-            String nsId, String mciId, String measurement, String startTime, String endTime) {
-        return insightClient.getPredictionHistoryForMci(
-                nsId, mciId, measurement, startTime, endTime);
+    public Object getPredictionHistoryForInfra(
+            String nsId, String infraId, String measurement, String startTime, String endTime) {
+        return insightClient.getPredictionHistoryForInfra(
+                nsId, infraId, measurement, startTime, endTime);
     }
 
     @Override
-    public Object getPredictionHistoryForVm(
+    public Object getPredictionHistoryForNode(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             String measurement,
             String startTime,
             String endTime) {
-        return insightClient.getPredictionHistoryForVm(
-                nsId, mciId, vmId, measurement, startTime, endTime);
+        return insightClient.getPredictionHistoryForNode(
+                nsId, infraId, nodeId, measurement, startTime, endTime);
     }
 
     /* ===================== Anomaly Detection ===================== */
@@ -98,31 +99,32 @@ public class InsightClientAdapter implements InsightPort {
     }
 
     @Override
-    public Object getAnomalySettingsForMci(String nsId, String mciId) {
-        return insightClient.getAnomalySettingsForMci(nsId, mciId);
+    public Object getAnomalySettingsForInfra(String nsId, String infraId) {
+        return insightClient.getAnomalySettingsForInfra(nsId, infraId);
     }
 
     @Override
-    public Object getAnomalySettingsForVm(String nsId, String mciId, String vmId) {
-        return insightClient.getAnomalySettingsForVm(nsId, mciId, vmId);
+    public Object getAnomalySettingsForNode(String nsId, String infraId, String nodeId) {
+        return insightClient.getAnomalySettingsForNode(nsId, infraId, nodeId);
     }
 
     @Override
-    public Object getAnomalyHistoryForMci(
-            String nsId, String mciId, String measurement, String startTime, String endTime) {
-        return insightClient.getAnomalyHistoryForMci(nsId, mciId, measurement, startTime, endTime);
+    public Object getAnomalyHistoryForInfra(
+            String nsId, String infraId, String measurement, String startTime, String endTime) {
+        return insightClient.getAnomalyHistoryForInfra(
+                nsId, infraId, measurement, startTime, endTime);
     }
 
     @Override
-    public Object getAnomalyHistoryForVm(
+    public Object getAnomalyHistoryForNode(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             String measurement,
             String startTime,
             String endTime) {
-        return insightClient.getAnomalyHistoryForVm(
-                nsId, mciId, vmId, measurement, startTime, endTime);
+        return insightClient.getAnomalyHistoryForNode(
+                nsId, infraId, nodeId, measurement, startTime, endTime);
     }
 
     /* ===================== LLM ===================== */

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/spider/SpiderClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/spider/SpiderClient.java
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface SpiderClient {
 
     @GetMapping(
-            value = "/spider/monitoring/vm/{vmName}/{measurement}",
+            value = "/spider/monitoring/vm/{nodeName}/{measurement}",
             produces = "application/json")
     SpiderMonitoringInfo.Data getVMMonitoring(
-            @PathVariable String vmName,
+            @PathVariable String nodeName,
             @PathVariable String measurement,
             @RequestParam("ConnectionName") String connectionName,
             @RequestParam("TimeBeforeHour") String timeBeforeHour,

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/spider/SpiderClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/spider/SpiderClientAdapter.java
@@ -14,13 +14,13 @@ public class SpiderClientAdapter implements SpiderClient {
 
     @Override
     public SpiderMonitoringInfo.Data getVMMonitoring(
-            String vmName,
+            String nodeName,
             String measurement,
             String connectionName,
             String timeBeforeHour,
             String intervalMinute) {
         return spiderClient.getVMMonitoring(
-                vmName, measurement, connectionName, timeBeforeHour, intervalMinute);
+                nodeName, measurement, connectionName, timeBeforeHour, intervalMinute);
     }
 
     @Override

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/adapter/TempoClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/adapter/TempoClientAdapter.java
@@ -3,6 +3,7 @@ package com.mcmp.o11ymanager.manager.infrastructure.trace.adapter;
 import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
 import com.mcmp.o11ymanager.manager.infrastructure.trace.client.TempoFeignClient;
 import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoSearchResponseDto;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoServiceValuesDto;
 import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoTraceDto;
 import com.mcmp.o11ymanager.manager.port.TempoPort;
 import java.util.ArrayList;
@@ -106,6 +107,19 @@ public class TempoClientAdapter implements TempoPort {
             rows.sort(Comparator.comparingLong(TraceResponseDto.SpanRow::getStartTimeMs));
         }
         return TraceResponseDto.TraceDetail.builder().traceId(traceId).spans(rows).build();
+    }
+
+    @Override
+    public List<String> getServiceNames() {
+        try {
+            return tempoFeignClient
+                    .getServiceNames()
+                    .map(TempoServiceValuesDto::getTagValues)
+                    .orElse(Collections.emptyList());
+        } catch (Exception e) {
+            log.warn("tempo getServiceNames failed err={}", e.getMessage());
+            return Collections.emptyList();
+        }
     }
 
     // ---------- helpers ----------

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/adapter/TempoClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/adapter/TempoClientAdapter.java
@@ -1,0 +1,168 @@
+package com.mcmp.o11ymanager.manager.infrastructure.trace.adapter;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.client.TempoFeignClient;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoSearchResponseDto;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoTraceDto;
+import com.mcmp.o11ymanager.manager.port.TempoPort;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps Tempo's HTTP responses to the trace domain. Tempo failures (404 for unknown trace IDs,
+ * connectivity issues) degrade to empty results rather than propagating 500s to the UI.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TempoClientAdapter implements TempoPort {
+
+    private final TempoFeignClient tempoFeignClient;
+
+    @Override
+    public List<TraceResponseDto.TraceSummary> searchTraces(
+            String traceQl, Integer limit, Long startSec, Long endSec) {
+        List<TempoSearchResponseDto.TraceSummary> raw;
+        try {
+            raw =
+                    tempoFeignClient
+                            .search(traceQl, limit, startSec, endSec)
+                            .map(TempoSearchResponseDto::getTraces)
+                            .orElse(Collections.emptyList());
+        } catch (Exception e) {
+            log.warn("tempo search failed q={} err={}", traceQl, e.getMessage());
+            return Collections.emptyList();
+        }
+        if (raw == null) {
+            return Collections.emptyList();
+        }
+        return raw.stream()
+                .map(
+                        t ->
+                                TraceResponseDto.TraceSummary.builder()
+                                        .traceId(t.getTraceID())
+                                        .rootService(t.getRootServiceName())
+                                        .rootName(t.getRootTraceName())
+                                        .startTimeMs(parseUnixNanoToMs(t.getStartTimeUnixNano()))
+                                        .durationMs(
+                                                t.getDurationMs() == null ? 0 : t.getDurationMs())
+                                        .build())
+                .sorted(
+                        Comparator.comparingLong(TraceResponseDto.TraceSummary::getStartTimeMs)
+                                .reversed())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public TraceResponseDto.TraceDetail getTraceDetail(String traceId) {
+        TempoTraceDto raw;
+        try {
+            raw = tempoFeignClient.getTrace(traceId).orElse(null);
+        } catch (Exception e) {
+            log.warn("tempo getTrace failed id={} err={}", traceId, e.getMessage());
+            raw = null;
+        }
+
+        List<TraceResponseDto.SpanRow> rows = new ArrayList<>();
+        if (raw != null && raw.getBatches() != null) {
+            for (TempoTraceDto.Batch b : raw.getBatches()) {
+                String svc = serviceFromResource(b.getResource());
+                if (b.getScopeSpans() == null) {
+                    continue;
+                }
+                for (TempoTraceDto.ScopeSpans ss : b.getScopeSpans()) {
+                    if (ss.getSpans() == null) {
+                        continue;
+                    }
+                    for (TempoTraceDto.Span sp : ss.getSpans()) {
+                        long startNs = parseUnixNano(sp.getStartTimeUnixNano());
+                        long endNs = parseUnixNano(sp.getEndTimeUnixNano());
+                        // Truncate START to ms for display alignment; keep DURATION fractional so
+                        // sub-ms spans (DB lookups, RPC calls) don't all collapse to 0/1ms.
+                        long startMs = startNs / 1_000_000L;
+                        double durationMs = Math.max(0, (endNs - startNs) / 1_000_000.0);
+                        rows.add(
+                                TraceResponseDto.SpanRow.builder()
+                                        .spanId(sp.getSpanId())
+                                        .parentSpanId(sp.getParentSpanId())
+                                        .service(svc)
+                                        .name(sp.getName())
+                                        .kind(sp.getKind())
+                                        .startTimeMs(startMs)
+                                        .durationMs(durationMs)
+                                        .attributes(flattenAttrs(sp.getAttributes()))
+                                        .build());
+                    }
+                }
+            }
+            rows.sort(Comparator.comparingLong(TraceResponseDto.SpanRow::getStartTimeMs));
+        }
+        return TraceResponseDto.TraceDetail.builder().traceId(traceId).spans(rows).build();
+    }
+
+    // ---------- helpers ----------
+
+    private static String serviceFromResource(TempoTraceDto.Resource r) {
+        if (r == null || r.getAttributes() == null) {
+            return "";
+        }
+        for (TempoTraceDto.Attribute a : r.getAttributes()) {
+            if ("service.name".equals(a.getKey())) {
+                return attrValueAsString(a.getValue());
+            }
+        }
+        return "";
+    }
+
+    private static Map<String, String> flattenAttrs(List<TempoTraceDto.Attribute> attrs) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (attrs == null) {
+            return out;
+        }
+        for (TempoTraceDto.Attribute a : attrs) {
+            String v = attrValueAsString(a.getValue());
+            if (v != null) {
+                out.put(a.getKey(), v);
+            }
+        }
+        return out;
+    }
+
+    private static String attrValueAsString(Map<String, Object> value) {
+        if (value == null) {
+            return null;
+        }
+        // OTLP value is a oneof; whichever key is set carries the value.
+        for (Map.Entry<String, Object> e : value.entrySet()) {
+            Object v = e.getValue();
+            if (v == null) {
+                continue;
+            }
+            return v.toString();
+        }
+        return null;
+    }
+
+    private static long parseUnixNanoToMs(String unixNano) {
+        return parseUnixNano(unixNano) / 1_000_000L;
+    }
+
+    private static long parseUnixNano(String unixNano) {
+        if (unixNano == null || unixNano.isBlank()) {
+            return 0;
+        }
+        try {
+            return Long.parseLong(unixNano);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/client/TempoFeignClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/client/TempoFeignClient.java
@@ -2,6 +2,7 @@ package com.mcmp.o11ymanager.manager.infrastructure.trace.client;
 
 import com.mcmp.o11ymanager.manager.infrastructure.log.client.FeignLogConfig;
 import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoSearchResponseDto;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoServiceValuesDto;
 import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoTraceDto;
 import java.util.Optional;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -31,4 +32,8 @@ public interface TempoFeignClient {
     /** Full OTLP-shaped payload of a single trace (resource + scope + spans). */
     @GetMapping(value = "${tempo.endpoints.trace}/{traceId}")
     Optional<TempoTraceDto> getTrace(@PathVariable("traceId") String traceId);
+
+    /** Distinct service.name values ingested by Tempo — drives the UI service dropdown. */
+    @GetMapping(value = "${tempo.endpoints.serviceValues}")
+    Optional<TempoServiceValuesDto> getServiceNames();
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/client/TempoFeignClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/client/TempoFeignClient.java
@@ -1,0 +1,34 @@
+package com.mcmp.o11ymanager.manager.infrastructure.trace.client;
+
+import com.mcmp.o11ymanager.manager.infrastructure.log.client.FeignLogConfig;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoSearchResponseDto;
+import com.mcmp.o11ymanager.manager.infrastructure.trace.dto.TempoTraceDto;
+import java.util.Optional;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Tempo HTTP query surface used by the trace facade. Only the subset we render — TraceQL search for
+ * the list view and a single-trace fetch for the span detail view.
+ */
+@FeignClient(name = "TempoFeignClient", url = "${tempo.url}", configuration = FeignLogConfig.class)
+public interface TempoFeignClient {
+
+    /**
+     * TraceQL-backed search. {@code q} is a raw TraceQL expression (e.g. {@code {
+     * resource.service.name="svc" }}). Returns trace IDs + root service/name + duration so the list
+     * renders without a fetch per row.
+     */
+    @GetMapping(value = "${tempo.endpoints.search}")
+    Optional<TempoSearchResponseDto> search(
+            @RequestParam("q") String q,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "start", required = false) Long start,
+            @RequestParam(value = "end", required = false) Long end);
+
+    /** Full OTLP-shaped payload of a single trace (resource + scope + spans). */
+    @GetMapping(value = "${tempo.endpoints.trace}/{traceId}")
+    Optional<TempoTraceDto> getTrace(@PathVariable("traceId") String traceId);
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoSearchResponseDto.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoSearchResponseDto.java
@@ -1,0 +1,29 @@
+package com.mcmp.o11ymanager.manager.infrastructure.trace.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Subset of Tempo's /api/search response we render. Tempo emits more stats/metadata fields;
+ * ignoring them keeps the DTO compact.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TempoSearchResponseDto {
+
+    private List<TraceSummary> traces;
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TraceSummary {
+        private String traceID;
+        private String rootServiceName;
+        private String rootTraceName;
+        private String startTimeUnixNano;
+        private Long durationMs;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoServiceValuesDto.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoServiceValuesDto.java
@@ -1,0 +1,14 @@
+package com.mcmp.o11ymanager.manager.infrastructure.trace.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Tempo /api/search/tag/service.name/values response (distinct service.name values). */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TempoServiceValuesDto {
+    private List<String> tagValues;
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoTraceDto.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trace/dto/TempoTraceDto.java
@@ -1,0 +1,66 @@
+package com.mcmp.o11ymanager.manager.infrastructure.trace.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Tempo's /api/traces/{id} returns the OTLP wire shape (batches / resourceSpans / scopeSpans /
+ * spans). Mirrored loosely as nested DTOs because the trace detail is flattened into a per-span
+ * table on the way out.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TempoTraceDto {
+
+    private List<Batch> batches;
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Batch {
+        private Resource resource;
+        private List<ScopeSpans> scopeSpans;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Resource {
+        private List<Attribute> attributes;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ScopeSpans {
+        private Map<String, Object> scope;
+        private List<Span> spans;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Span {
+        private String traceId;
+        private String spanId;
+        private String parentSpanId;
+        private String name;
+        private String kind;
+        private String startTimeUnixNano;
+        private String endTimeUnixNano;
+        private List<Attribute> attributes;
+        private Map<String, Object> status;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Attribute {
+        private String key;
+        private Map<String, Object> value;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
@@ -19,35 +19,35 @@ public class ManagerAdapter implements ManagerPort {
     private final InfluxDbService influxDbService;
 
     @Override
-    public String getInfluxUid(String nsId, String vmScope, String vmId) {
+    public String getInfluxUid(String nsId, String vmScope, String nodeId) {
 
         Long influxId;
 
         // 1. Check whether vmScope is "infra_id" or "node_id"
         if ("mci".equalsIgnoreCase(vmScope)) {
-            final String mciId = vmId;
+            final String infraId = nodeId;
 
             // 2. Map influx id using the combination of ns id and mci id
-            List<VMDTO> vms = vmService.getByNsMci(nsId, mciId);
+            List<VMDTO> vms = vmService.getByNsMci(nsId, infraId);
             influxId =
                     vms.stream()
                             .map(VMDTO::getInfluxSeq)
                             .filter(Objects::nonNull)
                             .findFirst() // Can choose first/latest/minimum based on rules
-                            .orElseGet(() -> influxDbService.resolveInfluxDb(nsId, mciId));
+                            .orElseGet(() -> influxDbService.resolveInfluxDb(nsId, infraId));
 
         } else if ("vm".equalsIgnoreCase(vmScope)) {
             // 3. Map mci id using ns and vm
-            VMDTO t = vmService.getByNsVm(nsId, vmId);
+            VMDTO t = vmService.getByNsVm(nsId, nodeId);
 
             influxId = t.getInfluxSeq();
             if (influxId == null) {
-                String mciId = t.getMciId();
-                if (mciId == null || mciId.isBlank()) {
+                String infraId = t.getInfraId();
+                if (infraId == null || infraId.isBlank()) {
                     throw new IllegalStateException(
-                            "mciId not found for vm: ns=" + nsId + ", vmId=" + vmId);
+                            "infraId not found for vm: ns=" + nsId + ", nodeId=" + nodeId);
                 }
-                influxId = influxDbService.resolveInfluxDb(nsId, mciId);
+                influxId = influxDbService.resolveInfluxDb(nsId, infraId);
             }
 
         } else {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/mapper/host/VMMapper.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/mapper/host/VMMapper.java
@@ -14,10 +14,10 @@ public class VMMapper {
 
     public VMEntity fromResponseDTO(VMDTO dto) {
         return VMEntity.builder()
-                .vmId(dto.getVmId())
+                .nodeId(dto.getNodeId())
                 .nsId(dto.getNsId())
                 .vmStatus(dto.getVmStatus())
-                .mciId(dto.getMciId())
+                .infraId(dto.getInfraId())
                 .name(dto.getName())
                 .description(dto.getDescription())
                 .monitoringAgentTaskStatus(dto.getMonitoringAgentTaskStatus())
@@ -30,7 +30,7 @@ public class VMMapper {
                 .logServiceStatus(dto.getLogServiceStatus())
                 .traceServiceStatus(dto.getTraceServiceStatus())
                 .nsId(dto.getNsId())
-                .mciId(dto.getMciId())
+                .infraId(dto.getInfraId())
                 .build();
     }
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/InsightPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/InsightPort.java
@@ -9,17 +9,17 @@ public interface InsightPort {
 
     Object getPredictionOptions();
 
-    Object predictMonitoringDataForMci(String nsId, String mciId, Object body);
+    Object predictMonitoringDataForInfra(String nsId, String infraId, Object body);
 
-    Object predictMonitoringDataForVm(String nsId, String mciId, String vmId, Object body);
+    Object predictMonitoringDataForNode(String nsId, String infraId, String nodeId, Object body);
 
-    Object getPredictionHistoryForMci(
-            String nsId, String mciId, String measurement, String startTime, String endTime);
+    Object getPredictionHistoryForInfra(
+            String nsId, String infraId, String measurement, String startTime, String endTime);
 
-    Object getPredictionHistoryForVm(
+    Object getPredictionHistoryForNode(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             String measurement,
             String startTime,
             String endTime);
@@ -41,17 +41,17 @@ public interface InsightPort {
 
     Object deleteAnomalySetting(int settingSeq);
 
-    Object getAnomalySettingsForMci(String nsId, String mciId);
+    Object getAnomalySettingsForInfra(String nsId, String infraId);
 
-    Object getAnomalySettingsForVm(String nsId, String mciId, String vmId);
+    Object getAnomalySettingsForNode(String nsId, String infraId, String nodeId);
 
-    Object getAnomalyHistoryForMci(
-            String nsId, String mciId, String measurement, String startTime, String endTime);
+    Object getAnomalyHistoryForInfra(
+            String nsId, String infraId, String measurement, String startTime, String endTime);
 
-    Object getAnomalyHistoryForVm(
+    Object getAnomalyHistoryForNode(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             String measurement,
             String startTime,
             String endTime);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/SpiderPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/SpiderPort.java
@@ -5,7 +5,7 @@ import com.mcmp.o11ymanager.manager.dto.SpiderMonitoringInfo;
 public interface SpiderPort {
 
     SpiderMonitoringInfo.Data getVMMonitoring(
-            String vmName,
+            String nodeName,
             String measurement,
             String connectionName,
             String timeBeforeHour,

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TempoPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TempoPort.java
@@ -28,4 +28,11 @@ public interface TempoPort {
      * @return trace detail with span rows
      */
     TraceResponseDto.TraceDetail getTraceDetail(String traceId);
+
+    /**
+     * List distinct service names known to Tempo.
+     *
+     * @return service.name values
+     */
+    List<String> getServiceNames();
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TempoPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/TempoPort.java
@@ -1,0 +1,31 @@
+package com.mcmp.o11ymanager.manager.port;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import java.util.List;
+
+/**
+ * Interface (port) for interacting with the Tempo trace storage. Enables dependency inversion from
+ * the domain layer to the infrastructure layer.
+ */
+public interface TempoPort {
+
+    /**
+     * Search trace summaries via a TraceQL expression within a time window.
+     *
+     * @param traceQl TraceQL expression (e.g. {@code { resource.service.name="svc" }})
+     * @param limit maximum number of traces to return
+     * @param startSec window start (unix seconds, optional)
+     * @param endSec window end (unix seconds, optional)
+     * @return trace summary list
+     */
+    List<TraceResponseDto.TraceSummary> searchTraces(
+            String traceQl, Integer limit, Long startSec, Long endSec);
+
+    /**
+     * Fetch a single trace and flatten it into a span list.
+     *
+     * @param traceId trace ID
+     * @return trace detail with span rows
+     */
+    TraceResponseDto.TraceDetail getTraceDetail(String traceId);
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/repository/VMJpaRepository.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/repository/VMJpaRepository.java
@@ -1,20 +1,20 @@
 package com.mcmp.o11ymanager.manager.repository;
 
+import com.mcmp.o11ymanager.manager.entity.NodeId;
 import com.mcmp.o11ymanager.manager.entity.VMEntity;
-import com.mcmp.o11ymanager.manager.entity.VmId;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface VMJpaRepository extends JpaRepository<VMEntity, VmId> {
+public interface VMJpaRepository extends JpaRepository<VMEntity, NodeId> {
 
-    List<VMEntity> findByNsIdAndMciId(String nsId, String mciId);
+    List<VMEntity> findByNsIdAndInfraId(String nsId, String infraId);
 
-    Optional<VMEntity> findByNsIdAndMciIdAndVmId(String nsId, String mciId, String vmId);
+    Optional<VMEntity> findByNsIdAndInfraIdAndNodeId(String nsId, String infraId, String nodeId);
 
-    Optional<VMEntity> findTop1ByNsIdAndMciIdOrderByVmIdAsc(String nsId, String mciId);
+    Optional<VMEntity> findTop1ByNsIdAndInfraIdOrderByNodeIdAsc(String nsId, String infraId);
 
-    Optional<VMEntity> findByNsIdAndVmId(String nsId, String vmId);
+    Optional<VMEntity> findByNsIdAndNodeId(String nsId, String nodeId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
@@ -101,8 +101,8 @@ public class InfluxDbServiceImpl implements InfluxDbService {
     }
 
     @Override
-    public InfluxDTO resolveInfluxDto(String nsId, String mciId) {
-        Long influxId = resolveInfluxDb(nsId, mciId);
+    public InfluxDTO resolveInfluxDto(String nsId, String infraId) {
+        Long influxId = resolveInfluxDb(nsId, infraId);
         InfluxEntity e =
                 influxJpaRepository
                         .findById(influxId)
@@ -189,7 +189,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
     // ------------------------------------getMetric--------------------------------------------------//
 
     @Override
-    public List<MetricDTO> getMetricsByNsMci(String nsId, String mciId, MetricRequestDTO req) {
+    public List<MetricDTO> getMetricsByNsMci(String nsId, String infraId, MetricRequestDTO req) {
 
         if (req.getConditions() != null) {
             for (MetricRequestDTO.ConditionInfo c : req.getConditions()) {
@@ -214,17 +214,17 @@ public class InfluxDbServiceImpl implements InfluxDbService {
 
         MetricRequestDTO.ConditionInfo mciCond = new MetricRequestDTO.ConditionInfo();
         mciCond.setKey("infra_id");
-        mciCond.setValue(mciId);
+        mciCond.setValue(infraId);
         conditions.add(mciCond);
 
         req.setConditions(conditions);
 
         return monitoringCacheService.getOrLoad(
-                nsId, mciId, null, req, () -> loadMetricsByNsMci(nsId, mciId, req));
+                nsId, infraId, null, req, () -> loadMetricsByNsMci(nsId, infraId, req));
     }
 
-    private List<MetricDTO> loadMetricsByNsMci(String nsId, String mciId, MetricRequestDTO req) {
-        Long influxId = resolveInfluxDb(nsId, mciId);
+    private List<MetricDTO> loadMetricsByNsMci(String nsId, String infraId, MetricRequestDTO req) {
+        Long influxId = resolveInfluxDb(nsId, infraId);
         InfluxEntity entity =
                 influxJpaRepository
                         .findById(influxId)
@@ -244,10 +244,11 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         String rp = fetchDefaultRp(s);
         String q = InfluxQl.buildQuery(req, rp);
 
-        if (!existsNsMciInInflux(s, nsId, mciId)) {
+        if (!existsNsMciInInflux(s, nsId, infraId)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Invalid nsId='%s' or mciId='%s': not found in InfluxDB", nsId, mciId));
+                            "Invalid nsId='%s' or infraId='%s': not found in InfluxDB",
+                            nsId, infraId));
         }
 
         List<MetricDTO> metrics = exec(s, q).map(QueryMapper::toMetricDTOs).orElse(List.of());
@@ -260,7 +261,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
                                 tags.putAll(m.tags());
                             }
                             tags.put("ns_id", nsId);
-                            tags.put("infra_id", mciId);
+                            tags.put("infra_id", infraId);
                             return new MetricDTO(m.name(), m.columns(), tags, m.values());
                         })
                 .collect(Collectors.toList());
@@ -268,7 +269,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
 
     @Override
     public List<MetricDTO> getMetricsByVM(
-            String nsId, String mciId, String vmId, MetricRequestDTO req) {
+            String nsId, String infraId, String nodeId, MetricRequestDTO req) {
 
         if (req.getConditions() != null) {
             for (MetricRequestDTO.ConditionInfo c : req.getConditions()) {
@@ -293,23 +294,23 @@ public class InfluxDbServiceImpl implements InfluxDbService {
 
         MetricRequestDTO.ConditionInfo mciCond = new MetricRequestDTO.ConditionInfo();
         mciCond.setKey("infra_id");
-        mciCond.setValue(mciId);
+        mciCond.setValue(infraId);
         conditions.add(mciCond);
 
         MetricRequestDTO.ConditionInfo vmCond = new MetricRequestDTO.ConditionInfo();
         vmCond.setKey("node_id");
-        vmCond.setValue(vmId);
+        vmCond.setValue(nodeId);
         conditions.add(vmCond);
 
         req.setConditions(conditions);
 
         return monitoringCacheService.getOrLoad(
-                nsId, mciId, vmId, req, () -> loadMetricsByVM(nsId, mciId, vmId, req));
+                nsId, infraId, nodeId, req, () -> loadMetricsByVM(nsId, infraId, nodeId, req));
     }
 
     private List<MetricDTO> loadMetricsByVM(
-            String nsId, String mciId, String vmId, MetricRequestDTO req) {
-        Long influxId = resolveInfluxDb(nsId, mciId);
+            String nsId, String infraId, String nodeId, MetricRequestDTO req) {
+        Long influxId = resolveInfluxDb(nsId, infraId);
         InfluxEntity entity =
                 influxJpaRepository
                         .findById(influxId)
@@ -329,11 +330,11 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         String rp = fetchDefaultRp(s);
         String q = InfluxQl.buildQuery(req, rp);
 
-        if (!existsVmInInflux(s, nsId, mciId, vmId)) {
+        if (!existsVmInInflux(s, nsId, infraId, nodeId)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Invalid vmId='%s': does not exist for nsId='%s', mciId='%s'",
-                            vmId, nsId, mciId));
+                            "Invalid nodeId='%s': does not exist for nsId='%s', infraId='%s'",
+                            nodeId, nsId, infraId));
         }
 
         List<MetricDTO> metrics = exec(s, q).map(QueryMapper::toMetricDTOs).orElse(List.of());
@@ -346,8 +347,8 @@ public class InfluxDbServiceImpl implements InfluxDbService {
                                 tags.putAll(m.tags());
                             }
                             tags.put("ns_id", nsId);
-                            tags.put("infra_id", mciId);
-                            tags.put("node_id", vmId);
+                            tags.put("infra_id", infraId);
+                            tags.put("node_id", nodeId);
                             return new MetricDTO(m.name(), m.columns(), tags, m.values());
                         })
                 .collect(Collectors.toList());
@@ -447,13 +448,13 @@ public class InfluxDbServiceImpl implements InfluxDbService {
     // ------------------------------------resolveInfluxdb--------------------------------------------------//
 
     @Override
-    public Long resolveInfluxDb(String nsId, String mciId) {
+    public Long resolveInfluxDb(String nsId, String infraId) {
         var entities = rawEntities();
         if (entities.isEmpty()) {
             throw new IllegalStateException("influxdb.servers must contain at least 1 server");
         }
 
-        log.info("[INF-RESOLVE] start ns={}, mci={}, servers={}", nsId, mciId, entities.size());
+        log.info("[INF-RESOLVE] start ns={}, mci={}, servers={}", nsId, infraId, entities.size());
 
         // DB where (ns_id, infra_id) combination already exists
         for (var e : entities) {
@@ -465,7 +466,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
                         s.getUrl());
                 continue;
             }
-            if (existsTagCombination(s, nsId, mciId)) {
+            if (existsTagCombination(s, nsId, infraId)) {
                 log.info(
                         "[INF-RESOLVE] found vm combination at id={}, url={}",
                         e.getId(),
@@ -500,7 +501,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         }
 
         throw new IllegalStateException(
-                "no reachable influxdb candidates (ns=" + nsId + ", mci=" + mciId + ")");
+                "no reachable influxdb candidates (ns=" + nsId + ", mci=" + infraId + ")");
     }
 
     // ------------------------------------Retention
@@ -569,7 +570,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
                 log.info("[CARDINALITY] id={}, url={} PING FAIL -> skip", e.getId(), s.getUrl());
                 continue;
             }
-            int count = countMciIdTag(s);
+            int count = countInfraIdTag(s);
             log.info("[CARDINALITY] id={}, url={}, count={}", e.getId(), s.getUrl(), count);
 
             if (count < bestCount) {
@@ -583,25 +584,26 @@ public class InfluxDbServiceImpl implements InfluxDbService {
 
     // ------------------------------------query--------------------------------------------------//
 
-    private boolean existsVmInInflux(InfluxDTO influxDTO, String nsId, String mciId, String vmId) {
+    private boolean existsVmInInflux(
+            InfluxDTO influxDTO, String nsId, String infraId, String nodeId) {
         String q =
                 String.format(
                         "SHOW TAG VALUES ON \"%s\" WITH KEY=\"node_id\" "
                                 + "WHERE \"ns_id\"='%s' AND \"infra_id\"='%s' AND \"node_id\"='%s' LIMIT 1",
-                        influxDTO.getDatabase(), esc(nsId), esc(mciId), esc(vmId));
+                        influxDTO.getDatabase(), esc(nsId), esc(infraId), esc(nodeId));
         return hasResult(influxDTO, q);
     }
 
-    private boolean existsNsMciInInflux(InfluxDTO influxDTO, String nsId, String mciId) {
+    private boolean existsNsMciInInflux(InfluxDTO influxDTO, String nsId, String infraId) {
         String q =
                 String.format(
                         "SHOW TAG VALUES ON \"%s\" WITH KEY=\"infra_id\" "
                                 + "WHERE \"ns_id\"='%s' AND \"infra_id\"='%s' LIMIT 1",
-                        influxDTO.getDatabase(), esc(nsId), esc(mciId));
+                        influxDTO.getDatabase(), esc(nsId), esc(infraId));
         return hasResult(influxDTO, q);
     }
 
-    public boolean existsTagCombination(InfluxDTO influxDTO, String nsId, String mciId) {
+    public boolean existsTagCombination(InfluxDTO influxDTO, String nsId, String infraId) {
         String q =
                 "SHOW TAG VALUES ON \""
                         + influxDTO.getDatabase()
@@ -616,13 +618,13 @@ public class InfluxDbServiceImpl implements InfluxDbService {
                         + "' AND \""
                         + INFRA_ID
                         + "\"='"
-                        + esc(mciId)
+                        + esc(infraId)
                         + "' "
                         + "LIMIT 1";
         return hasResult(influxDTO, q);
     }
 
-    public int countMciIdTag(InfluxDTO influxDTO) {
+    public int countInfraIdTag(InfluxDTO influxDTO) {
         String q =
                 "SHOW TAG VALUES CARDINALITY ON \""
                         + influxDTO.getDatabase()
@@ -780,7 +782,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
 
         } catch (Exception e) {
             log.warn(
-                    "[countMciIdTag] query failed url={}, db={}, q={}, err={}",
+                    "[countInfraIdTag] query failed url={}, db={}, q={}, err={}",
                     influxDTO.getUrl(),
                     influxDTO.getDatabase(),
                     query,

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/StatusServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/StatusServiceImpl.java
@@ -23,17 +23,17 @@ public class StatusServiceImpl implements StatusService {
             Integer taskId,
             VMAgentTaskStatus hostAgentTaskStatus,
             String nsId,
-            String mciId,
-            String vmId) {
+            String infraId,
+            String nodeId) {
         log.debug(
                 "Updating Agent Task Status - Request ID: {}, VM: {}/{}/{}, Agent Task Status: {}",
                 requestId,
                 nsId,
-                mciId,
-                vmId,
+                infraId,
+                nodeId,
                 hostAgentTaskStatus);
 
-        VMEntity updateVM = VMEntity.builder().nsId(nsId).mciId(mciId).vmId(vmId).build();
+        VMEntity updateVM = VMEntity.builder().nsId(nsId).infraId(infraId).nodeId(nodeId).build();
 
         updateVM.setMonitoringAgentTaskStatus(hostAgentTaskStatus);
         updateVM.setLogAgentTaskStatus(hostAgentTaskStatus);
@@ -50,19 +50,20 @@ public class StatusServiceImpl implements StatusService {
     }
 
     @Override
-    public void resetVMAgentTaskStatus(String requestId, String nsId, String mciId, String vmId) {
+    public void resetVMAgentTaskStatus(
+            String requestId, String nsId, String infraId, String nodeId) {
         if (nsId == null
                 || nsId.isEmpty()
-                || mciId == null
-                || mciId.isEmpty()
-                || vmId == null
-                || vmId.isEmpty()) {
+                || infraId == null
+                || infraId.isEmpty()
+                || nodeId == null
+                || nodeId.isEmpty()) {
             return;
         }
 
         try {
             agentTaskStatusLock.lock();
-            updateVMAgentTaskStatus(requestId, null, VMAgentTaskStatus.IDLE, nsId, mciId, vmId);
+            updateVMAgentTaskStatus(requestId, null, VMAgentTaskStatus.IDLE, nsId, infraId, nodeId);
         } finally {
             agentTaskStatusLock.unlock();
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TraceServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TraceServiceImpl.java
@@ -1,0 +1,28 @@
+package com.mcmp.o11ymanager.manager.service;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import com.mcmp.o11ymanager.manager.port.TempoPort;
+import com.mcmp.o11ymanager.manager.service.interfaces.TraceService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TraceServiceImpl implements TraceService {
+
+    private final TempoPort tempoPort;
+
+    @Override
+    public List<TraceResponseDto.TraceSummary> searchTraces(
+            String traceQl, Integer limit, Long startSec, Long endSec) {
+        return tempoPort.searchTraces(traceQl, limit, startSec, endSec);
+    }
+
+    @Override
+    public TraceResponseDto.TraceDetail getTraceDetail(String traceId) {
+        return tempoPort.getTraceDetail(traceId);
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TraceServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TraceServiceImpl.java
@@ -25,4 +25,9 @@ public class TraceServiceImpl implements TraceService {
     public TraceResponseDto.TraceDetail getTraceDetail(String traceId) {
         return tempoPort.getTraceDetail(traceId);
     }
+
+    @Override
+    public List<String> getServiceNames() {
+        return tempoPort.getServiceNames();
+    }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
@@ -29,43 +29,43 @@ public class VMServiceImpl implements VMService {
     private final ConcurrentHashMap<String, ReentrantLock> repositoryLocks =
             new ConcurrentHashMap<>();
 
-    public ReentrantLock getHostLock(String nsId, String mciId, String vmId) {
-        String lockKey = nsId + "-" + mciId + "-" + vmId;
+    public ReentrantLock getHostLock(String nsId, String infraId, String nodeId) {
+        String lockKey = nsId + "-" + infraId + "-" + nodeId;
         return repositoryLocks.computeIfAbsent(lockKey, k -> new ReentrantLock());
     }
 
     @Override
-    public VMDTO get(String nsId, String mciId, String vmId) {
+    public VMDTO get(String nsId, String infraId, String nodeId) {
         VMEntity entity =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
                                                 requestInfo.getRequestId(),
                                                 "VMEntity",
-                                                nsId + "/" + mciId));
+                                                nsId + "/" + infraId));
         return VMDTO.fromEntity(entity);
     }
 
     @Override
-    public List<VMDTO> getByNsMci(String nsId, String mciId) {
-        return vmJpaRepository.findByNsIdAndMciId(nsId, mciId).stream()
+    public List<VMDTO> getByNsMci(String nsId, String infraId) {
+        return vmJpaRepository.findByNsIdAndInfraId(nsId, infraId).stream()
                 .map(VMDTO::fromEntity)
                 .toList();
     }
 
     @Override
-    public VMDTO getByNsVm(String nsId, String vmId) {
+    public VMDTO getByNsVm(String nsId, String nodeId) {
         VMEntity e =
                 vmJpaRepository
-                        .findByNsIdAndVmId(nsId, vmId)
+                        .findByNsIdAndNodeId(nsId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
                                                 requestInfo.getRequestId(),
                                                 "VMEntity",
-                                                nsId + "/" + vmId));
+                                                nsId + "/" + nodeId));
         return VMDTO.fromEntity(e);
     }
 
@@ -77,20 +77,20 @@ public class VMServiceImpl implements VMService {
     @Override
     public VMDTO post(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             VMStatus vmStatus,
             VMRequestDTO dto,
             Long influxSeq) {
         VMEntity vm =
                 VMEntity.builder()
                         .nsId(nsId)
-                        .mciId(mciId)
-                        .vmId(vmId)
+                        .infraId(infraId)
+                        .nodeId(nodeId)
                         .name(dto.getName())
                         .description(dto.getDescription())
                         .nsId(nsId)
-                        .mciId(mciId)
+                        .infraId(infraId)
                         .vmStatus(vmStatus)
                         .influxSeq(influxSeq)
                         .build();
@@ -101,14 +101,14 @@ public class VMServiceImpl implements VMService {
     }
 
     @Override
-    public VMDTO put(String nsId, String mciId, String vmId, VMRequestDTO dto) {
+    public VMDTO put(String nsId, String infraId, String nodeId, VMRequestDTO dto) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         if (dto.getName() != null) vm.setName(dto.getName());
         if (dto.getDescription() != null) vm.setDescription(dto.getDescription());
@@ -120,98 +120,99 @@ public class VMServiceImpl implements VMService {
 
     @Override
     @Transactional
-    public void delete(String nsId, String mciId, String vmId) {
+    public void delete(String nsId, String infraId, String nodeId) {
         VMEntity entity =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vmJpaRepository.delete(entity);
     }
 
     @Override
-    public VMAgentTaskStatus getMonitoringAgentTaskStatus(String nsId, String mciId, String vmId) {
+    public VMAgentTaskStatus getMonitoringAgentTaskStatus(
+            String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
         return vm.getMonitoringAgentTaskStatus();
     }
 
     @Override
-    public VMAgentTaskStatus getLogAgentTaskStatus(String nsId, String mciId, String vmId) {
+    public VMAgentTaskStatus getLogAgentTaskStatus(String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
         return vm.getLogAgentTaskStatus();
     }
 
     @Override
-    public VMAgentTaskStatus getTraceAgentTaskStatus(String nsId, String mciId, String vmId) {
+    public VMAgentTaskStatus getTraceAgentTaskStatus(String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
         return vm.getTraceAgentTaskStatus();
     }
 
     @Override
-    public void isIdleMonitoringAgent(String nsId, String mciId, String vmId) {
+    public void isIdleMonitoringAgent(String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         if (vm.getMonitoringAgentTaskStatus() != VMAgentTaskStatus.IDLE) {
             throw new VMAgentTaskProcessingException(
                     requestInfo.getRequestId(),
-                    vmId,
+                    nodeId,
                     "monitoringAgentTask",
                     vm.getMonitoringAgentTaskStatus());
         }
     }
 
     @Override
-    public void isIdleLogAgent(String nsId, String mciId, String vmId) {
+    public void isIdleLogAgent(String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         if (vm.getLogAgentTaskStatus() != VMAgentTaskStatus.IDLE) {
             throw new VMAgentTaskProcessingException(
-                    requestInfo.getRequestId(), vmId, "로그", vm.getLogAgentTaskStatus());
+                    requestInfo.getRequestId(), nodeId, "로그", vm.getLogAgentTaskStatus());
         }
     }
 
     @Override
-    public void isIdleTraceAgent(String nsId, String mciId, String vmId) {
+    public void isIdleTraceAgent(String nsId, String infraId, String nodeId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         VMAgentTaskStatus status = vm.getTraceAgentTaskStatus();
         // NULL은 아직 Beyla 작업이 한 번도 없었던 상태로 간주하고 IDLE과 동일하게 취급.
@@ -219,20 +220,20 @@ public class VMServiceImpl implements VMService {
         // 기존 VM 레코드들이 NULL로 남아있는 경우를 대응.
         if (status != null && status != VMAgentTaskStatus.IDLE) {
             throw new VMAgentTaskProcessingException(
-                    requestInfo.getRequestId(), vmId, "traceAgent", status);
+                    requestInfo.getRequestId(), nodeId, "traceAgent", status);
         }
     }
 
     @Override
     public void updateMonitoringAgentTaskStatus(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setMonitoringAgentTaskStatus(status);
 
@@ -249,14 +250,14 @@ public class VMServiceImpl implements VMService {
 
     @Override
     public void updateLogAgentTaskStatus(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setLogAgentTaskStatus(status);
 
@@ -273,16 +274,16 @@ public class VMServiceImpl implements VMService {
 
     @Override
     public void updateTraceAgentTaskStatus(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status) {
         // 특정 VM의 Beyla 작업 상태를 DB에 업데이트
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(
-                                nsId, mciId, vmId) // nsId + mciId + vmId 복합키로 VMEntity 조회
+                        .findByNsIdAndInfraIdAndNodeId(
+                                nsId, infraId, nodeId) // nsId + infraId + nodeId 복합키로 VMEntity 조회
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setTraceAgentTaskStatus(status); // traceAgentTaskStatus 필드에 새 상태 세팅
 
@@ -300,14 +301,14 @@ public class VMServiceImpl implements VMService {
 
     @Override
     public void updateMonitoringAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setMonitoringAgentTaskStatus(status);
         vm.setVmMonitoringAgentTaskId(taskId);
@@ -320,14 +321,14 @@ public class VMServiceImpl implements VMService {
 
     @Override
     public void updateLogAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setLogAgentTaskStatus(status);
         vm.setVmLogAgentTaskId(taskId);
@@ -339,14 +340,14 @@ public class VMServiceImpl implements VMService {
 
     @Override
     public void updateTraceAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId) {
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId) {
         VMEntity vm =
                 vmJpaRepository
-                        .findByNsIdAndMciIdAndVmId(nsId, mciId, vmId)
+                        .findByNsIdAndInfraIdAndNodeId(nsId, infraId, nodeId)
                         .orElseThrow(
                                 () ->
                                         new ResourceNotExistsException(
-                                                requestInfo.getRequestId(), "VMEntity", vmId));
+                                                requestInfo.getRequestId(), "VMEntity", nodeId));
 
         vm.setTraceAgentTaskStatus(status);
         vm.setVmTraceAgentTaskId(taskId);
@@ -357,17 +358,17 @@ public class VMServiceImpl implements VMService {
     }
 
     @Override
-    public List<String> getVmIds(String nsId, String mciId) {
-        return vmJpaRepository.findByNsIdAndMciId(nsId, mciId).stream()
-                .map(VMEntity::getVmId)
+    public List<String> getNodeIds(String nsId, String infraId) {
+        return vmJpaRepository.findByNsIdAndInfraId(nsId, infraId).stream()
+                .map(VMEntity::getNodeId)
                 .toList();
     }
 
     @Override
-    public Long getInfluxId(String nsId, String mciId) {
+    public Long getInfluxId(String nsId, String infraId) {
         VMEntity t =
                 vmJpaRepository
-                        .findTop1ByNsIdAndMciIdOrderByVmIdAsc(nsId, mciId)
+                        .findTop1ByNsIdAndInfraIdOrderByNodeIdAsc(nsId, infraId)
                         .orElseThrow(() -> new IllegalStateException("no vms under ns/mci"));
 
         return t.getInfluxSeq();

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheKey.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheKey.java
@@ -21,14 +21,14 @@ public record CspCacheKey(
     }
 
     public static CspCacheKey forVm(
-            String vmName,
+            String nodeName,
             String measurement,
             String connectionName,
             String timeBeforeHour,
             String intervalMinute) {
         return new CspCacheKey(
                 Scope.VM,
-                nullToEmpty(vmName),
+                nullToEmpty(nodeName),
                 nullToEmpty(measurement),
                 nullToEmpty(connectionName),
                 nullToEmpty(timeBeforeHour),

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -235,7 +235,7 @@ public class CspCacheWarmScheduler {
         for (VmRef ref : active) {
             try {
                 TumblebugInfra.Node node =
-                        tumblebugService.getNode(ref.nsId(), ref.mciId(), ref.vmId());
+                        tumblebugService.getNode(ref.nsId(), ref.infraId(), ref.nodeId());
                 if (node == null
                         || node.getConnectionName() == null
                         || node.getCspResourceName() == null) {
@@ -246,7 +246,7 @@ public class CspCacheWarmScheduler {
                 }
                 Instant createdAt =
                         vmCreatedTimeResolver
-                                .resolve(ref.nsId(), ref.mciId(), ref.vmId())
+                                .resolve(ref.nsId(), ref.infraId(), ref.nodeId())
                                 .orElse(Instant.EPOCH);
                 resolved.add(
                         new VmWithCsp(
@@ -258,8 +258,8 @@ public class CspCacheWarmScheduler {
                 log.debug(
                         "[CSP-CACHE-WARM] resolve failed ns={}, mci={}, vm={}, err={}",
                         ref.nsId(),
-                        ref.mciId(),
-                        ref.vmId(),
+                        ref.infraId(),
+                        ref.nodeId(),
                         e.toString());
             }
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheKey.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheKey.java
@@ -13,14 +13,22 @@ import java.util.Objects;
  * identical requests in the same hour return cached data, while a new hour produces a fresh entry.
  */
 public record MonitoringCacheKey(
-        String nsId, String mciId, String vmId, String requestSignature, long hourBucket) {
+        String nsId, String infraId, String nodeId, String requestSignature, long hourBucket) {
 
     /** Builds the canonical cache key for an ns/mci-scoped metric query. */
     public static MonitoringCacheKey of(
-            String nsId, String mciId, String vmId, MetricRequestDTO req, long blockPeriodSeconds) {
+            String nsId,
+            String infraId,
+            String nodeId,
+            MetricRequestDTO req,
+            long blockPeriodSeconds) {
         long bucket = (System.currentTimeMillis() / 1000L) / blockPeriodSeconds;
         return new MonitoringCacheKey(
-                nullToEmpty(nsId), nullToEmpty(mciId), nullToEmpty(vmId), signatureOf(req), bucket);
+                nullToEmpty(nsId),
+                nullToEmpty(infraId),
+                nullToEmpty(nodeId),
+                signatureOf(req),
+                bucket);
     }
 
     /**

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheService.java
@@ -75,15 +75,16 @@ public class MonitoringCacheService {
      */
     public List<MetricDTO> getOrLoad(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             MetricRequestDTO req,
             Supplier<List<MetricDTO>> loader) {
         if (cache == null) {
             return loader.get();
         }
         MonitoringCacheKey key =
-                MonitoringCacheKey.of(nsId, mciId, vmId, req, properties.getBlockPeriodSeconds());
+                MonitoringCacheKey.of(
+                        nsId, infraId, nodeId, req, properties.getBlockPeriodSeconds());
 
         List<MetricDTO> hit = cache.getIfPresent(key);
         if (hit != null && hasAnyDataPoint(hit)) {
@@ -91,8 +92,8 @@ public class MonitoringCacheService {
             log.debug(
                     "[MON-CACHE] HIT ns={}, mci={}, vm={}, bucket={}",
                     key.nsId(),
-                    key.mciId(),
-                    key.vmId(),
+                    key.infraId(),
+                    key.nodeId(),
                     key.hourBucket());
             return hit;
         }
@@ -101,8 +102,8 @@ public class MonitoringCacheService {
         log.debug(
                 "[MON-CACHE] MISS ns={}, mci={}, vm={}, bucket={}",
                 key.nsId(),
-                key.mciId(),
-                key.vmId(),
+                key.infraId(),
+                key.nodeId(),
                 key.hourBucket());
 
         List<MetricDTO> loaded = loader.get();
@@ -157,12 +158,12 @@ public class MonitoringCacheService {
      */
     private long computeTtlNanos(MonitoringCacheKey key) {
         long maxTtlSec = properties.getExpireAfterWriteSeconds();
-        if (key.vmId() == null || key.vmId().isEmpty()) {
+        if (key.nodeId() == null || key.nodeId().isEmpty()) {
             // ns/mci-scoped queries can't be tied to a specific VM creation time → use global TTL
             return TimeUnit.SECONDS.toNanos(maxTtlSec);
         }
         Optional<Instant> createdAt =
-                vmCreatedTimeResolver.resolve(key.nsId(), key.mciId(), key.vmId());
+                vmCreatedTimeResolver.resolve(key.nsId(), key.infraId(), key.nodeId());
         if (createdAt.isEmpty()) {
             return TimeUnit.SECONDS.toNanos(maxTtlSec);
         }
@@ -220,8 +221,8 @@ public class MonitoringCacheService {
             MonitoringCacheKey key, List<MetricDTO> value, int bytesPerPoint) {
         int keyBytes =
                 (key.nsId().length()
-                                        + key.mciId().length()
-                                        + key.vmId().length()
+                                        + key.infraId().length()
+                                        + key.nodeId().length()
                                         + key.requestSignature().length())
                                 * 2
                         + 16;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/MonitoringCacheWarmScheduler.java
@@ -194,7 +194,7 @@ public class MonitoringCacheWarmScheduler {
             for (RangeSpec spec : ranges) {
                 try {
                     influxDbService.getMetricsByVM(
-                            vm.nsId(), vm.mciId(), vm.vmId(), buildRequest(spec, measurement));
+                            vm.nsId(), vm.infraId(), vm.nodeId(), buildRequest(spec, measurement));
                     ok.incrementAndGet();
                 } catch (Exception e) {
                     fail.incrementAndGet();
@@ -202,8 +202,8 @@ public class MonitoringCacheWarmScheduler {
                             "[CACHE-WARM:{}] failed ns={}, mci={}, vm={}, m={}, range={}, err={}",
                             jobName,
                             vm.nsId(),
-                            vm.mciId(),
-                            vm.vmId(),
+                            vm.infraId(),
+                            vm.nodeId(),
                             measurement,
                             spec.getRange(),
                             e.toString());
@@ -254,15 +254,15 @@ public class MonitoringCacheWarmScheduler {
         for (OverviewQuery q : queries) {
             try {
                 influxDbService.getMetricsByVM(
-                        vm.nsId(), vm.mciId(), vm.vmId(), buildOverviewRequest(q));
+                        vm.nsId(), vm.infraId(), vm.nodeId(), buildOverviewRequest(q));
                 ok.incrementAndGet();
             } catch (Exception e) {
                 fail.incrementAndGet();
                 log.debug(
                         "[CACHE-WARM:overview] failed ns={}, mci={}, vm={}, m={}, fn={}, fd={}, err={}",
                         vm.nsId(),
-                        vm.mciId(),
-                        vm.vmId(),
+                        vm.infraId(),
+                        vm.nodeId(),
                         q.getMeasurement(),
                         q.getFunction(),
                         q.getField(),
@@ -303,7 +303,7 @@ public class MonitoringCacheWarmScheduler {
         List<VmWithCreatedAt> withTime = new ArrayList<>(active.size());
         for (VmRef vm : active) {
             Optional<Instant> createdAt =
-                    vmCreatedTimeResolver.resolve(vm.nsId(), vm.mciId(), vm.vmId());
+                    vmCreatedTimeResolver.resolve(vm.nsId(), vm.infraId(), vm.nodeId());
             createdAt.ifPresent(instant -> withTime.add(new VmWithCreatedAt(vm, instant)));
         }
         if (withTime.isEmpty()) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/VmCreatedTimeResolver.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/VmCreatedTimeResolver.java
@@ -41,23 +41,23 @@ public class VmCreatedTimeResolver {
             Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(1, TimeUnit.HOURS).build();
 
     /** Returns the VM creation instant if known, or empty if Tumblebug doesn't expose it. */
-    public Optional<Instant> resolve(String nsId, String mciId, String vmId) {
-        if (nsId == null || mciId == null || vmId == null) {
+    public Optional<Instant> resolve(String nsId, String infraId, String nodeId) {
+        if (nsId == null || infraId == null || nodeId == null) {
             return Optional.empty();
         }
-        String key = nsId + "/" + mciId + "/" + vmId;
+        String key = nsId + "/" + infraId + "/" + nodeId;
         Optional<Instant> cached = cache.getIfPresent(key);
         if (cached != null) {
             return cached;
         }
-        Optional<Instant> resolved = fetchFromTumblebug(nsId, mciId, vmId);
+        Optional<Instant> resolved = fetchFromTumblebug(nsId, infraId, nodeId);
         cache.put(key, resolved);
         return resolved;
     }
 
-    private Optional<Instant> fetchFromTumblebug(String nsId, String mciId, String vmId) {
+    private Optional<Instant> fetchFromTumblebug(String nsId, String infraId, String nodeId) {
         try {
-            TumblebugInfra.Node node = tumblebugService.getNode(nsId, mciId, vmId);
+            TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             if (node == null || node.getCreatedTime() == null || node.getCreatedTime().isBlank()) {
                 return Optional.empty();
             }
@@ -67,8 +67,8 @@ public class VmCreatedTimeResolver {
             log.debug(
                     "[VM-CREATED] failed to resolve createdTime ns={}, mci={}, vm={}, err={}",
                     nsId,
-                    mciId,
-                    vmId,
+                    infraId,
+                    nodeId,
                     e.toString());
             return Optional.empty();
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/BeylaSystemRequirementValidator.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/BeylaSystemRequirementValidator.java
@@ -15,11 +15,11 @@ public class BeylaSystemRequirementValidator {
 
     private final TumblebugService tumblebugService;
 
-    public BeylaSystemCheckResult validate(String nsId, String mciId, String vmId) {
-        log.info("Validating Beyla system requirements for VM: {}/{}/{}", nsId, mciId, vmId);
+    public BeylaSystemCheckResult validate(String nsId, String infraId, String nodeId) {
+        log.info("Validating Beyla system requirements for VM: {}/{}/{}", nsId, infraId, nodeId);
 
-        String kernelVersion = getKernelVersion(nsId, mciId, vmId);
-        boolean btfSupported = checkBtfSupport(nsId, mciId, vmId);
+        String kernelVersion = getKernelVersion(nsId, infraId, nodeId);
+        boolean btfSupported = checkBtfSupport(nsId, infraId, nodeId);
         boolean kernelVersionValid = isKernelVersionValid(kernelVersion);
 
         BeylaSystemCheckResult result =
@@ -35,8 +35,8 @@ public class BeylaSystemRequirementValidator {
         return result;
     }
 
-    public void validateAndThrow(String nsId, String mciId, String vmId) {
-        BeylaSystemCheckResult result = validate(nsId, mciId, vmId);
+    public void validateAndThrow(String nsId, String infraId, String nodeId) {
+        BeylaSystemCheckResult result = validate(nsId, infraId, nodeId);
 
         if (!result.isKernelVersionValid()) {
             throw new BeylaSystemRequirementException(
@@ -65,13 +65,13 @@ public class BeylaSystemRequirementValidator {
                 result.isBtfSupported());
     }
 
-    private String getKernelVersion(String nsId, String mciId, String vmId) {
+    private String getKernelVersion(String nsId, String infraId, String nodeId) {
         try {
             String result =
                     tumblebugService.executeCommand(
                             nsId,
-                            mciId,
-                            vmId,
+                            infraId,
+                            nodeId,
                             "uname -r"); // 원격 VM에 'uname -r'을 실행 => '5.15.0-91-generic' 같은 문자열이 들어옴
             return result != null ? result.trim() : "unknown";
         } catch (Exception e) {
@@ -80,13 +80,13 @@ public class BeylaSystemRequirementValidator {
         }
     }
 
-    private boolean checkBtfSupport(String nsId, String mciId, String vmId) {
+    private boolean checkBtfSupport(String nsId, String infraId, String nodeId) {
         try {
             String result =
                     tumblebugService.executeCommand(
                             nsId,
-                            mciId,
-                            vmId,
+                            infraId,
+                            nodeId,
                             "test -f /sys/kernel/btf/vmlinux && echo 'true' || echo 'false'"); // 원격
             // vm에 해당 문자열 입력, BTF 팡리이 있으면 true 없으면 false
             return result != null

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/VMDomainService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/VMDomainService.java
@@ -22,7 +22,10 @@ public class VMDomainService {
         VMEntity savedVM = vmJpaRepository.save(vmEntity);
 
         vmNotificationService.notifyVMUpdate(
-                savedVM.getNsId(), savedVM.getMciId(), savedVM.getVmId(), vmMapper.toDTO(savedVM));
+                savedVM.getNsId(),
+                savedVM.getInfraId(),
+                savedVM.getNodeId(),
+                vmMapper.toDTO(savedVM));
         vmNotificationService.notifyAllVMsUpdate(vmJpaRepository.findAll());
         log.info("VMDomainService : {}", savedVM);
     }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/VMNotificationService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/domain/VMNotificationService.java
@@ -22,10 +22,11 @@ public class VMNotificationService {
             hostResponseList.add(vmMapper.toDTO(vm));
         }
 
-        messagingTemplate.convertAndSend("/topic/vms", hostResponseList);
+        messagingTemplate.convertAndSend("/topic/nodes", hostResponseList);
     }
 
-    public void notifyVMUpdate(String nsId, String mciId, String vmId, VMDTO vmInfo) {
-        messagingTemplate.convertAndSend("/topic/vm/" + nsId + "/" + mciId + "/" + vmId, vmInfo);
+    public void notifyVMUpdate(String nsId, String infraId, String nodeId, VMDTO vmInfo) {
+        messagingTemplate.convertAndSend(
+                "/topic/node/" + nsId + "/" + infraId + "/" + nodeId, vmInfo);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/InfluxDbService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/InfluxDbService.java
@@ -15,7 +15,7 @@ public interface InfluxDbService {
 
     boolean isConnectedDb(InfluxDTO influxDTO);
 
-    Long resolveInfluxDb(String nsId, String mciId);
+    Long resolveInfluxDb(String nsId, String infraId);
 
     ResBody<List<FieldDTO>> getFields();
 
@@ -23,13 +23,14 @@ public interface InfluxDbService {
 
     String fetchDefaultRp(InfluxDTO influxDTO);
 
-    List<MetricDTO> getMetricsByNsMci(String nsId, String mciId, MetricRequestDTO req);
+    List<MetricDTO> getMetricsByNsMci(String nsId, String infraId, MetricRequestDTO req);
 
-    List<MetricDTO> getMetricsByVM(String nsId, String mciId, String vmId, MetricRequestDTO req);
+    List<MetricDTO> getMetricsByVM(
+            String nsId, String infraId, String nodeId, MetricRequestDTO req);
 
     List<InfluxDTO> rawServers();
 
-    InfluxDTO resolveInfluxDto(String nsId, String mciId);
+    InfluxDTO resolveInfluxDto(String nsId, String infraId);
 
     /**
      * Returns distinct (ns_id, infra_id, node_id) tuples that currently have metric data in any

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/StatusService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/StatusService.java
@@ -9,8 +9,8 @@ public interface StatusService {
             Integer taskId,
             VMAgentTaskStatus hostAgentTaskStatus,
             String nsId,
-            String mciId,
-            String vmId);
+            String infraId,
+            String nodeId);
 
-    void resetVMAgentTaskStatus(String requestId, String nsId, String mciId, String vmId);
+    void resetVMAgentTaskStatus(String requestId, String nsId, String infraId, String nodeId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TraceService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TraceService.java
@@ -1,0 +1,12 @@
+package com.mcmp.o11ymanager.manager.service.interfaces;
+
+import com.mcmp.o11ymanager.manager.dto.trace.TraceResponseDto;
+import java.util.List;
+
+public interface TraceService {
+
+    List<TraceResponseDto.TraceSummary> searchTraces(
+            String traceQl, Integer limit, Long startSec, Long endSec);
+
+    TraceResponseDto.TraceDetail getTraceDetail(String traceId);
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TraceService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/TraceService.java
@@ -9,4 +9,6 @@ public interface TraceService {
             String traceQl, Integer limit, Long startSec, Long endSec);
 
     TraceResponseDto.TraceDetail getTraceDetail(String traceId);
+
+    List<String> getServiceNames();
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/VMService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/VMService.java
@@ -10,61 +10,62 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public interface VMService {
 
-    ReentrantLock getHostLock(String nsId, String mciId, String vmId);
+    ReentrantLock getHostLock(String nsId, String infraId, String nodeId);
 
-    VMDTO get(String nsId, String mciId, String vmId);
+    VMDTO get(String nsId, String infraId, String nodeId);
 
-    List<VMDTO> getByNsMci(String nsId, String mciId);
+    List<VMDTO> getByNsMci(String nsId, String infraId);
 
-    VMDTO getByNsVm(String nsId, String vmId);
+    VMDTO getByNsVm(String nsId, String nodeId);
 
     List<VMDTO> list();
 
     VMDTO post(
             String nsId,
-            String mciId,
-            String vmId,
+            String infraId,
+            String nodeId,
             VMStatus vmStatus,
             VMRequestDTO dto,
             Long influxSeq);
 
-    VMDTO put(String nsId, String mciId, String vmId, VMRequestDTO dto);
+    VMDTO put(String nsId, String infraId, String nodeId, VMRequestDTO dto);
 
-    void delete(String nsId, String mciId, String vmId);
+    void delete(String nsId, String infraId, String nodeId);
 
-    void isIdleMonitoringAgent(String nsId, String mciId, String vmId)
+    void isIdleMonitoringAgent(String nsId, String infraId, String nodeId)
             throws HostAgentTaskProcessingException;
 
-    void isIdleLogAgent(String nsId, String mciId, String vmId)
+    void isIdleLogAgent(String nsId, String infraId, String nodeId)
             throws HostAgentTaskProcessingException;
 
-    void isIdleTraceAgent(String nsId, String mciId, String vmId)
+    void isIdleTraceAgent(String nsId, String infraId, String nodeId)
             throws HostAgentTaskProcessingException;
 
-    VMAgentTaskStatus getMonitoringAgentTaskStatus(String nsId, String mciId, String vmId);
+    VMAgentTaskStatus getMonitoringAgentTaskStatus(String nsId, String infraId, String nodeId);
 
-    VMAgentTaskStatus getLogAgentTaskStatus(String nsId, String mciId, String vmId);
+    VMAgentTaskStatus getLogAgentTaskStatus(String nsId, String infraId, String nodeId);
 
-    VMAgentTaskStatus getTraceAgentTaskStatus(String nsId, String mciId, String vmId);
+    VMAgentTaskStatus getTraceAgentTaskStatus(String nsId, String infraId, String nodeId);
 
     void updateMonitoringAgentTaskStatus(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status);
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status);
 
-    void updateLogAgentTaskStatus(String nsId, String mciId, String vmId, VMAgentTaskStatus status);
+    void updateLogAgentTaskStatus(
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status);
 
     void updateTraceAgentTaskStatus(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status);
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status);
 
     void updateMonitoringAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId);
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId);
 
     void updateLogAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId);
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId);
 
     void updateTraceAgentTaskStatusAndTaskId(
-            String nsId, String mciId, String vmId, VMAgentTaskStatus status, String taskId);
+            String nsId, String infraId, String nodeId, VMAgentTaskStatus status, String taskId);
 
-    List<String> getVmIds(String nsId, String mciId);
+    List<String> getNodeIds(String nsId, String infraId);
 
-    Long getInfluxId(String nsId, String mciId);
+    Long getInfluxId(String nsId, String infraId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/adapter/internal/trigger/ManagerPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/adapter/internal/trigger/ManagerPort.java
@@ -2,5 +2,5 @@ package com.mcmp.o11ymanager.trigger.adapter.internal.trigger;
 
 public interface ManagerPort {
 
-    String getInfluxUid(String nsId, String vmScope, String vmId);
+    String getInfluxUid(String nsId, String vmScope, String nodeId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/TriggerController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/TriggerController.java
@@ -119,7 +119,7 @@ public class TriggerController {
             summary = "AddTriggerVM",
             description = "Add trigger vm",
             operationId = "AddTriggerVM")
-    @PostMapping("/{id}/vm")
+    @PostMapping("/{id}/node")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResBody<Void> addTriggerVM(
             @Parameter(name = "id", description = "trigger policy id") @PathVariable long id,
@@ -132,7 +132,7 @@ public class TriggerController {
             summary = "RemoveTriggerVM",
             description = "Remove trigger vm",
             operationId = "RemoveTriggerVM")
-    @DeleteMapping("/{id}/vm")
+    @DeleteMapping("/{id}/node")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResBody<Void> removeTriggerVM(
             @Parameter(name = "id", description = "trigger policy id") @PathVariable long id,

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/TriggerVMAddRequest.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/TriggerVMAddRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record TriggerVMAddRequest(
         @Schema(description = "Namespace ID", example = "first-ns") @NotNull @NotBlank String namespaceId,
-        @Schema(description = "Target scope", example = "mci") @NotNull @NotBlank String targetScope,
+        @Schema(description = "Target scope", example = "infra") @NotNull @NotBlank String targetScope,
         @Schema(description = "Target ID", example = "test01") @NotNull @NotBlank String targetId) {
 
     public TriggerVMDto toDto() {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/TriggerVMRemoveRequest.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/TriggerVMRemoveRequest.java
@@ -7,8 +7,8 @@ import jakarta.validation.constraints.NotNull;
 
 public record TriggerVMRemoveRequest(
         @Schema(description = "Namespace ID", example = "namespace-1") @NotNull @NotBlank String namespaceId,
-        @Schema(description = "Target scope", example = "vm") @NotNull @NotBlank String targetScope,
-        @Schema(description = "Target ID", example = "vm-1") @NotNull @NotBlank String targetId) {
+        @Schema(description = "Target scope", example = "node") @NotNull @NotBlank String targetScope,
+        @Schema(description = "Target ID", example = "node-1") @NotNull @NotBlank String targetId) {
 
     public TriggerVMDto toDto() {
         return new TriggerVMDto(namespaceId, targetScope, targetId, true);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/grafana/GrafanaAlertRuleFactory.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/grafana/GrafanaAlertRuleFactory.java
@@ -55,7 +55,7 @@ public class GrafanaAlertRuleFactory {
      * @param thresholdCondition threshold expression defining info/warning/critical levels
      * @param repeatInterval interval for re-sending the alert when the same condition/state
      *     continues.
-     * @param targetScope scope identifier for the monitoring target (mci or vm)
+     * @param targetScope scope identifier for the monitoring target (infra or node)
      * @return GrafanaAlertRule configured for the specified parameters
      */
     public GrafanaAlertRule createGrafanaAlertRule(

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/discord/DiscordNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/discord/DiscordNoti.java
@@ -134,8 +134,8 @@ public class DiscordNoti implements Noti {
                     String.format(
                             "%-15s %-15s %-15s %-15s %s%%\n",
                             truncateString(alert.getNamespaceId(), 14),
-                            truncateString(alert.getMciId(), 14),
-                            truncateString(alert.getVmId(), 14),
+                            truncateString(alert.getInfraId(), 14),
+                            truncateString(alert.getNodeId(), 14),
                             truncateString(alert.getResourceType(), 14),
                             alert.getResourceUsage()));
         }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/discord/DiscordNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/discord/DiscordNoti.java
@@ -126,7 +126,7 @@ public class DiscordNoti implements Noti {
         sb.append(
                 String.format(
                         "%-15s %-15s %-15s %-15s %s\n",
-                        "Namespace ID", "MCI ID", "VM ID", "Metric", "Usage"));
+                        "Namespace ID", "Infra ID", "Node ID", "Metric", "Usage"));
         sb.append("─".repeat(90)).append("\n");
 
         for (AlertDetail alert : alerts) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/slack/SlackNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/slack/SlackNoti.java
@@ -138,7 +138,7 @@ public class SlackNoti implements Noti {
         sb.append(
                 String.format(
                         "%-15s %-15s %-15s %-15s %s\n",
-                        "Namespace ID", "MCI ID", "VM ID", "Metric", "Usage"));
+                        "Namespace ID", "Infra ID", "Node ID", "Metric", "Usage"));
         sb.append("─".repeat(90)).append("\n");
 
         for (AlertDetail alert : alerts) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/teams/TeamsNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/teams/TeamsNoti.java
@@ -137,8 +137,8 @@ public class TeamsNoti implements Noti {
         factSet.facts =
                 List.of(
                         new Fact("Namespace ID", safe(alert.getNamespaceId())),
-                        new Fact("MCI ID", safe(alert.getInfraId())),
-                        new Fact("VM ID", safe(alert.getNodeId())),
+                        new Fact("Infra ID", safe(alert.getInfraId())),
+                        new Fact("Node ID", safe(alert.getNodeId())),
                         new Fact("Metric", safe(alert.getResourceType())),
                         new Fact("Usage", alert.getResourceUsage() + "%"));
         return factSet;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/teams/TeamsNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/teams/TeamsNoti.java
@@ -137,8 +137,8 @@ public class TeamsNoti implements Noti {
         factSet.facts =
                 List.of(
                         new Fact("Namespace ID", safe(alert.getNamespaceId())),
-                        new Fact("MCI ID", safe(alert.getMciId())),
-                        new Fact("VM ID", safe(alert.getVmId())),
+                        new Fact("MCI ID", safe(alert.getInfraId())),
+                        new Fact("VM ID", safe(alert.getNodeId())),
                         new Fact("Metric", safe(alert.getResourceType())),
                         new Fact("Usage", alert.getResourceUsage() + "%"));
         return factSet;

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -67,6 +67,13 @@ loki:
     query: /loki/api/v1/query
     range: /loki/api/v1/query_range
 
+tempo:
+  # Tempo HTTP query API (port 3200). OTLP ingest(4317/4318)와 별개의 read 경로.
+  url: ${TEMPO_URL:http://mc-observability-tempo:3200}
+  endpoints:
+    search: /api/search
+    trace: /api/traces
+
 beyla:
   # Beyla agent가 trace/metric을 송신할 OTEL 엔드포인트.
   # 기본값은 사내 docker network의 Tempo OTLP receiver. 사이트별로 BEYLA_OTEL_ENDPOINT
@@ -182,6 +189,8 @@ feign:
         read-timeout: ${FEIGN_READ_TIMEOUT:30000}
         loggerLevel: full
       LokiFeignClient:
+        loggerLevel: full
+      TempoFeignClient:
         loggerLevel: full
   semaphore:
     url: ${SEMAPHORE_URL:http://mc-observability-infra:3000}

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -73,6 +73,10 @@ tempo:
   endpoints:
     search: /api/search
     trace: /api/traces
+    serviceValues: /api/search/tag/service.name/values
+  # service.name prefix that identifies the o11y platform's own (framework) traces.
+  # Everything else is treated as VM/application trace (Beyla / OTel agents).
+  framework-service-prefix: ${TEMPO_FRAMEWORK_PREFIX:mc-observability}
 
 beyla:
   # Beyla agent가 trace/metric을 송신할 OTEL 엔드포인트.

--- a/java/mc-o11y-manager/src/main/resources/banner.txt
+++ b/java/mc-o11y-manager/src/main/resources/banner.txt
@@ -12,6 +12,7 @@ Site Code: ${deploy.site-code}
 Active Profile: ${spring.profiles.active:[No active profile]}
 Current Server Port: ${server.port}
 Loki URL: ${loki.url}
+Tempo URL: ${tempo.url}
 InfluxDB 1 URL: ${influxdb.servers[0].url}
 InfluxDB 2 URL: ${influxdb.servers[1].url}
 

--- a/python/insight/app/api/anomaly/anomaly.py
+++ b/python/insight/app/api/anomaly/anomaly.py
@@ -140,29 +140,29 @@ async def delete_anomaly_detection_target(settingSeq: int, db: Session = Depends
 
 
 @router.get(
-    path="/anomaly-detection/settings/ns/{nsId}/mci/{mciId}",
+    path="/anomaly-detection/settings/ns/{nsId}/infra/{infraId}",
     description=get_specific_settings_mci_description["api_description"],
     response_model=ResBodyAnomalyDetectionSettings,
     operation_id="GetMCIAnomalyDetectionSettings",
 )
-async def get_specific_anomaly_detection_mci(nsId: str, mciId: str, db: Session = Depends(get_db)):
+async def get_specific_anomaly_detection_mci(nsId: str, infraId: str, db: Session = Depends(get_db)):
     service = AnomalySettingsService(db=db)
-    return service.get_setting(ns_id=nsId, infra_id=mciId)
+    return service.get_setting(ns_id=nsId, infra_id=infraId)
 
 
 @router.get(
-    path="/anomaly-detection/settings/ns/{nsId}/mci/{mciId}/vm/{vmId}",
+    path="/anomaly-detection/settings/ns/{nsId}/infra/{infraId}/node/{nodeId}",
     description=get_specific_settings_vm_description["api_description"],
     response_model=ResBodyAnomalyDetectionSettings,
     operation_id="GetVMAnomalyDetectionSettings",
 )
-async def get_specific_anomaly_detection_vm(nsId: str, mciId: str, vmId: str, db: Session = Depends(get_db)):
+async def get_specific_anomaly_detection_vm(nsId: str, infraId: str, nodeId: str, db: Session = Depends(get_db)):
     service = AnomalySettingsService(db=db)
-    return service.get_setting(ns_id=nsId, infra_id=mciId, node_id=vmId)
+    return service.get_setting(ns_id=nsId, infra_id=infraId, node_id=nodeId)
 
 
 @router.get(
-    path="/anomaly-detection/ns/{nsId}/mci/{mciId}/history",
+    path="/anomaly-detection/ns/{nsId}/infra/{infraId}/history",
     description=get_history_mci_description["api_description"],
     response_model=ResBodyAnomalyDetectionHistoryResponse,
     operation_id="GetAnomalyDetectionMCIHistory",
@@ -177,7 +177,7 @@ async def get_anomaly_detection_mci_history(
 
 
 @router.get(
-    path="/anomaly-detection/ns/{nsId}/mci/{mciId}/vm/{vmId}/history",
+    path="/anomaly-detection/ns/{nsId}/infra/{infraId}/node/{nodeId}/history",
     description=get_history_vm_description["api_description"],
     response_model=ResBodyAnomalyDetectionHistoryResponse,
     operation_id="GetAnomalyDetectionVMHistory",

--- a/python/insight/app/api/anomaly/repo/repo.py
+++ b/python/insight/app/api/anomaly/repo/repo.py
@@ -99,8 +99,8 @@ class InfluxDBRepository:
 
     def query_anomaly_detection_results(self, path_params, query_params: GetAnomalyHistoryFilter):
         ns_id = path_params.nsId
-        infra_id = path_params.mciId
-        node_id = getattr(path_params, "vmId", None)
+        infra_id = path_params.infraId
+        node_id = getattr(path_params, "nodeId", None)
         measurement = query_params.measurement.value.lower()
 
         start_time = query_params.start_time

--- a/python/insight/app/api/anomaly/request/req.py
+++ b/python/insight/app/api/anomaly/request/req.py
@@ -55,13 +55,13 @@ class AnomalyDetectionTargetUpdate(BaseModel):
 
 class GetHistoryMCIPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for anomaly detection."))
-    mciId: str = Field(Path(description="The MCI ID for anomaly detection."))
+    infraId: str = Field(Path(description="The MCI ID for anomaly detection."))
 
 
 class GetHistoryVMPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for anomaly detection."))
-    mciId: str = Field(Path(description="The MCI ID for anomaly detection."))
-    vmId: str = Field(Path(description="The VM ID for anomaly detection"))
+    infraId: str = Field(Path(description="The MCI ID for anomaly detection."))
+    nodeId: str = Field(Path(description="The VM ID for anomaly detection"))
 
 
 class GetAnomalyHistoryFilter(BaseModel):

--- a/python/insight/app/api/anomaly/utils/history.py
+++ b/python/insight/app/api/anomaly/utils/history.py
@@ -42,11 +42,11 @@ class AnomalyHistoryService:
 
     def get_raw_data(self):
         all_data = []
-        node_id = getattr(self.path_params, "vmId", None)
+        node_id = getattr(self.path_params, "nodeId", None)
         if node_id:
-            url = self._build_url(f"influxdb/metric/{self.path_params.nsId}/{self.path_params.mciId}/{node_id}")
+            url = self._build_url(f"influxdb/metric/{self.path_params.nsId}/{self.path_params.infraId}/{node_id}")
         else:
-            url = self._build_url(f"influxdb/metric/{self.path_params.nsId}/{self.path_params.mciId}")
+            url = self._build_url(f"influxdb/metric/{self.path_params.nsId}/{self.path_params.infraId}")
         body = self._build_body()
 
         response = self._send_request("POST", url, json=body)
@@ -121,10 +121,10 @@ class AnomalyHistoryService:
             )
             values.append(value)
 
-        node_id = getattr(self.path_params, "vmId", None)
+        node_id = getattr(self.path_params, "nodeId", None)
         data = AnomalyDetectionHistoryResponse(
             ns_id=self.path_params.nsId,
-            infra_id=self.path_params.mciId,
+            infra_id=self.path_params.infraId,
             node_id=node_id,
             measurement=self.query_params.measurement.value,
             values=values,

--- a/python/insight/app/api/prediction/prediction.py
+++ b/python/insight/app/api/prediction/prediction.py
@@ -90,7 +90,7 @@ async def get_prediction_options():
 
 
 @router.post(
-    path="/predictions/ns/{nsId}/mci/{mciId}",
+    path="/predictions/ns/{nsId}/infra/{infraId}",
     description=post_prediction_mci_description["api_description"],
     responses=post_prediction_mci_description["response"],
     response_model=ResBodyPredictionMCIResult,
@@ -101,14 +101,14 @@ async def predict_mci(body_params: PredictionBody, path_params: PredictionMCIPat
     df = prediction_service.get_data(path_params, body_params)
     result_dict = prediction_service.predict(df, path_params, body_params)
     prediction_result = PredictionMCIResult(
-        ns_id=path_params.nsId, infra_id=path_params.mciId, measurement=body_params.measurement, values=result_dict
+        ns_id=path_params.nsId, infra_id=path_params.infraId, measurement=body_params.measurement, values=result_dict
     )
 
     return ResBodyPredictionMCIResult(data=prediction_result)
 
 
 @router.post(
-    path="/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}",
+    path="/predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}",
     description=post_prediction_vm_description["api_description"],
     responses=post_prediction_vm_description["response"],
     response_model=ResBodyPredictionVMResult,
@@ -120,8 +120,8 @@ async def predict_vm(body_params: PredictionBody, path_params: PredictionVMPath 
     result_dict = prediction_service.predict(df, path_params, body_params)
     prediction_result = PredictionVMResult(
         ns_id=path_params.nsId,
-        infra_id=path_params.mciId,
-        node_id=path_params.vmId,
+        infra_id=path_params.infraId,
+        node_id=path_params.nodeId,
         measurement=body_params.measurement,
         values=result_dict,
     )
@@ -130,7 +130,7 @@ async def predict_vm(body_params: PredictionBody, path_params: PredictionVMPath 
 
 
 @router.get(
-    path="/predictions/ns/{nsId}/mci/{mciId}/history",
+    path="/predictions/ns/{nsId}/infra/{infraId}/history",
     description=get_history_mci_description["api_description"],
     responses=get_history_mci_description["response"],
     response_model=ResBodyPredictionMCIHistory,
@@ -143,14 +143,14 @@ async def get_prediction_mci_history(
     result_dict = prediction_service.get_prediction_history(path_params, query_params)
 
     prediction_history = PredictionMCIHistory(
-        ns_id=path_params.nsId, infra_id=path_params.mciId, measurement=query_params.measurement, values=result_dict
+        ns_id=path_params.nsId, infra_id=path_params.infraId, measurement=query_params.measurement, values=result_dict
     )
 
     return ResBodyPredictionMCIHistory(data=prediction_history)
 
 
 @router.get(
-    path="/predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}/history",
+    path="/predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}/history",
     description=get_history_vm_description["api_description"],
     responses=get_history_vm_description["response"],
     response_model=ResBodyPredictionVMHistory,
@@ -164,8 +164,8 @@ async def get_prediction_vm_history(
 
     prediction_history = PredictionVMHistory(
         ns_id=path_params.nsId,
-        infra_id=path_params.mciId,
-        node_id=path_params.vmId,
+        infra_id=path_params.infraId,
+        node_id=path_params.nodeId,
         measurement=query_params.measurement,
         values=result_dict,
     )

--- a/python/insight/app/api/prediction/repo/repo.py
+++ b/python/insight/app/api/prediction/repo/repo.py
@@ -30,12 +30,12 @@ class InfluxDBRepository:
             database=db_info["database"],
         )
 
-    def save_results(self, df: pd.DataFrame, nsId: str, mciId: str, vmId: str, measurement: str):
+    def save_results(self, df: pd.DataFrame, nsId: str, infraId: str, nodeId: str, measurement: str):
         points = []
-        if vmId:
-            tags = {"ns_id": nsId, "infra_id": mciId, "node_id": vmId}
+        if nodeId:
+            tags = {"ns_id": nsId, "infra_id": infraId, "node_id": nodeId}
         else:
-            tags = {"ns_id": nsId, "infra_id": mciId}
+            tags = {"ns_id": nsId, "infra_id": infraId}
         for _, row in df.iterrows():
             point = {
                 "measurement": measurement.lower(),
@@ -49,16 +49,16 @@ class InfluxDBRepository:
         logger.info("Success saving prediction result to influxdb")
 
     def query_prediction_history(
-        self, nsId: str, mciId: str, measurement: str, start_time: str, end_time: str, vmId=None
+        self, nsId: str, infraId: str, measurement: str, start_time: str, end_time: str, nodeId=None
     ):
         measurement = measurement.lower()
         query = f'SELECT mean("prediction_metric") as "prediction_metric" FROM "insight"."autogen".f"{measurement}"'
 
         conditions = []
         conditions.append(f"\"ns_id\" = '{nsId}'")
-        conditions.append(f"\"infra_id\" = '{mciId}'")
-        if vmId:
-            conditions.append(f"\"node_id\" = '{vmId}'")
+        conditions.append(f"\"infra_id\" = '{infraId}'")
+        if nodeId:
+            conditions.append(f"\"node_id\" = '{nodeId}'")
         conditions.append(f"time >= '{start_time}'")
         conditions.append(f"time <= '{end_time}'")
 

--- a/python/insight/app/api/prediction/request/req.py
+++ b/python/insight/app/api/prediction/request/req.py
@@ -21,13 +21,13 @@ class GetMeasurementPath(BaseModel):
 
 class PredictionMCIPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for the prediction."))
-    mciId: str = Field(Path(description="The MCI ID for the prediction."))
+    infraId: str = Field(Path(description="The MCI ID for the prediction."))
 
 
 class PredictionVMPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for the prediction."))
-    mciId: str = Field(Path(description="The MCI ID for the prediction."))
-    vmId: str = Field(Path(description="The VM ID for the prediction."))
+    infraId: str = Field(Path(description="The MCI ID for the prediction."))
+    nodeId: str = Field(Path(description="The VM ID for the prediction."))
 
 
 class PredictionMetricType(str, Enum):
@@ -54,13 +54,13 @@ def add_time_delta(delta=0) -> str:
 
 class GetHistoryMCIPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for retrieving predictions."))
-    mciId: str = Field(Path(description="The MCI ID for retrieving predictions."))
+    infraId: str = Field(Path(description="The MCI ID for retrieving predictions."))
 
 
 class GetHistoryVMPath(BaseModel):
     nsId: str = Field(Path(description="The Namespace ID for retrieving predictions."))
-    mciId: str = Field(Path(description="The MCI ID for retrieving predictions."))
-    vmId: str = Field(Path(description="The VM ID for retrieving predictions."))
+    infraId: str = Field(Path(description="The MCI ID for retrieving predictions."))
+    nodeId: str = Field(Path(description="The VM ID for retrieving predictions."))
 
 
 class GetPredictionHistoryQuery(BaseModel):

--- a/python/insight/app/api/prediction/response/res.py
+++ b/python/insight/app/api/prediction/response/res.py
@@ -33,7 +33,7 @@ class ResBodyPredictionOptions(BaseModel):
     rs_msg: str = "Success"
 
 
-# POST /predictions/ns/{nsId}/mci/{mciId}
+# POST /predictions/ns/{nsId}/infra/{infraId}
 class PredictValue(BaseModel):
     timestamp: str
     value: float | None
@@ -46,7 +46,7 @@ class PredictionMCIResult(BaseModel):
     values: list[PredictValue]
 
 
-# POST /predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}
+# POST /predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}
 class PredictionVMResult(BaseModel):
     ns_id: str
     infra_id: str
@@ -67,7 +67,7 @@ class ResBodyPredictionMCIResult(BaseModel):
     rs_msg: str = "Success"
 
 
-# GET /predictions/ns/{nsId}/mci/{mciId}/history
+# GET /predictions/ns/{nsId}/infra/{infraId}/history
 class HistoryValue(BaseModel):
     timestamp: str
     value: float | None
@@ -86,7 +86,7 @@ class ResBodyPredictionMCIHistory(BaseModel):
     rs_msg: str = "Success"
 
 
-# GET /predictions/ns/{nsId}/mci/{mciId}/vm/{vmId}history
+# GET /predictions/ns/{nsId}/infra/{infraId}/node/{nodeId}history
 class PredictionVMHistory(BaseModel):
     ns_id: str
     infra_id: str

--- a/python/insight/app/api/prediction/utils/utils.py
+++ b/python/insight/app/api/prediction/utils/utils.py
@@ -78,17 +78,17 @@ class PredictionService:
 
     def get_data(self, path_params, body_params):
         nsId = path_params.nsId
-        mciId = path_params.mciId
-        vmId = getattr(path_params, "vmId", None)
+        infraId = path_params.infraId
+        nodeId = getattr(path_params, "nodeId", None)
 
         measurement = body_params.measurement
         prediction_range = body_params.prediction_range
 
         all_data = []
-        if vmId:
-            url = self._build_url(f"influxdb/metric/{nsId}/{mciId}/{vmId}")
+        if nodeId:
+            url = self._build_url(f"influxdb/metric/{nsId}/{infraId}/{nodeId}")
         else:
-            url = self._build_url(f"influxdb/metric/{nsId}/{mciId}")
+            url = self._build_url(f"influxdb/metric/{nsId}/{infraId}")
 
         body = self._build_body(measurement, prediction_range)
 
@@ -116,8 +116,8 @@ class PredictionService:
     def predict(self, df: pd.DataFrame, path_params, body_params):
         logger.info("start prediction")
         nsId = path_params.nsId
-        mciId = path_params.mciId
-        vmId = getattr(path_params, "vmId", None)
+        infraId = path_params.infraId
+        nodeId = getattr(path_params, "nodeId", None)
 
         measurement = body_params.measurement
         prediction_range = body_params.prediction_range
@@ -144,13 +144,13 @@ class PredictionService:
         prediction["value"] = np.clip(prediction["value"], 0, 100).round(2)
         prediction["timestamp"] = prediction["timestamp"].apply(self.insert_timezone)
         logger.info("start prediction result saving")
-        self.save_prediction_result(prediction, nsId, mciId, vmId, measurement)
+        self.save_prediction_result(prediction, nsId, infraId, nodeId, measurement)
         result_dict = prediction.to_dict("records")
 
         return result_dict
 
-    def save_prediction_result(self, df: pd.DataFrame, nsId: str, mciId: str, vmId: str, measurement: str):
-        self.influxdb_repo.save_results(df, nsId, mciId, vmId, measurement)
+    def save_prediction_result(self, df: pd.DataFrame, nsId: str, infraId: str, nodeId: str, measurement: str):
+        self.influxdb_repo.save_results(df, nsId, infraId, nodeId, measurement)
 
     @staticmethod
     def convert_prediction_range(prediction_range: str):
@@ -177,7 +177,7 @@ class PredictionService:
     def get_prediction_history(self, path_params, query_params):
         prediction_points = self.influxdb_repo.query_prediction_history(
             nsId=path_params.nsId,
-            mciId=path_params.mciId,
+            infraId=path_params.infraId,
             measurement=query_params.measurement,
             start_time=query_params.start_time,
             end_time=query_params.end_time,

--- a/scripts/db/2026-06-09-rename-vm-to-node.sql
+++ b/scripts/db/2026-06-09-rename-vm-to-node.sql
@@ -1,0 +1,39 @@
+-- Rename MCI -> Infra, VM -> Node in the mc-o11y-manager schema.
+--
+-- The JPA entity moved from @Table(name="vm") to @Table(name="node") and the
+-- identity columns mci_id/vm_id to infra_id/node_id. Because the service runs
+-- with hibernate ddl-auto=update (no migration tool), apply this BEFORE
+-- starting the renamed build so existing agent-registration rows are preserved
+-- instead of being orphaned in the old `vm` table.
+--
+-- Idempotent-ish: guarded with information_schema checks for MariaDB/MySQL.
+-- Run against the mc-o11y-manager database.
+
+-- 1) table vm -> node
+SET @ddl := (
+  SELECT IF(
+    EXISTS (SELECT 1 FROM information_schema.tables
+            WHERE table_schema = DATABASE() AND table_name = 'vm')
+    AND NOT EXISTS (SELECT 1 FROM information_schema.tables
+            WHERE table_schema = DATABASE() AND table_name = 'node'),
+    'RENAME TABLE vm TO node',
+    'SELECT 1'));
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 2) column mci_id -> infra_id
+SET @ddl := (
+  SELECT IF(
+    EXISTS (SELECT 1 FROM information_schema.columns
+            WHERE table_schema = DATABASE() AND table_name = 'node' AND column_name = 'mci_id'),
+    'ALTER TABLE node CHANGE COLUMN mci_id infra_id VARCHAR(255) NOT NULL',
+    'SELECT 1'));
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 3) column vm_id -> node_id
+SET @ddl := (
+  SELECT IF(
+    EXISTS (SELECT 1 FROM information_schema.columns
+            WHERE table_schema = DATABASE() AND table_name = 'node' AND column_name = 'vm_id'),
+    'ALTER TABLE node CHANGE COLUMN vm_id node_id VARCHAR(255) NOT NULL',
+    'SELECT 1'));
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;


### PR DESCRIPTION
## Tracing (Tempo)
- mc-o11y-manager에 Tempo 조회 연동 추가: `GET /api/o11y/trace/search`, `/api/o11y/trace/{traceId}`, `/api/o11y/trace/services` (Feign → Tempo `/api/search`, `/api/traces`, service.name tag values).
- Front에 Tracing 메뉴/뷰어 추가(Logs 화면 스타일): service 드롭다운, keyword, range 검색, trace 목록.
- Framework(o11y 플랫폼 self-trace: manager/insight, OTel 자기계측) vs VM(대상 VM Beyla/OTel) 을 service.name 접두사로 분리하여 섞이지 않게 함.
- trace 행 클릭 시 API 호출 순서를 인라인으로 펼침(parent→child span 트리, 시작시간 DFS 들여쓰기, kind별 색 타임라인).
- VM 트레이스는 대상 노드에 trace agent(Beyla/OTel) 설치 시 수집됨(미설치 시 VM scope는 비어 있음).

## Rename MCI/VM → Infra/Node
- cb-tumblebug Infra/Node 네이밍을 o11y 스택 전반에 적용(#296/#299 후속).
- Backend: URL 경로(`/vm`→`/node`, `/mci/`→`/infra/`), 식별자(mciId→infraId, vmId→nodeId), 엔티티 테이블 `vm`→`node` + 컬럼 `mci_id`→`infra_id`/`vm_id`→`node_id`, insight client/service 경로.
- python insight 서비스 라우트/파라미터, front API 호출 및 라벨.
- Trigger `targetScope` 값 mci/vm → infra/node (Telegraf/InfluxDB 태그 `infra_id`/`node_id`와 정합).
- 외부 cb-spider/cb-tumblebug 다운스트림 경로는 변경하지 않음.
- 데이터 보존형 DB 마이그레이션 추가: `scripts/db/2026-06-09-rename-vm-to-node.sql` (ddl-auto=update, 마이그레이션 도구 없음).
- Discord/Teams 알림 채널이 리네임된 getter를 쓰도록 수정.
