### PR TITLE
feat: Make Insight menu usable (anomaly, prediction, server error analysis)

### DIFF
--- a/front/src/api/insight.js
+++ b/front/src/api/insight.js
@@ -14,6 +14,11 @@ export async function createAnomalySetting(body) {
   return res.data?.data || res.data;
 }
 
+export async function updateAnomalySetting(seq, body) {
+  const res = await client.put(`/api/o11y/insight/anomaly-detection/settings/${seq}`, body);
+  return res.data?.data || res.data;
+}
+
 export async function deleteAnomalySetting(seq) {
   return client.delete(`/api/o11y/insight/anomaly-detection/settings/${seq}`);
 }
@@ -62,6 +67,43 @@ export async function runPrediction(nsId, infraId, nodeId, body) {
     : `/api/o11y/insight/predictions/ns/${nsId}/infra/${infraId}`;
   const res = await client.post(path, body);
   return res.data?.data || res.data?.responseData || {};
+}
+
+export async function getPredictionMeasurements() {
+  const res = await client.get('/api/o11y/insight/predictions/measurement');
+  return res.data?.data || [];
+}
+
+// Server Error Analysis (#300) — LLM-based 5xx analysis over Tempo traces.
+export async function getServerErrorRecords({ status, from, to, page = 1, size = 20 } = {}) {
+  const params = { page, size };
+  if (status) params.status = status;
+  if (from) params.from = from;
+  if (to) params.to = to;
+  const res = await client.get('/api/o11y/insight/server-error-analysis/records', { params });
+  return res.data?.data || {};
+}
+
+export async function getServerErrorRecord(analysisId) {
+  const res = await client.get(`/api/o11y/insight/server-error-analysis/records/${analysisId}`);
+  return res.data?.data || res.data;
+}
+
+export async function detectServerError(body) {
+  const res = await client.post('/api/o11y/insight/server-error-analysis/detect', body);
+  return res.data?.data || res.data;
+}
+
+export async function queryServerError(body) {
+  const res = await client.post('/api/o11y/insight/server-error-analysis/query', body);
+  return res.data?.data || res.data;
+}
+
+export async function rerunServerErrorAnalysis(analysisId) {
+  const res = await client.post(
+    `/api/o11y/insight/server-error-analysis/records/${analysisId}/rerun`,
+  );
+  return res.data?.data || res.data;
 }
 
 // LLM

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -160,7 +160,7 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
       await createAnomalySetting(body);
       onCreated();
     } catch (e2) {
-      setErr(e2.response?.data?.error_message || e2.response?.data?.rs_msg || e2.message);
+      setErr(e2.response?.data?.detail || e2.response?.data?.error_message || e2.response?.data?.rs_msg || e2.message);
     }
     setBusy(false);
   }
@@ -241,7 +241,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
       setMsg('Prediction started. Loading history…');
       await loadHistory();
     } catch (e) {
-      setMsg(e.response?.data?.error_message || e.response?.data?.rs_msg || e.message);
+      setMsg(e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message);
     }
     setLoading(false);
   }
@@ -323,7 +323,7 @@ function ServerErrorTab() {
       setMsg(`Detect 요청됨 (accepted=${res?.accepted}, ids=${(res?.analysis_ids || []).join(',') || '-'})`);
       await load();
     } catch (e) {
-      setMsg('Detect 실패 (LLM 미설정 가능): ' + (e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+      setMsg('Detect 실패 (LLM 미설정 가능): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
     }
     setBusy(false);
   }
@@ -335,7 +335,7 @@ function ServerErrorTab() {
       setMsg(`#${id} rerun 요청됨`);
       await load();
     } catch (e) {
-      setMsg('Rerun 실패 (LLM 미설정 가능): ' + (e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+      setMsg('Rerun 실패 (LLM 미설정 가능): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
     }
     setBusy(false);
   }

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -218,6 +218,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   const [measurement, setMeasurement] = useState('');
   const [range, setRange] = useState('24h');
   const [history, setHistory] = useState([]);
+  const [loadedMeasurement, setLoadedMeasurement] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
 
@@ -231,6 +232,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
     try {
       const data = await getPredictionHistory(nsId, infraId, nodeId, measurement);
       setHistory(data.values || []);
+      setLoadedMeasurement(measurement);
     } catch { setHistory([]); }
     setLoading(false);
   }
@@ -248,10 +250,17 @@ function PredictionTab({ nsId, infraId, nodeId }) {
     setLoading(false);
   }
 
+  // Backend predicts the cpu measurement's `usage_idle` field. Show it as usage (100 - idle),
+  // matching the Monitoring dashboard's "CPU Used" convention.
+  const isCpu = loadedMeasurement === 'cpu';
   const chartSeries = history.length > 0 ? [{
-    name: 'Prediction',
+    name: isCpu ? 'Predicted CPU Usage (%)' : 'Prediction',
     data: history
-      .map((h) => ({ x: new Date(h.timestamp).getTime(), y: h.value == null ? null : parseFloat(h.value) }))
+      .map((h) => {
+        if (h.value == null) return { x: new Date(h.timestamp).getTime(), y: null };
+        const v = parseFloat(h.value);
+        return { x: new Date(h.timestamp).getTime(), y: isCpu ? 100 - v : v };
+      })
       .filter((p) => p.y != null && !Number.isNaN(p.y)),
   }] : [];
 

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -1,10 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, Fragment } from 'react';
 import { useParams } from 'react-router-dom';
-import { getAnomalySettings, createAnomalySetting, deleteAnomalySetting, getAnomalyHistory, getAnomalyMeasurements } from '../api/insight';
-import { getPredictionHistory, runPrediction } from '../api/insight';
+import {
+  getAnomalySettings, createAnomalySetting, deleteAnomalySetting, getAnomalyHistory,
+  getAnomalyMeasurements, getAnomalyOptions,
+  getPredictionHistory, runPrediction, getPredictionOptions,
+  getServerErrorRecords, getServerErrorRecord, detectServerError, rerunServerErrorAnalysis,
+} from '../api/insight';
 import MetricChart from '../components/MetricChart';
 
-const TABS = ['Anomaly Detection', 'Prediction'];
+const TABS = ['Anomaly Detection', 'Prediction', 'Server Error Analysis'];
 
 export default function InsightDashboard() {
   const { nsId, infraId, nodeId } = useParams();
@@ -12,7 +16,6 @@ export default function InsightDashboard() {
 
   return (
     <div className="space-y-4">
-      {/* Tab bar */}
       <div className="flex gap-1 bg-white rounded-lg shadow px-2 py-1">
         {TABS.map((t, i) => (
           <button key={t} onClick={() => setTab(i)}
@@ -20,27 +23,36 @@ export default function InsightDashboard() {
             {t}
           </button>
         ))}
+        <span className="ml-auto self-center text-xs text-gray-400 pr-2">
+          {nsId}/{infraId}{nodeId ? `/${nodeId}` : ''}
+        </span>
       </div>
       {tab === 0 && <AnomalyTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
       {tab === 1 && <PredictionTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
+      {tab === 2 && <ServerErrorTab />}
     </div>
   );
 }
 
+/* ----------------------------- Anomaly ----------------------------- */
 function AnomalyTab({ nsId, infraId, nodeId }) {
   const [settings, setSettings] = useState([]);
+  const [options, setOptions] = useState({ measurements: [], execution_intervals: [] });
   const [measurements, setMeasurements] = useState([]);
   const [selectedMeasurement, setSelectedMeasurement] = useState('');
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const loadSettings = useCallback(() => {
+    getAnomalySettings().then((d) => setSettings(Array.isArray(d) ? d : [])).catch(() => setSettings([]));
+  }, []);
 
   useEffect(() => {
-    getAnomalySettings().then(setSettings).catch(() => {});
-    getAnomalyMeasurements().then((d) => {
-      if (Array.isArray(d)) setMeasurements(d.map(m => m.measurement || m));
-      else setMeasurements([]);
-    }).catch(() => {});
-  }, []);
+    loadSettings();
+    getAnomalyOptions().then((o) => setOptions(o || {})).catch(() => {});
+    getAnomalyMeasurements().then((d) => setMeasurements(Array.isArray(d) ? d.map((m) => m.measurement || m) : [])).catch(() => {});
+  }, [loadSettings]);
 
   async function loadHistory() {
     if (!selectedMeasurement) return;
@@ -53,39 +65,50 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
   }
 
   async function handleDelete(seq) {
+    if (!confirm(`Delete anomaly setting #${seq}?`)) return;
     await deleteAnomalySetting(seq);
-    setSettings(await getAnomalySettings());
+    loadSettings();
   }
 
   const chartSeries = history.length > 0 ? [{
     name: 'Anomaly Score',
-    data: history.map(h => ({ x: new Date(h.timestamp).getTime(), y: h.anomaly_score })),
+    data: history.map((h) => ({ x: new Date(h.timestamp).getTime(), y: h.anomaly_score ?? parseFloat(h.value) })),
   }] : [];
 
   return (
     <div className="space-y-4">
-      {/* Settings table */}
       <div className="bg-white rounded-lg shadow">
-        <div className="px-4 py-3 border-b font-semibold text-sm">Anomaly Detection Settings</div>
+        <div className="px-4 py-3 border-b flex justify-between items-center">
+          <span className="font-semibold text-sm">Anomaly Detection Settings</span>
+          <button onClick={() => setShowCreate(!showCreate)} className="text-xs bg-purple-600 text-white px-3 py-1 rounded hover:bg-purple-700">
+            {showCreate ? 'Cancel' : '+ New Setting'}
+          </button>
+        </div>
+        {showCreate && (
+          <CreateAnomalyForm nsId={nsId} infraId={infraId} nodeId={nodeId} options={options}
+            onCreated={() => { setShowCreate(false); loadSettings(); }} />
+        )}
         <div className="p-4 overflow-auto">
-          {settings.length === 0 ? (
-            <p className="text-sm text-gray-400">No settings configured</p>
-          ) : (
+          {settings.length === 0 ? <p className="text-sm text-gray-400">No settings configured</p> : (
             <table className="w-full text-sm">
               <thead><tr className="bg-gray-50 text-left">
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Seq</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">NS / Infra / Node</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Measurement</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Interval</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Last Run</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Actions</th>
               </tr></thead>
               <tbody>
-                {settings.map((s, i) => (
-                  <tr key={s.settingSeq || s.seq || i} className="hover:bg-gray-50">
-                    <td className="px-3 py-2 border-b">{s.settingSeq || s.seq}</td>
-                    <td className="px-3 py-2 border-b">{s.nsId || s.ns_id}/{s.infraId || s.infra_id}/{s.nodeId || s.node_id || '-'}</td>
-                    <td className="px-3 py-2 border-b">{s.measurement || '-'}</td>
+                {settings.map((s) => (
+                  <tr key={s.seq} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 border-b">{s.seq}</td>
+                    <td className="px-3 py-2 border-b">{s.ns_id}/{s.infra_id}/{s.node_id || '-'}</td>
+                    <td className="px-3 py-2 border-b">{s.measurement}</td>
+                    <td className="px-3 py-2 border-b">{s.execution_interval}</td>
+                    <td className="px-3 py-2 border-b text-xs text-gray-500">{s.last_execution || '-'}</td>
                     <td className="px-3 py-2 border-b text-right">
-                      <button onClick={() => handleDelete(s.settingSeq || s.seq)} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+                      <button onClick={() => handleDelete(s.seq)} className="text-xs text-red-500 hover:text-red-700">Delete</button>
                     </td>
                   </tr>
                 ))}
@@ -95,14 +118,13 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
         </div>
       </div>
 
-      {/* History chart */}
       <div className="bg-white rounded-lg shadow">
         <div className="px-4 py-3 border-b font-semibold text-sm">Anomaly Detection History</div>
         <div className="p-4">
           <div className="flex gap-3 mb-4">
             <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMeasurement} onChange={(e) => setSelectedMeasurement(e.target.value)}>
               <option value="">Select Measurement</option>
-              {measurements.map(m => <option key={m} value={m}>{m}</option>)}
+              {(measurements.length ? measurements : options.measurements || []).map((m) => <option key={m} value={m}>{m}</option>)}
             </select>
             <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
               {loading ? 'Loading...' : 'Load History'}
@@ -115,64 +137,288 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
   );
 }
 
+function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
+  const [measurement, setMeasurement] = useState('');
+  const [interval, setInterval] = useState('');
+  const [scope, setScope] = useState(nodeId ? 'node' : 'infra');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  const measurements = options.measurements || [];
+  const intervals = options.execution_intervals || [];
+
+  async function submit(e) {
+    e.preventDefault();
+    if (!measurement || !interval) { setErr('Measurement and interval are required.'); return; }
+    setBusy(true); setErr('');
+    try {
+      const body = {
+        ns_id: nsId,
+        infra_id: infraId,
+        node_id: scope === 'node' ? nodeId : null,
+        measurement,
+        execution_interval: interval,
+      };
+      await createAnomalySetting(body);
+      onCreated();
+    } catch (e2) {
+      setErr(e2.response?.data?.error_message || e2.response?.data?.rs_msg || e2.message);
+    }
+    setBusy(false);
+  }
+
+  return (
+    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">Target</label>
+          <select value={scope} onChange={(e) => setScope(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
+            <option value="infra">Infra ({infraId})</option>
+            {nodeId && <option value="node">Node ({nodeId})</option>}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">Measurement</label>
+          <select value={measurement} onChange={(e) => setMeasurement(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
+            <option value="">Select</option>
+            {measurements.map((m) => <option key={m} value={m}>{m}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">Execution Interval</label>
+          <select value={interval} onChange={(e) => setInterval(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
+            <option value="">Select</option>
+            {intervals.map((i) => <option key={i} value={i}>{i}</option>)}
+          </select>
+        </div>
+      </div>
+      {err && <p className="text-xs text-red-500">{err}</p>}
+      <button type="submit" disabled={busy} className="bg-purple-600 text-white px-4 py-1.5 rounded text-sm hover:bg-purple-700 disabled:opacity-50">
+        {busy ? 'Creating...' : 'Create'}
+      </button>
+    </form>
+  );
+}
+
+/* ----------------------------- Prediction ----------------------------- */
 function PredictionTab({ nsId, infraId, nodeId }) {
-  const [measurements, setMeasurements] = useState([]);
-  const [selectedMeasurement, setSelectedMeasurement] = useState('');
+  const [options, setOptions] = useState({ measurements: [], prediction_ranges: {} });
+  const [measurement, setMeasurement] = useState('');
+  const [range, setRange] = useState('');
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState('');
 
   useEffect(() => {
-    getAnomalyMeasurements().then((d) => {
-      if (Array.isArray(d)) setMeasurements(d.map(m => m.measurement || m));
-      else setMeasurements([]);
+    getPredictionOptions().then((o) => {
+      setOptions(o || {});
+      const ranges = Object.keys(o?.prediction_ranges || {});
+      if (ranges.length) setRange(ranges[0]);
     }).catch(() => {});
   }, []);
 
   async function loadHistory() {
-    if (!selectedMeasurement) return;
-    setLoading(true);
+    if (!measurement) return;
+    setLoading(true); setMsg('');
     try {
-      const data = await getPredictionHistory(nsId, infraId, nodeId, selectedMeasurement);
+      const data = await getPredictionHistory(nsId, infraId, nodeId, measurement);
       setHistory(data.values || []);
     } catch { setHistory([]); }
     setLoading(false);
   }
 
-  async function handleRunPrediction() {
-    if (!selectedMeasurement) return;
-    setLoading(true);
+  async function handleRun() {
+    if (!measurement || !range) { setMsg('Measurement and range are required.'); return; }
+    setLoading(true); setMsg('');
     try {
-      await runPrediction(nsId, infraId, nodeId, { measurement: selectedMeasurement });
+      await runPrediction(nsId, infraId, nodeId, { measurement, prediction_range: range });
+      setMsg('Prediction started. Loading history…');
       await loadHistory();
     } catch (e) {
-      console.error('Prediction failed', e);
+      setMsg(e.response?.data?.error_message || e.response?.data?.rs_msg || e.message);
     }
     setLoading(false);
   }
 
   const chartSeries = history.length > 0 ? [{
     name: 'Prediction',
-    data: history.map(h => ({ x: new Date(h.timestamp).getTime(), y: parseFloat(h.value) })),
+    data: history.map((h) => ({ x: new Date(h.timestamp).getTime(), y: parseFloat(h.value) })),
   }] : [];
 
   return (
     <div className="bg-white rounded-lg shadow">
       <div className="px-4 py-3 border-b font-semibold text-sm">Prediction</div>
       <div className="p-4">
-        <div className="flex gap-3 mb-4">
-          <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedMeasurement} onChange={(e) => setSelectedMeasurement(e.target.value)}>
-            <option value="">Select Measurement</option>
-            {measurements.map(m => <option key={m} value={m}>{m}</option>)}
-          </select>
-          <button onClick={handleRunPrediction} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
+        <div className="flex gap-3 mb-2 flex-wrap items-end">
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Measurement</label>
+            <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={measurement} onChange={(e) => setMeasurement(e.target.value)}>
+              <option value="">Select</option>
+              {(options.measurements || []).map((m) => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Prediction Range</label>
+            <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={range} onChange={(e) => setRange(e.target.value)}>
+              {Object.entries(options.prediction_ranges || {}).map(([k, v]) => <option key={k} value={k}>{v || k}</option>)}
+            </select>
+          </div>
+          <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
             Run Prediction
           </button>
           <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
             Load History
           </button>
         </div>
+        {msg && <p className="text-xs text-gray-500 mb-2">{msg}</p>}
         <MetricChart title="Prediction" series={chartSeries} height={240} />
       </div>
     </div>
   );
+}
+
+/* ----------------------- Server Error Analysis ----------------------- */
+const SE_STATUS = ['', 'PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'PARTIAL'];
+
+function ServerErrorTab() {
+  const [records, setRecords] = useState([]);
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState('');
+  const [limit, setLimit] = useState(20);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getServerErrorRecords({ status, size: 50 });
+      setRecords(data.items || []);
+    } catch (e) {
+      setRecords([]);
+      setMsg('records 조회 실패: ' + (e.response?.data?.error_message || e.message));
+    }
+    setLoading(false);
+  }, [status]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function openDetail(id) {
+    if (selected === id) { setSelected(null); setDetail(null); return; }
+    setSelected(id); setDetail(null);
+    try { setDetail(await getServerErrorRecord(id)); } catch { setDetail({ error: 'load failed' }); }
+  }
+
+  async function handleDetect() {
+    setBusy(true); setMsg('');
+    try {
+      const res = await detectServerError({ provider: 'openai', model_name: 'gpt-5-mini', limit: Number(limit) });
+      setMsg(`Detect 요청됨 (accepted=${res?.accepted}, ids=${(res?.analysis_ids || []).join(',') || '-'})`);
+      await load();
+    } catch (e) {
+      setMsg('Detect 실패 (LLM 미설정 가능): ' + (e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+    }
+    setBusy(false);
+  }
+
+  async function handleRerun(id) {
+    setBusy(true); setMsg('');
+    try {
+      await rerunServerErrorAnalysis(id);
+      setMsg(`#${id} rerun 요청됨`);
+      await load();
+    } catch (e) {
+      setMsg('Rerun 실패 (LLM 미설정 가능): ' + (e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+    }
+    setBusy(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-4 py-3 border-b flex items-center gap-3">
+          <span className="font-semibold text-sm">Server Error (5xx) Analysis</span>
+          <select className="border rounded px-2 py-1 text-xs ml-auto" value={status} onChange={(e) => setStatus(e.target.value)}>
+            {SE_STATUS.map((s) => <option key={s} value={s}>{s || 'All status'}</option>)}
+          </select>
+          <button onClick={load} className="text-xs text-gray-500 hover:text-gray-700">Refresh</button>
+        </div>
+        <div className="p-4 flex items-end gap-3 border-b bg-gray-50">
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Limit (max 5xx to analyze)</label>
+            <input type="number" min={1} max={100} value={limit} onChange={(e) => setLimit(e.target.value)} className="border rounded px-3 py-1.5 text-sm w-28" />
+          </div>
+          <button onClick={handleDetect} disabled={busy} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
+            {busy ? 'Working...' : 'Detect 5xx & Analyze'}
+          </button>
+          <span className="text-xs text-gray-400">LLM(OpenAI/ollama) 미설정 시 분석은 실패합니다.</span>
+        </div>
+        {msg && <p className="text-xs text-gray-500 px-4 pt-2">{msg}</p>}
+        <div className="p-4 overflow-auto">
+          {loading ? <p className="text-sm text-gray-400">Loading...</p> : records.length === 0 ? (
+            <p className="text-sm text-gray-400">No analysis records</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500 w-6" />
+                <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Status</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Trace ID</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Summary</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Created</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Actions</th>
+              </tr></thead>
+              <tbody>
+                {records.map((r) => (
+                  <Fragment key={r.id}>
+                    <tr onClick={() => openDetail(r.id)} className={`cursor-pointer hover:bg-blue-50 ${selected === r.id ? 'bg-blue-100' : ''}`}>
+                      <td className="px-3 py-2 border-b text-gray-400">{selected === r.id ? '▼' : '▶'}</td>
+                      <td className="px-3 py-2 border-b">{r.id}</td>
+                      <td className="px-3 py-2 border-b"><SeBadge status={r.status} /></td>
+                      <td className="px-3 py-2 border-b font-mono text-xs text-gray-500">{r.trace_id ? r.trace_id.slice(0, 16) + '…' : '-'}</td>
+                      <td className="px-3 py-2 border-b text-xs">{r.summary ? r.summary.slice(0, 60) : '-'}</td>
+                      <td className="px-3 py-2 border-b text-xs text-gray-500">{fmt(r.created_at)}</td>
+                      <td className="px-3 py-2 border-b text-right">
+                        <button onClick={(e) => { e.stopPropagation(); handleRerun(r.id); }} className="text-xs text-blue-500 hover:text-blue-700">Rerun</button>
+                      </td>
+                    </tr>
+                    {selected === r.id && (
+                      <tr>
+                        <td colSpan={7} className="border-b bg-gray-50 p-3">
+                          {!detail ? <p className="text-sm text-gray-400 animate-pulse">Loading detail...</p> : (
+                            <div className="space-y-2">
+                              <div className="text-xs text-gray-500">Summary</div>
+                              <p className="text-sm whitespace-pre-wrap">{detail.summary || '-'}</p>
+                              <div className="text-xs text-gray-500 mt-2">Detail</div>
+                              <pre className="text-xs bg-white border rounded p-2 overflow-auto max-h-80">{detail.detail ? JSON.stringify(detail.detail, null, 2) : '-'}</pre>
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SeBadge({ status }) {
+  const s = (status || '').toUpperCase();
+  const c = s === 'SUCCEEDED' ? 'bg-green-100 text-green-700'
+    : s === 'RUNNING' ? 'bg-blue-100 text-blue-700'
+    : s === 'PENDING' ? 'bg-yellow-100 text-yellow-700'
+    : s === 'FAILED' ? 'bg-red-100 text-red-700'
+    : s === 'PARTIAL' ? 'bg-orange-100 text-orange-700' : 'bg-gray-100 text-gray-500';
+  return <span className={`text-xs px-2 py-0.5 rounded-full ${c}`}>{status || '-'}</span>;
+}
+
+function fmt(t) {
+  if (!t) return '-';
+  try { return new Date(t).toLocaleString(); } catch { return String(t); }
 }

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -92,7 +92,6 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
           {settings.length === 0 ? <p className="text-sm text-gray-400">No settings configured</p> : (
             <table className="w-full text-sm">
               <thead><tr className="bg-gray-50 text-left">
-                <th className="px-3 py-2 border-b text-xs text-gray-500">Seq</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">NS / Infra / Node</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Measurement</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Interval</th>
@@ -102,7 +101,6 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
               <tbody>
                 {settings.map((s) => (
                   <tr key={s.seq} className="hover:bg-gray-50">
-                    <td className="px-3 py-2 border-b">{s.seq}</td>
                     <td className="px-3 py-2 border-b">{s.ns_id}/{s.infra_id}/{s.node_id || '-'}</td>
                     <td className="px-3 py-2 border-b">{s.measurement}</td>
                     <td className="px-3 py-2 border-b">{s.execution_interval}</td>
@@ -201,20 +199,28 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
 }
 
 /* ----------------------------- Prediction ----------------------------- */
+// prediction_range is a duration string within the options' min~max bounds (e.g. 1h~2160h),
+// NOT the option keys ("min"/"max"). Offer sensible presets.
+const RANGE_PRESETS = [
+  { value: '1h', label: '1 hour' },
+  { value: '6h', label: '6 hours' },
+  { value: '12h', label: '12 hours' },
+  { value: '24h', label: '1 day' },
+  { value: '72h', label: '3 days' },
+  { value: '168h', label: '7 days' },
+  { value: '720h', label: '30 days' },
+];
+
 function PredictionTab({ nsId, infraId, nodeId }) {
   const [options, setOptions] = useState({ measurements: [], prediction_ranges: {} });
   const [measurement, setMeasurement] = useState('');
-  const [range, setRange] = useState('');
+  const [range, setRange] = useState('24h');
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
 
   useEffect(() => {
-    getPredictionOptions().then((o) => {
-      setOptions(o || {});
-      const ranges = Object.keys(o?.prediction_ranges || {});
-      if (ranges.length) setRange(ranges[0]);
-    }).catch(() => {});
+    getPredictionOptions().then((o) => setOptions(o || {})).catch(() => {});
   }, []);
 
   async function loadHistory() {
@@ -260,7 +266,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
           <div>
             <label className="block text-xs text-gray-600 mb-1">Prediction Range</label>
             <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={range} onChange={(e) => setRange(e.target.value)}>
-              {Object.entries(options.prediction_ranges || {}).map(([k, v]) => <option key={k} value={k}>{v || k}</option>)}
+              {RANGE_PRESETS.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
             </select>
           </div>
           <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -72,7 +72,9 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
 
   const chartSeries = history.length > 0 ? [{
     name: 'Anomaly Score',
-    data: history.map((h) => ({ x: new Date(h.timestamp).getTime(), y: h.anomaly_score ?? parseFloat(h.value) })),
+    data: history
+      .map((h) => ({ x: new Date(h.timestamp).getTime(), y: h.anomaly_score ?? (h.value == null ? null : parseFloat(h.value)) }))
+      .filter((p) => p.y != null && !Number.isNaN(p.y)),
   }] : [];
 
   return (
@@ -248,7 +250,9 @@ function PredictionTab({ nsId, infraId, nodeId }) {
 
   const chartSeries = history.length > 0 ? [{
     name: 'Prediction',
-    data: history.map((h) => ({ x: new Date(h.timestamp).getTime(), y: parseFloat(h.value) })),
+    data: history
+      .map((h) => ({ x: new Date(h.timestamp).getTime(), y: h.value == null ? null : parseFloat(h.value) }))
+      .filter((p) => p.y != null && !Number.isNaN(p.y)),
   }] : [];
 
   return (

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -23,10 +23,18 @@ export default function InsightDashboard() {
             {t}
           </button>
         ))}
-        <span className="ml-auto self-center text-xs text-gray-400 pr-2">
-          {nsId}/{infraId}{nodeId ? `/${nodeId}` : ''}
+        <span className="ml-auto self-center text-xs pr-2 flex items-center gap-1.5">
+          <span className="text-gray-400">분석 대상</span>
+          {nodeId
+            ? <span className="px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700" title={`${nsId} / ${infraId} / ${nodeId}`}>Node: {nodeId}</span>
+            : <span className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700" title={`${nsId} / ${infraId}`}>Infra: {infraId} (전체 노드 집계)</span>}
         </span>
       </div>
+      {!nodeId && tab !== 2 && (
+        <p className="text-xs text-gray-400 px-1">
+          노드 미선택 — Infra 전체(노드들 평균) 기준입니다. 특정 VM을 보려면 상단에서 Node를 선택하세요.
+        </p>
+      )}
       {tab === 0 && <AnomalyTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
       {tab === 1 && <PredictionTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
       {tab === 2 && <ServerErrorTab />}
@@ -127,7 +135,7 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
               {(measurements.length ? measurements : options.measurements || []).map((m) => <option key={m} value={m}>{m}</option>)}
             </select>
             <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
-              {loading ? 'Loading...' : 'Load History'}
+              {loading ? 'Loading...' : '이상탐지 점수 조회'}
             </button>
           </div>
           <MetricChart title="Anomaly Score" series={chartSeries} height={240} chartType="line" />
@@ -171,10 +179,10 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
     <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
       <div className="grid grid-cols-3 gap-3">
         <div>
-          <label className="block text-xs text-gray-600 mb-1">Target</label>
+          <label className="block text-xs text-gray-600 mb-1">분석 대상</label>
           <select value={scope} onChange={(e) => setScope(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
-            <option value="infra">Infra ({infraId})</option>
-            {nodeId && <option value="node">Node ({nodeId})</option>}
+            <option value="infra">Infra 전체 ({infraId})</option>
+            {nodeId && <option value="node">Node {nodeId}</option>}
           </select>
         </div>
         <div>
@@ -282,11 +290,11 @@ function PredictionTab({ nsId, infraId, nodeId }) {
               {RANGE_PRESETS.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
             </select>
           </div>
-          <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50">
-            Run Prediction
+          <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50" title="새로 예측을 실행하고 결과를 저장합니다">
+            예측 실행
           </button>
-          <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
-            Load History
+          <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50" title="이미 저장된 예측 결과를 불러옵니다 (재실행 안 함)">
+            저장된 예측 조회
           </button>
         </div>
         {msg && <p className="text-xs text-gray-500 mb-2">{msg}</p>}

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -24,15 +24,15 @@ export default function InsightDashboard() {
           </button>
         ))}
         <span className="ml-auto self-center text-xs pr-2 flex items-center gap-1.5">
-          <span className="text-gray-400">분석 대상</span>
+          <span className="text-gray-400">Scope</span>
           {nodeId
             ? <span className="px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700" title={`${nsId} / ${infraId} / ${nodeId}`}>Node: {nodeId}</span>
-            : <span className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700" title={`${nsId} / ${infraId}`}>Infra: {infraId} (전체 노드 집계)</span>}
+            : <span className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700" title={`${nsId} / ${infraId}`}>Infra: {infraId} (all nodes)</span>}
         </span>
       </div>
       {!nodeId && tab !== 2 && (
         <p className="text-xs text-gray-400 px-1">
-          노드 미선택 — Infra 전체(노드들 평균) 기준입니다. 특정 VM을 보려면 상단에서 Node를 선택하세요.
+          No node selected — using Infra-level (averaged across nodes). Select a Node above to scope to a specific VM.
         </p>
       )}
       {tab === 0 && <AnomalyTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
@@ -135,7 +135,7 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
               {(measurements.length ? measurements : options.measurements || []).map((m) => <option key={m} value={m}>{m}</option>)}
             </select>
             <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
-              {loading ? 'Loading...' : '이상탐지 점수 조회'}
+              {loading ? 'Loading...' : 'Load History'}
             </button>
           </div>
           <MetricChart title="Anomaly Score" series={chartSeries} height={240} chartType="line" />
@@ -179,10 +179,10 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
     <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
       <div className="grid grid-cols-3 gap-3">
         <div>
-          <label className="block text-xs text-gray-600 mb-1">분석 대상</label>
+          <label className="block text-xs text-gray-600 mb-1">Scope</label>
           <select value={scope} onChange={(e) => setScope(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
-            <option value="infra">Infra 전체 ({infraId})</option>
-            {nodeId && <option value="node">Node {nodeId}</option>}
+            <option value="infra">Infra: {infraId} (all nodes)</option>
+            {nodeId && <option value="node">Node: {nodeId}</option>}
           </select>
         </div>
         <div>
@@ -290,11 +290,11 @@ function PredictionTab({ nsId, infraId, nodeId }) {
               {RANGE_PRESETS.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
             </select>
           </div>
-          <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50" title="새로 예측을 실행하고 결과를 저장합니다">
-            예측 실행
+          <button onClick={handleRun} disabled={loading} className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50" title="Run a new prediction and store the result">
+            Run Prediction
           </button>
-          <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50" title="이미 저장된 예측 결과를 불러옵니다 (재실행 안 함)">
-            저장된 예측 조회
+          <button onClick={loadHistory} disabled={loading} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50" title="Load previously stored prediction (no re-run)">
+            Load Saved
           </button>
         </div>
         {msg && <p className="text-xs text-gray-500 mb-2">{msg}</p>}
@@ -324,7 +324,7 @@ function ServerErrorTab() {
       setRecords(data.items || []);
     } catch (e) {
       setRecords([]);
-      setMsg('records 조회 실패: ' + (e.response?.data?.error_message || e.message));
+      setMsg('Failed to load records: ' + (e.response?.data?.error_message || e.message));
     }
     setLoading(false);
   }, [status]);
@@ -341,10 +341,10 @@ function ServerErrorTab() {
     setBusy(true); setMsg('');
     try {
       const res = await detectServerError({ provider: 'openai', model_name: 'gpt-5-mini', limit: Number(limit) });
-      setMsg(`Detect 요청됨 (accepted=${res?.accepted}, ids=${(res?.analysis_ids || []).join(',') || '-'})`);
+      setMsg(`Detect requested (accepted=${res?.accepted}, ids=${(res?.analysis_ids || []).join(",") || "-"})`);
       await load();
     } catch (e) {
-      setMsg('Detect 실패 (LLM 미설정 가능): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+      setMsg('Detect failed (LLM may be unconfigured): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
     }
     setBusy(false);
   }
@@ -353,10 +353,10 @@ function ServerErrorTab() {
     setBusy(true); setMsg('');
     try {
       await rerunServerErrorAnalysis(id);
-      setMsg(`#${id} rerun 요청됨`);
+      setMsg(`#${id} rerun requested`);
       await load();
     } catch (e) {
-      setMsg('Rerun 실패 (LLM 미설정 가능): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
+      setMsg('Rerun failed (LLM may be unconfigured): ' + (e.response?.data?.detail || e.response?.data?.error_message || e.response?.data?.rs_msg || e.message));
     }
     setBusy(false);
   }
@@ -379,7 +379,7 @@ function ServerErrorTab() {
           <button onClick={handleDetect} disabled={busy} className="px-4 py-1.5 bg-purple-600 text-white rounded text-sm hover:bg-purple-700 disabled:opacity-50">
             {busy ? 'Working...' : 'Detect 5xx & Analyze'}
           </button>
-          <span className="text-xs text-gray-400">LLM(OpenAI/ollama) 미설정 시 분석은 실패합니다.</span>
+          <span className="text-xs text-gray-400">Analysis requires an LLM (OpenAI/ollama) to be configured.</span>
         </div>
         {msg && <p className="text-xs text-gray-500 px-4 pt-2">{msg}</p>}
         <div className="p-4 overflow-auto">

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -26,6 +26,10 @@ export default function TraceViewer() {
   const [traces, setTraces] = useState(null);
   const [loading, setLoading] = useState(false);
 
+  // paging
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
   // inline-expanded trace detail
   const [expandedId, setExpandedId] = useState('');
   const [spans, setSpans] = useState(null);
@@ -37,6 +41,7 @@ export default function TraceViewer() {
     setTraces(null);
     setExpandedId('');
     setSpans(null);
+    setPage(1);
     getTraceServices(scope).then(setServices).catch(() => setServices([]));
   }, [scope]);
 
@@ -44,8 +49,9 @@ export default function TraceViewer() {
     setLoading(true);
     setExpandedId('');
     setSpans(null);
+    setPage(1);
     try {
-      const result = await searchTraces({ scope, service, keyword, rangeHours });
+      const result = await searchTraces({ scope, service, keyword, rangeHours, limit: 500 });
       setTraces(Array.isArray(result) ? result : []);
     } catch (e) {
       console.error('Trace query failed', e);
@@ -133,13 +139,17 @@ export default function TraceViewer() {
 
       {/* Trace list with inline expand */}
       <div className="bg-white rounded-lg shadow">
-        <div className="px-4 py-3 border-b font-semibold text-sm">List of Trace</div>
+        <div className="px-4 py-3 border-b font-semibold text-sm flex items-center gap-2">
+          <span>List of Trace</span>
+          {traces && traces.length > 0 && <span className="text-xs font-normal text-gray-400">· {traces.length} traces</span>}
+        </div>
         <div className="p-4 overflow-auto">
           {traces === null ? (
             <p className="text-sm text-gray-400">Click Search to query traces</p>
           ) : traces.length === 0 ? (
             <p className="text-sm text-gray-400">No traces found</p>
           ) : (
+            <>
             <table className="w-full text-sm">
               <thead><tr className="bg-gray-50 text-left">
                 <th className="px-3 py-2 border-b text-xs text-gray-500 w-6" />
@@ -150,7 +160,7 @@ export default function TraceViewer() {
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Trace ID</th>
               </tr></thead>
               <tbody>
-                {traces.map((t) => {
+                {traces.slice((page - 1) * pageSize, page * pageSize).map((t) => {
                   const open = expandedId === t.traceId;
                   return (
                     <Fragment key={t.traceId}>
@@ -182,8 +192,33 @@ export default function TraceViewer() {
                 })}
               </tbody>
             </table>
+            <Pager total={traces.length} page={page} pageSize={pageSize}
+              onPage={setPage} onPageSize={(s) => { setPageSize(s); setPage(1); }} />
+            </>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+function Pager({ total, page, pageSize, onPage, onPageSize }) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const cur = Math.min(page, pageCount);
+  const from = total === 0 ? 0 : (cur - 1) * pageSize + 1;
+  const to = Math.min(cur * pageSize, total);
+  return (
+    <div className="flex items-center gap-2 mt-3 flex-wrap">
+      <span className="text-xs text-gray-500">{from}–{to} / {total}</span>
+      <div className="ml-auto flex items-center gap-1">
+        <button onClick={() => onPage(1)} disabled={cur <= 1} className="px-2 py-1 border rounded text-xs disabled:opacity-40">«</button>
+        <button onClick={() => onPage(cur - 1)} disabled={cur <= 1} className="px-2 py-1 border rounded text-xs disabled:opacity-40">‹ Prev</button>
+        <span className="text-xs text-gray-600 px-1">{cur} / {pageCount}</span>
+        <button onClick={() => onPage(cur + 1)} disabled={cur >= pageCount} className="px-2 py-1 border rounded text-xs disabled:opacity-40">Next ›</button>
+        <button onClick={() => onPage(pageCount)} disabled={cur >= pageCount} className="px-2 py-1 border rounded text-xs disabled:opacity-40">»</button>
+        <select value={pageSize} onChange={(e) => onPageSize(+e.target.value)} className="ml-2 border rounded px-2 py-1 text-xs">
+          {[10, 20, 50, 100].map((n) => <option key={n} value={n}>{n}/page</option>)}
+        </select>
       </div>
     </div>
   );

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InsightController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/InsightController.java
@@ -332,4 +332,35 @@ public class InsightController {
         return insightPort.getPredictionHistoryForNode(
                 nsId, infraId, nodeId, measurement, startTime, endTime);
     }
+
+    /* ===================== Server Error Analysis ===================== */
+    @PostMapping("/server-error-analysis/detect")
+    public Object detectServerError(@RequestBody Object body) {
+        return insightPort.detectServerError(body);
+    }
+
+    @PostMapping("/server-error-analysis/query")
+    public Object queryServerError(@RequestBody Object body) {
+        return insightPort.queryServerError(body);
+    }
+
+    @GetMapping("/server-error-analysis/records")
+    public Object listServerErrorRecords(
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "from", required = false) String fromDt,
+            @RequestParam(value = "to", required = false) String toDt,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "size", required = false) Integer size) {
+        return insightPort.listServerErrorRecords(status, fromDt, toDt, page, size);
+    }
+
+    @GetMapping("/server-error-analysis/records/{analysisId}")
+    public Object getServerErrorRecord(@PathVariable int analysisId) {
+        return insightPort.getServerErrorRecord(analysisId);
+    }
+
+    @PostMapping("/server-error-analysis/records/{analysisId}/rerun")
+    public Object rerunServerErrorAnalysis(@PathVariable int analysisId) {
+        return insightPort.rerunServerErrorAnalysis(analysisId);
+    }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClient.java
@@ -11,6 +11,7 @@ public interface InsightClient {
     String LLM = "/api/o11y/insight/llm";
     String LOG = "/api/o11y/insight/log-analysis";
     String PREDICTION = "/api/o11y/insight/predictions";
+    String SERVER_ERROR = "/api/o11y/insight/server-error-analysis";
 
     @GetMapping(ANOMALY + "/measurement")
     Object getMeasurements();
@@ -141,4 +142,25 @@ public interface InsightClient {
             @RequestParam("measurement") String measurement,
             @RequestParam(value = "start_time", required = false) String startTime,
             @RequestParam(value = "end_time", required = false) String endTime);
+
+    /* ===================== Server Error Analysis ===================== */
+    @PostMapping(SERVER_ERROR + "/detect")
+    Object detectServerError(@RequestBody Object body);
+
+    @PostMapping(SERVER_ERROR + "/query")
+    Object queryServerError(@RequestBody Object body);
+
+    @GetMapping(SERVER_ERROR + "/records")
+    Object listServerErrorRecords(
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "from", required = false) String fromDt,
+            @RequestParam(value = "to", required = false) String toDt,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "size", required = false) Integer size);
+
+    @GetMapping(SERVER_ERROR + "/records/{analysisId}")
+    Object getServerErrorRecord(@PathVariable("analysisId") int analysisId);
+
+    @PostMapping(SERVER_ERROR + "/records/{analysisId}/rerun")
+    Object rerunServerErrorAnalysis(@PathVariable("analysisId") int analysisId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClientAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/insight/InsightClientAdapter.java
@@ -184,4 +184,31 @@ public class InsightClientAdapter implements InsightPort {
     public Object queryLogAnalysis(Object body) {
         return insightClient.queryLogAnalysis(body);
     }
+
+    /* ===================== Server Error Analysis ===================== */
+    @Override
+    public Object detectServerError(Object body) {
+        return insightClient.detectServerError(body);
+    }
+
+    @Override
+    public Object queryServerError(Object body) {
+        return insightClient.queryServerError(body);
+    }
+
+    @Override
+    public Object listServerErrorRecords(
+            String status, String fromDt, String toDt, Integer page, Integer size) {
+        return insightClient.listServerErrorRecords(status, fromDt, toDt, page, size);
+    }
+
+    @Override
+    public Object getServerErrorRecord(int analysisId) {
+        return insightClient.getServerErrorRecord(analysisId);
+    }
+
+    @Override
+    public Object rerunServerErrorAnalysis(int analysisId) {
+        return insightClient.rerunServerErrorAnalysis(analysisId);
+    }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/InsightPort.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/port/InsightPort.java
@@ -80,4 +80,16 @@ public interface InsightPort {
 
     /* ===================== Log Analysis ===================== */
     Object queryLogAnalysis(Object body);
+
+    /* ===================== Server Error Analysis ===================== */
+    Object detectServerError(Object body);
+
+    Object queryServerError(Object body);
+
+    Object listServerErrorRecords(
+            String status, String fromDt, String toDt, Integer page, Integer size);
+
+    Object getServerErrorRecord(int analysisId);
+
+    Object rerunServerErrorAnalysis(int analysisId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
@@ -277,7 +277,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         InfluxDTO s =
                 InfluxDTO.builder()
                         .url(entity.getUrl())
-                        .database(pickDatabase(entity, req))
+                        .database(pickDatabase(entity, req, nsId, infraId, null))
                         .username(entity.getUsername())
                         .password(entity.getPassword())
                         .build();
@@ -363,7 +363,7 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         InfluxDTO s =
                 InfluxDTO.builder()
                         .url(entity.getUrl())
-                        .database(pickDatabase(entity, req))
+                        .database(pickDatabase(entity, req, nsId, infraId, nodeId))
                         .username(entity.getUsername())
                         .password(entity.getPassword())
                         .build();
@@ -738,15 +738,32 @@ public class InfluxDbServiceImpl implements InfluxDbService {
      * downsampling DB when the requested range is at least 1 day, otherwise the entity's default
      * (raw) DB.
      */
-    private String pickDatabase(InfluxEntity entity, MetricRequestDTO req) {
+    private String pickDatabase(
+            InfluxEntity entity, MetricRequestDTO req, String nsId, String infraId, String nodeId) {
+        String raw = entity.getDatabase();
         long rangeSec = parseRangeSeconds(req == null ? null : req.getRange());
-        if (rangeSec >= DOWNSAMPLING_THRESHOLD_SECONDS) {
-            String dsDb = influxDbInfo.downsamplingDatabase();
-            if (dsDb != null && !dsDb.isBlank()) {
-                return dsDb;
-            }
+        if (rangeSec < DOWNSAMPLING_THRESHOLD_SECONDS) {
+            return raw;
         }
-        return entity.getDatabase();
+        String dsDb = influxDbInfo.downsamplingDatabase();
+        if (dsDb == null || dsDb.isBlank()) {
+            return raw;
+        }
+        // Use the downsampling DB for long ranges only when it actually holds the data.
+        // If the downsampling pipeline hasn't populated it, fall back to the raw DB so
+        // metric/prediction queries don't silently return empty results.
+        InfluxDTO probe =
+                InfluxDTO.builder()
+                        .url(entity.getUrl())
+                        .database(dsDb)
+                        .username(entity.getUsername())
+                        .password(entity.getPassword())
+                        .build();
+        boolean dsHasData =
+                (nodeId != null)
+                        ? existsVmInInflux(probe, nsId, infraId, nodeId)
+                        : existsNsMciInInflux(probe, nsId, infraId);
+        return dsHasData ? dsDb : raw;
     }
 
     /**


### PR DESCRIPTION
## Summary
Insight 메뉴를 UI에서 실제로 쓸 수 있도록 구현 (Anomaly / Prediction / Server Error Analysis #300) + 사용 중 발견된 문제 수정.

## Anomaly Detection
- 설정 생성 폼(분석 대상 Infra/Node, measurement, execution_interval) + 목록/삭제 + 이상탐지 점수 이력 차트.

## Prediction
- measurement + 예측범위 선택 → 예측 실행 + 결과 차트.
- cpu는 사용률(100 − usage_idle)로 표시(Monitoring과 일관), null/NaN 포인트 제외.

## Server Error Analysis (#300)
- 매니저에 server-error-analysis 프록시 5종 추가(detect/query/records/record/rerun → insight 서비스).
- UI: 분석 레코드 목록/Detect/상세 펼침/Rerun. (실제 분석은 LLM 키 필요)

## Fixes
- InfluxDB downsampling DB가 비었을 때 raw DB로 폴백 → 24h 이상 예측 및 장기 모니터링 차트 정상화.
- prediction 입력 에러 detail 노출, 예측범위 프리셋, Seq 컬럼 숨김.
- 분석 대상(Infra 전체 vs Node) 및 액션 버튼 라벨 명확화.
