### PR TITLE
fix: java: Auto-derive VM-reachable host for fluent-bit (Loki) and Beyla (Tempo) agents

### DIFF
--- a/config/manager/.env
+++ b/config/manager/.env
@@ -40,11 +40,12 @@ SLACK_API_PATH=/api/chat.postMessage
 ##########################################################################
 
 ########## AGENT ENDPOINTS ##########
-# Optional override for the host VM log agents (fluent-bit) push logs to. Normally leave
-# this unset: the manager auto-derives it from the InfluxDB endpoint each VM already uses
-# (same host as Loki, already VM-reachable). Set it only when Loki is NOT co-located with
-# InfluxDB. Loki listens on port 3100.
+# Optional overrides for the hosts VM agents reach back to. Normally leave these unset: the
+# manager auto-derives the host from the InfluxDB endpoint each VM already uses (same host as
+# Loki/Tempo, already VM-reachable). Set them only when Loki/Tempo is NOT co-located with
+# InfluxDB. Loki listens on port 3100; Tempo OTLP on 4317.
 #LOKI_AGENT_HOST=
+#BEYLA_AGENT_HOST=
 
 
 ########## FEIGN ##########

--- a/config/manager/.env
+++ b/config/manager/.env
@@ -39,6 +39,14 @@ SLACK_BASEURL=https://slack.com
 SLACK_API_PATH=/api/chat.postMessage
 ##########################################################################
 
+########## AGENT ENDPOINTS ##########
+# Optional override for the host VM log agents (fluent-bit) push logs to. Normally leave
+# this unset: the manager auto-derives it from the InfluxDB endpoint each VM already uses
+# (same host as Loki, already VM-reachable). Set it only when Loki is NOT co-located with
+# InfluxDB. Loki listens on port 3100.
+#LOKI_AGENT_HOST=
+
+
 ########## FEIGN ##########
 #TUMBLEBUG_URL=http://mc-infra-manager:1323
 #TUMBLEBUG_ID=default

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/BeylaConfigFacadeService.java
@@ -1,5 +1,6 @@
 package com.mcmp.o11ymanager.manager.facade;
 
+import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
 import com.mcmp.o11ymanager.manager.service.interfaces.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,9 @@ import org.springframework.stereotype.Service;
  * <p>치환 placeholder: {@code @SITE_CODE}, {@code @NS_ID}, {@code @INFRA_ID}, {@code @NODE_ID},
  * {@code @OTEL_ENDPOINT}.
  *
- * <p>OTEL endpoint는 application.yaml의 {@code beyla.otel-endpoint}에서 주입 (사이트별 환경변수 {@code
- * BEYLA_OTEL_ENDPOINT}로 override 가능). InfluxDbFacadeService 같은 DB 조회 없이 단일 전역 endpoint 사용.
+ * <p>OTEL endpoint의 host는, 내부 docker 이름(otel-endpoint 기본값)이 실제 VM에서 해석되지 않으므로, 그 VM이 이미 사용하는
+ * InfluxDB 엔드포인트의 host(Tempo와 동일 호스트이자 VM-도달 가능 주소)로 자동 치환한다. scheme/port는 유지. {@code
+ * beyla.agent-host}로 명시적 override 가능. (FluentBitConfigFacadeService와 동일 패턴)
  */
 @Service
 @Slf4j
@@ -26,12 +28,16 @@ import org.springframework.stereotype.Service;
 public class BeylaConfigFacadeService {
 
     private final FileService fileService;
+    private final InfluxDbFacadeService influxDbFacadeService;
 
     @Value("${deploy.site-code}")
     private String deploySiteCode;
 
     @Value("${beyla.otel-endpoint}")
     private String otelEndpoint;
+
+    @Value("${beyla.agent-host:}")
+    private String beylaAgentHost;
 
     private final ClassPathResource beylaConfigTemplate =
             new ClassPathResource("beyla_template.yaml");
@@ -56,6 +62,66 @@ public class BeylaConfigFacadeService {
                 .replace("@NS_ID", finalNsId)
                 .replace("@INFRA_ID", finalInfraId)
                 .replace("@NODE_ID", finalNodeId)
-                .replace("@OTEL_ENDPOINT", otelEndpoint);
+                .replace("@OTEL_ENDPOINT", resolveOtelEndpoint(nsId, infraId));
+    }
+
+    /**
+     * Rewrites the OTLP endpoint host to one reachable FROM the target VM (the internal docker
+     * hostname in otel-endpoint is not), keeping the configured scheme and port.
+     *
+     * <p>Host resolution order: explicit {@code beyla.agent-host} → the host of the InfluxDB
+     * endpoint this VM already uses (co-located with Tempo, already VM-reachable) → the original
+     * otel-endpoint host (legacy).
+     */
+    private String resolveOtelEndpoint(String nsId, String infraId) {
+        if (beylaAgentHost != null && !beylaAgentHost.isBlank()) {
+            return rewriteHost(otelEndpoint, beylaAgentHost.trim());
+        }
+        try {
+            InfluxDTO out = influxDbFacadeService.resolveForVM(nsId, infraId);
+            String host = hostOf(out.getUrl());
+            if (host != null && !host.isBlank()) {
+                return rewriteHost(otelEndpoint, host);
+            }
+        } catch (Exception e) {
+            log.warn(
+                    "[BEYLA] failed to derive OTLP host from InfluxDB endpoint for {}/{}; "
+                            + "using configured otel-endpoint. err={}",
+                    nsId,
+                    infraId,
+                    e.getMessage());
+        }
+        return otelEndpoint;
+    }
+
+    /** Replaces the host of a {@code scheme://host:port/path} URL, preserving scheme/port/path. */
+    private String rewriteHost(String url, String newHost) {
+        if (url == null) {
+            return null;
+        }
+        int schemeIdx = url.indexOf("://");
+        String scheme = schemeIdx >= 0 ? url.substring(0, schemeIdx + 3) : "";
+        String rest = schemeIdx >= 0 ? url.substring(schemeIdx + 3) : url;
+        int portIdx = rest.indexOf(':');
+        int pathIdx = rest.indexOf('/');
+        String tail;
+        if (portIdx >= 0 && (pathIdx < 0 || portIdx < pathIdx)) {
+            tail = rest.substring(portIdx);
+        } else if (pathIdx >= 0) {
+            tail = rest.substring(pathIdx);
+        } else {
+            tail = "";
+        }
+        return scheme + newHost + tail;
+    }
+
+    /** Extracts the host portion from a {@code scheme://host:port} URL. */
+    private String hostOf(String url) {
+        if (url == null) {
+            return null;
+        }
+        String[] schemeSplit = url.split("://");
+        String hostPort = schemeSplit.length == 2 ? schemeSplit[1] : schemeSplit[0];
+        return hostPort.split("[:/]")[0];
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitConfigFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/FluentBitConfigFacadeService.java
@@ -1,5 +1,6 @@
 package com.mcmp.o11ymanager.manager.facade;
 
+import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
 import com.mcmp.o11ymanager.manager.service.interfaces.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,9 +14,16 @@ import org.springframework.stereotype.Service;
 public class FluentBitConfigFacadeService {
 
     private final FileService fileService;
+    private final InfluxDbFacadeService influxDbFacadeService;
 
     @Value("${loki.url}")
     private String lokiURL;
+
+    // Optional explicit override for the host the VM's fluent-bit pushes logs to. Normally left
+    // blank: the host is auto-derived from the InfluxDB endpoint this VM already uses (same host
+    // as Loki, already set to the deployment's VM-reachable address). See loki.agent-host.
+    @Value("${loki.agent-host:}")
+    private String lokiAgentHost;
 
     private final ClassPathResource fluentBitVariables =
             new ClassPathResource("fluent-bit_variables");
@@ -23,16 +31,7 @@ public class FluentBitConfigFacadeService {
     public String initFluentbitConfig(String nsId, String infraId, String nodeId) {
         String template = fileService.getFileContent(fluentBitVariables);
 
-        String[] lokiURLSplit = lokiURL.split("://");
-        if (lokiURLSplit.length != 2) {
-            throw new RuntimeException("Manager's Loki URL is invalid!");
-        }
-        lokiURLSplit = lokiURLSplit[1].split(":");
-        if (lokiURLSplit.length < 1) {
-            throw new RuntimeException("Manager's Loki URL is invalid!");
-        }
-
-        String lokiHost = lokiURLSplit[0];
+        String lokiHost = resolveLokiAgentHost(nsId, infraId);
 
         StringBuilder sb = new StringBuilder();
 
@@ -49,5 +48,51 @@ public class FluentBitConfigFacadeService {
                 .replace("@INFRA_ID", infraId)
                 .replace("@NODE_ID", nodeId)
                 .replace("@LOKI_HOST", lokiHost);
+    }
+
+    /**
+     * Resolves the host the VM's fluent-bit should push logs to — it must be reachable FROM the
+     * target VM, so it cannot be the manager's internal docker hostname (loki.url).
+     *
+     * <p>Resolution order:
+     *
+     * <ol>
+     *   <li>explicit {@code loki.agent-host} override, if set;
+     *   <li>the host of the InfluxDB endpoint this VM already uses — telegraf pushes metrics there
+     *       successfully, it is co-located with Loki, and the deployment (mc-admin-cli) already
+     *       sets it to the VM-reachable (public) address, so log collection works automatically
+     *       without extra config;
+     *   <li>the host parsed from {@code loki.url} as a last resort (legacy behavior).
+     * </ol>
+     */
+    private String resolveLokiAgentHost(String nsId, String infraId) {
+        if (lokiAgentHost != null && !lokiAgentHost.isBlank()) {
+            return lokiAgentHost.trim();
+        }
+        try {
+            InfluxDTO out = influxDbFacadeService.resolveForVM(nsId, infraId);
+            String host = hostOf(out.getUrl());
+            if (host != null && !host.isBlank()) {
+                return host;
+            }
+        } catch (Exception e) {
+            log.warn(
+                    "[FLUENTBIT] failed to derive Loki host from InfluxDB endpoint for {}/{}; "
+                            + "falling back to loki.url. err={}",
+                    nsId,
+                    infraId,
+                    e.getMessage());
+        }
+        return hostOf(lokiURL);
+    }
+
+    /** Extracts the host portion from a {@code scheme://host:port} URL. */
+    private String hostOf(String url) {
+        if (url == null) {
+            return null;
+        }
+        String[] schemeSplit = url.split("://");
+        String hostPort = schemeSplit.length == 2 ? schemeSplit[1] : schemeSplit[0];
+        return hostPort.split("[:/]")[0];
     }
 }

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -63,6 +63,11 @@ springdoc:
 
 loki:
   url: ${LOKI_URL:http://mc-observability-loki:3100}
+  # Optional override for the host VM log agents (fluent-bit) push logs to. Normally leave
+  # empty: the manager auto-derives it from the InfluxDB endpoint each VM already uses
+  # (same host as Loki, already set by the deployment to a VM-reachable address). Set this
+  # only when Loki is NOT co-located with InfluxDB.
+  agent-host: ${LOKI_AGENT_HOST:}
   endpoints:
     query: /loki/api/v1/query
     range: /loki/api/v1/query_range

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -89,6 +89,12 @@ beyla:
   # 환경변수만 override하면 다른 사이트(외부 endpoint)에 배포 가능.
   # 본 키는 Windows OTel Java agent에서도 그대로 재사용한다(POC 후 tracing.otel-endpoint로 일반화 예정).
   otel-endpoint: ${BEYLA_OTEL_ENDPOINT:http://mc-observability-tempo:4317}
+  # Optional override for the host the VM's Beyla agent sends OTLP traces to. Like the Loki
+  # agent host, the internal docker name in otel-endpoint is unreachable from real VMs. Leave
+  # empty to auto-derive the host from the InfluxDB endpoint the VM already uses (same host as
+  # Tempo, already VM-reachable); the scheme/port of otel-endpoint are kept. Set this only when
+  # Tempo is NOT co-located with InfluxDB. Mirrors loki.agent-host.
+  agent-host: ${BEYLA_AGENT_HOST:}
 
 otel-java-agent:
   # Windows VM 트레이싱용 OpenTelemetry Java Auto-Instrumentation jar 다운로드 URL.


### PR DESCRIPTION
## Summary
원격 VM의 로그/트레이스 수집이 안 되던 문제 수정. 매니저가 VM 에이전트 설정에 Loki/Tempo 호스트를 내부 docker 이름(`mc-observability-loki`, `mc-observability-tempo`)으로 주입해, 실제 VM에서 해석 불가 → push가 전부 실패했음.

## Changes
- fluent-bit(Loki)와 Beyla(Tempo OTLP) 에이전트의 대상 호스트를, 그 노드가 사용하는 InfluxDB 엔드포인트의 호스트에서 자동 도출. telegraf가 이미 도달 중인 주소이고 Loki/Tempo와 동일 호스트라, 추가 설정 없이 VM-도달 가능한(공인) 주소가 들어감. scheme/port는 유지.
- Loki/Tempo를 InfluxDB와 다른 호스트에 둔 경우를 위한 선택적 override: `LOKI_AGENT_HOST`, `BEYLA_AGENT_HOST`.

## Why
메트릭(telegraf→InfluxDB)은 influx 테이블의 (배포 시 자동 설정되는) 공인 URL을 써서 정상 동작하지만, 로그/트레이스는 매니저 내부용 docker 이름을 그대로 사용해 실패했음. 같은 호스트의 InfluxDB 엔드포인트를 재사용해 동일하게 자동화.

## Note
기존에 이미 설치된 에이전트는 매니저만 갱신해서는 적용되지 않고, 에이전트 재설치(config 재배포) 시 새 설정이 VM에 반영됨. 신규 설치는 자동 적용.
