### PR TITLE
fix(notification): make Kakao channel work via NCP AlimTalk

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/kakao/ncp/KakaoNoti.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/kakao/ncp/KakaoNoti.java
@@ -56,6 +56,7 @@ public class KakaoNoti implements Noti {
 
         RequestBody requestBody = new RequestBody();
         requestBody.plusFriendId = kakaoProperties.getChannelId();
+        requestBody.templateCode = kakaoProperties.getDirectTemplateCode();
 
         String content =
                 """
@@ -89,6 +90,7 @@ public class KakaoNoti implements Noti {
             AlertEvent event, KakaoProperties kakaoProperties, List<String> recipients) {
         RequestBody requestBody = new RequestBody();
         requestBody.plusFriendId = kakaoProperties.getChannelId();
+        requestBody.templateCode = kakaoProperties.getAlertTemplateCode();
         String content =
                 """
             [M-CMP] %s alerts triggered.
@@ -133,6 +135,7 @@ public class KakaoNoti implements Noti {
     public static class RequestBody {
 
         private String plusFriendId;
+        private String templateCode;
         private List<Message> messages;
     }
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/kakao/ncp/KakaoProperties.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/notification/channel/kakao/ncp/KakaoProperties.java
@@ -13,15 +13,16 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Configuration properties for NCP Kakao AlimTalk service Contains NCP Kakao API settings
- * including channel configuration and signature generation.
+ * Configuration properties for NCP Kakao AlimTalk service Contains NCP Kakao API settings including
+ * channel configuration and signature generation.
  */
 @Getter
 @Setter
 public class KakaoProperties implements NotiProperty {
     private final NotificationType type = KAKAO;
     private String channelId;
-    private String templateCode;
+    private String alertTemplateCode;
+    private String directTemplateCode;
     private String serviceId;
     private String accessKey;
     private String secretKey;

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -271,7 +271,8 @@ notification:
     baseUrl: ${SMS_BASEURL:https://sens.apigw.ntruss.com}
   kakao:
     channelId: ${KAKAO_CHANNEL_ID:@xxxx}
-    templateCode: ${KAKAO_TEMPLATE_CODE:triggerTemplate}
+    alertTemplateCode: ${KAKAO_ALERT_TEMPLATE_CODE:alertTemplate}
+    directTemplateCode: ${KAKAO_DIRECT_TEMPLATE_CODE:directTemplate}
     serviceId: ${KAKAO_SERVICE_ID:ncp:kkobizmsg:kr:12345678:m-cmp}
     accessKey: ${KAKAO_ACCESS_KEY:ncp_iam_YYYY}
     secretKey: ${KAKAO_SECRET_KEY:ncp_iam_YYYYZZZZ}


### PR DESCRIPTION
## Summary
Fix the Kakao channel to deliver through NCP AlimTalk.

## Changes
- Correct API path friendtalk → alimtalk (friendtalk not provisioned, returned 404)
- Add required `templateCode` to the AlimTalk payload (missing → 400)
- Split the template code into **alert / direct** — the two message formats differ, so one code can't match both; each uses its own template
  - `alertTemplateCode`: trigger alerts
  - `directTemplateCode`: direct alerts

## Config
Register two approved AlimTalk templates in NCP, then set env:
`KAKAO_ALERT_TEMPLATE_CODE`, `KAKAO_DIRECT_TEMPLATE_CODE`