### PR TITLE
fix: Recover Semaphore initialization (Feign DTO deserialization)

### DIFF
--- a/java/.dockerignore
+++ b/java/.dockerignore
@@ -1,0 +1,6 @@
+# Build outputs must not pollute the image build context — copying stale
+# build/.gradle made Gradle skip recompilation (e.g. dropping -parameters).
+build/
+.gradle/
+*/build/
+*/.gradle/

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -37,6 +37,14 @@ subprojects {
         }
     }
 
+    // Keep constructor parameter names in the bytecode so Jackson can bind JSON to
+    // multi-arg constructors (e.g. Feign response DTOs like the Semaphore models).
+    // Without this, deserialization fails with "constructor ... has no property name
+    // annotation", which silently broke Semaphore initialization on startup.
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs << '-parameters'
+    }
+
     configurations {
         compileOnly {
             extendsFrom annotationProcessor

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/JacksonConfig.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/config/JacksonConfig.java
@@ -3,6 +3,7 @@ package com.mcmp.o11ymanager.manager.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.util.TimeZone;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,11 @@ public class JacksonConfig {
     public ObjectMapper jacksonObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
+        // Bind JSON to multi-arg constructors via -parameters constructor names. This @Primary
+        // mapper is also used by Feign decoders; without it, deserializing Feign DTOs (e.g. the
+        // Semaphore Project) fails with "constructor ... has no property name", which silently
+        // broke Semaphore initialization on startup.
+        objectMapper.registerModule(new ParameterNamesModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.setTimeZone(TimeZone.getDefault());
         return objectMapper;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/port/semaphore/SemaphoreFeignConfig.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/port/semaphore/SemaphoreFeignConfig.java
@@ -30,6 +30,11 @@ public class SemaphoreFeignConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
+        // Register classpath modules (incl. ParameterNamesModule) so Jackson can bind JSON to
+        // multi-arg constructors using the -parameters constructor names. Without this, decoding
+        // Semaphore responses (e.g. Project) fails with "constructor ... has no property name",
+        // which silently broke Semaphore initialization on startup.
+        mapper.findAndRegisterModules();
         mapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
         mapper.configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature(), true);
         return mapper;


### PR DESCRIPTION
## Summary
매니저 기동 시 Semaphore 초기화가 매번 실패하던 문제를 수정 (프로젝트/인벤토리/레포지토리/템플릿 자동 생성 복구).

## Why
- 기동 시 Semaphore 응답(Project 등)을 Jackson이 역직렬화하다 "constructor ... has no property name" 에러로 실패 → 초기화가 조용히 중단됨(에러 로그만 남고 앱은 그대로 기동).
- 원인: @Primary ObjectMapper에 ParameterNamesModule이 없어 다중인자 생성자에 JSON을 바인딩하지 못함 (Feign 디코더도 이 매퍼를 사용).

## Changes
- @Primary ObjectMapper(JacksonConfig)에 ParameterNamesModule 등록 (핵심 수정).
- 생성자 파라미터명을 바이트코드에 보존하도록 컴파일 `-parameters` 플래그 추가.
- Semaphore Feign ObjectMapper에도 모듈 자동 등록.
- 이미지 빌드 컨텍스트에 stale `build/`가 들어가 `-parameters`가 누락되던 문제 방지용 `.dockerignore` 추가.
