### PR TITLE
fix: front: Translate remaining Korean UI text and comments to English

### DIFF
--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -37,7 +37,7 @@ export default function Layout() {
     getNsList().then(setNsList).catch(() => setNsList([]));
   }, []);
 
-  // NS 변경 → Infra 목록 갱신
+  // NS change -> refresh Infra list
   const loadInfraList = useCallback(async (ns) => {
     if (!ns) { setInfraList([]); return []; }
     try {
@@ -48,7 +48,7 @@ export default function Layout() {
     } catch { setInfraList([]); return []; }
   }, []);
 
-  // Infra 변경 → Node 목록 갱신
+  // Infra change -> refresh Node list
   const loadNodeList = useCallback(async (ns, infra) => {
     if (!ns || !infra) { setNodeList([]); return; }
     try {
@@ -57,11 +57,11 @@ export default function Layout() {
     } catch { setNodeList([]); }
   }, []);
 
-  // URL의 nsId/infraId 가 바뀔 때마다 목록 갱신
+  // Refresh lists whenever URL nsId/infraId changes
   useEffect(() => { loadInfraList(nsId); }, [nsId, loadInfraList]);
   useEffect(() => { loadNodeList(nsId, infraId); }, [nsId, infraId, loadNodeList]);
 
-  // NS 드롭다운 변경
+  // NS dropdown change
   async function handleNsChange(newNs) {
     const infras = await loadInfraList(newNs);
     const firstInfra = infras[0]?.id;
@@ -70,7 +70,7 @@ export default function Layout() {
     }
   }
 
-  // Infra 드롭다운 변경
+  // Infra dropdown change
   function handleInfraChange(newInfra) {
     if (!newInfra) {
       navigate(`${base}/${currentSection}/${nsId}`);
@@ -79,7 +79,7 @@ export default function Layout() {
     navigate(`${base}/${currentSection}/${nsId}/${newInfra}`);
   }
 
-  // Node 드롭다운 변경
+  // Node dropdown change
   function handleNodeChange(newNode) {
     if (!nsId || !infraId) return;
     let path = `${base}/${currentSection}/${nsId}/${infraId}`;

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -28,7 +28,7 @@ export default function InfraOverview() {
   const [viewTab, setViewTab] = useState(infraId ? 'node' : 'node');
   const [clusters, setClusters] = useState([]);
 
-  // Infra 선택되면 Node 탭, Infra 없으면 유지
+  // Switch to Node tab when an Infra is selected; keep otherwise
   useEffect(() => {
     if (infraId) setViewTab('node');
   }, [infraId]);

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -15,7 +15,7 @@ export default function LogViewer() {
   const [logs, setLogs] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  // NS 레벨: Infra 목록 로드
+  // NS level: load Infra list
   useEffect(() => {
     if (!nsId) return;
     if (!infraId) {
@@ -25,7 +25,7 @@ export default function LogViewer() {
     }
   }, [nsId, infraId]);
 
-  // Infra 선택 시 Node 목록 로드
+  // Load Node list when an Infra is selected
   useEffect(() => {
     if (!nsId || !selectedInfraId) { setNodes([]); return; }
     getInfra(nsId, selectedInfraId)

--- a/front/src/pages/TraceViewer.jsx
+++ b/front/src/pages/TraceViewer.jsx
@@ -10,8 +10,8 @@ const RANGE_OPTIONS = [
 ];
 
 const SCOPES = [
-  { key: 'framework', label: 'Framework', desc: 'o11y 플랫폼 자체 트레이스 (manager / insight)' },
-  { key: 'vm', label: 'VM', desc: '대상 VM 애플리케이션 트레이스 (Beyla / OTel)' },
+  { key: 'framework', label: 'Framework', desc: 'Traces from the o11y platform itself (manager / insight)' },
+  { key: 'vm', label: 'VM', desc: 'Application traces from the target VM (Beyla / OTel)' },
 ];
 
 export default function TraceViewer() {
@@ -131,8 +131,8 @@ export default function TraceViewer() {
           </div>
           <p className="text-xs text-gray-400">
             {scope === 'vm'
-              ? 'VM 트레이스는 대상 노드에 trace agent(Beyla / OTel)가 설치되어 있어야 수집됩니다.'
-              : 'Framework 트레이스는 o11y 매니저/인사이트가 OTel로 자기계측한 데이터입니다. 행을 클릭하면 API 호출 흐름이 펼쳐집니다.'}
+              ? 'VM traces require a trace agent (Beyla / OTel) installed on the target node.'
+              : 'Framework traces are self-instrumented by the o11y manager/insight via OTel. Click a row to expand the API call flow.'}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
프론트에 남아있던 한글을 영어로 정리.

## Changes
- Tracing 스코프 설명/힌트(Framework·VM) 영어화 (TraceViewer).
- LogViewer / InfraOverview / Layout 의 한글 코드 주석 영어화.
