### PR TITLE
fix: Reset stuck agent task status on manager startup

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/runner/PreparationRunner.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/runner/PreparationRunner.java
@@ -2,6 +2,7 @@ package com.mcmp.o11ymanager.manager.global.runner;
 
 import com.mcmp.o11ymanager.manager.service.AgentPluginDefServiceImpl;
 import com.mcmp.o11ymanager.manager.service.SemaphoreService;
+import com.mcmp.o11ymanager.manager.service.interfaces.VMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
@@ -20,6 +21,7 @@ public class PreparationRunner implements ApplicationContextAware {
 
     private final SemaphoreService semaphoreService;
     private final AgentPluginDefServiceImpl agentPluginDefServiceImpl;
+    private final VMService vmService;
 
     @Override
     public void setApplicationContext(@Nullable ApplicationContext applicationContext)
@@ -39,7 +41,11 @@ public class PreparationRunner implements ApplicationContextAware {
         }
 
         log.info("Initializing agent task statuses for all hosts.");
-        // vmService.resetAllHostAgentTaskStatus();
+        try {
+            vmService.resetAllHostAgentTaskStatus();
+        } catch (Exception e) {
+            log.error("Failed to reset agent task statuses", e);
+        }
         log.info("Agent task status initialization for all hosts completed.");
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
@@ -373,4 +373,47 @@ public class VMServiceImpl implements VMService {
 
         return t.getInfluxSeq();
     }
+
+    @Override
+    @Transactional
+    public void resetAllHostAgentTaskStatus() {
+        List<VMEntity> all = vmJpaRepository.findAll();
+        int reset = 0;
+        for (VMEntity vm : all) {
+            boolean changed = false;
+            if (isInProgress(vm.getMonitoringAgentTaskStatus())) {
+                vm.setMonitoringAgentTaskStatus(VMAgentTaskStatus.IDLE);
+                vm.setVmMonitoringAgentTaskId("");
+                changed = true;
+            }
+            if (isInProgress(vm.getLogAgentTaskStatus())) {
+                vm.setLogAgentTaskStatus(VMAgentTaskStatus.IDLE);
+                vm.setVmLogAgentTaskId("");
+                changed = true;
+            }
+            if (isInProgress(vm.getTraceAgentTaskStatus())) {
+                vm.setTraceAgentTaskStatus(VMAgentTaskStatus.IDLE);
+                vm.setVmTraceAgentTaskId("");
+                changed = true;
+            }
+            if (changed) {
+                vmJpaRepository.save(vm);
+                reset++;
+                log.info(
+                        "[AGENT-TASK-RESET] reset stuck task status ns={} infra={} node={}",
+                        vm.getNsId(),
+                        vm.getInfraId(),
+                        vm.getNodeId());
+            }
+        }
+        log.info("[AGENT-TASK-RESET] reset {} node(s) with in-progress agent task status", reset);
+    }
+
+    /** In-progress = anything that is not a terminal/idle state, i.e. a task that was running. */
+    private static boolean isInProgress(VMAgentTaskStatus status) {
+        return status != null
+                && status != VMAgentTaskStatus.IDLE
+                && status != VMAgentTaskStatus.FINISHED
+                && status != VMAgentTaskStatus.FAILED;
+    }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/VMService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/interfaces/VMService.java
@@ -68,4 +68,10 @@ public interface VMService {
     List<String> getNodeIds(String nsId, String infraId);
 
     Long getInfluxId(String nsId, String infraId);
+
+    /**
+     * Resets any in-progress agent task status (e.g. INSTALLING left behind by a crash mid-task)
+     * back to IDLE for all nodes, so the UI/flow is not stuck. Called once on manager startup.
+     */
+    void resetAllHostAgentTaskStatus();
 }


### PR DESCRIPTION
## Summary
에이전트 작업이 중간에 실패하면 task 상태가 INSTALLING 등으로 남아 UI가 멈추던 문제를, 매니저 기동 시 자동 정리하도록 수정.

## Why
- 설치 등 에이전트 작업이 도중에 죽으면 node의 task 상태가 INSTALLING 상태로 남고, 매니저가 이를 그대로 유지해 재시도/해제가 막혔음.
- 과거 기동 시 자동 복구 로직(`resetAllHostAgentTaskStatus`)이 있었으나 리팩터링 중 주석 처리되어 비활성 상태였음.

## Changes
- 기동 시 진행 중(IDLE/FINISHED/FAILED 외) 에이전트 task 상태를 IDLE로 되돌리는 로직 복원 (`VMService.resetAllHostAgentTaskStatus`).
- `PreparationRunner`에서 기동 시 호출하도록 연결.
