### PR TITLE
fix: front: Fix blank Tracing screen when selecting a VM

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -42,6 +42,7 @@ export default function App() {
         <Route path="/insight/:nsId" element={<InsightDashboard />} />
         <Route path="/alerts/:nsId/:infraId" element={<AlertManager />} />
         <Route path="/alerts/:nsId" element={<AlertManager />} />
+        <Route path="/trace/:nsId/:infraId/:nodeId" element={<TraceViewer />} />
         <Route path="/trace/:nsId/:infraId" element={<TraceViewer />} />
         <Route path="/trace/:nsId" element={<TraceViewer />} />
       </Route>
@@ -62,6 +63,7 @@ export default function App() {
         <Route path="/embed/insight/:nsId" element={<InsightDashboard />} />
         <Route path="/embed/alerts/:nsId/:infraId" element={<AlertManager />} />
         <Route path="/embed/alerts/:nsId" element={<AlertManager />} />
+        <Route path="/embed/trace/:nsId/:infraId/:nodeId" element={<TraceViewer />} />
         <Route path="/embed/trace/:nsId/:infraId" element={<TraceViewer />} />
         <Route path="/embed/trace/:nsId" element={<TraceViewer />} />
       </Route>

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -15,9 +15,10 @@ const SCOPES = [
 ];
 
 export default function TraceViewer() {
-  const { infraId } = useParams();
+  const { infraId, nodeId } = useParams();
 
-  const [scope, setScope] = useState('framework');
+  // Selecting a specific VM/node implies you want VM (Beyla/OTel) traces, not framework ones.
+  const [scope, setScope] = useState(nodeId ? 'vm' : 'framework');
   const [services, setServices] = useState([]);
   const [service, setService] = useState('');
   const [keyword, setKeyword] = useState('');
@@ -91,7 +92,10 @@ export default function TraceViewer() {
 
       {/* Control card */}
       <div className="bg-white rounded-lg shadow">
-        <div className="px-4 py-3 border-b font-semibold text-sm">Trace Manage</div>
+        <div className="px-4 py-3 border-b font-semibold text-sm flex items-center gap-2">
+          <span>Trace Manage</span>
+          {infraId && <span className="text-xs font-normal text-gray-400">· Workload: {infraId}{nodeId ? ` / Node: ${nodeId}` : ''}</span>}
+        </div>
         <div className="p-4">
           <div className="grid grid-cols-4 gap-4 mb-2">
             <div>


### PR DESCRIPTION
## Summary
Tracing 화면에서 VM(Node)을 선택하면 화면이 비던 문제를 수정.

## Why
- 상단 네비에서 노드를 고르면 `/trace/{ns}/{infra}/{node}` 로 이동하는데, 트레이스 라우트가 `/trace/:nsId/:infraId` 까지만 등록돼 있어 매칭되는 화면이 없어 비었음.

## Changes
- `/trace/:nsId/:infraId/:nodeId` (및 `/embed/trace/:nsId/:infraId/:nodeId`) 라우트 추가.
- 노드가 선택되면 트레이스 스코프를 VM으로 기본 설정하고, 헤더에 Workload / Node 컨텍스트 표시.
