### PR TITLE
fix: front: Show point markers so single/sparse metric samples are visible

### DIFF
--- a/front/src/components/MetricChart.jsx
+++ b/front/src/components/MetricChart.jsx
@@ -20,6 +20,11 @@ export default function MetricChart({ title, series, height = 240, chartType = '
   const formatter = buildFormatter(unit);
   const yTitle = unit.label ? `(${unit.label})` : '';
 
+  // A line/area needs >=2 points to draw anything; show point markers when data
+  // is sparse so a single isolated sample is still visible (not just on hover).
+  const maxPoints = Math.max(0, ...series.map(s => (s.data ? s.data.length : 0)));
+  const markerSize = maxPoints <= 2 ? 5 : 0;
+
   const options = {
     chart: { type: chartType, toolbar: { show: true }, zoom: { enabled: true, type: 'x', autoScaleYaxis: true, allowMouseWheelZoom: false }, animations: { enabled: false } },
     title: { text: title + (yTitle ? ` ${yTitle}` : ''), align: 'left', style: { fontSize: '13px', fontWeight: 600 }, offsetY: 0 },
@@ -30,6 +35,7 @@ export default function MetricChart({ title, series, height = 240, chartType = '
     },
     fill: { type: 'solid', opacity: 0.12 },
     stroke: { curve: 'smooth', width: 2 },
+    markers: { size: markerSize, strokeWidth: 0, hover: { size: 6 } },
     colors: COLORS.slice(0, series.length),
     legend: { show: true, position: 'top', horizontalAlign: 'left', fontSize: '11px' },
     tooltip: {


### PR DESCRIPTION
## Summary
메트릭 차트에서 데이터 포인트가 1개뿐이거나 희소할 때 점이 보이지 않던 문제 수정.

## Why
- MetricChart(K8s 노드/Infra 모니터링 공용)가 line/area만 그리고 마커를 설정하지 않아, ApexCharts 기본값(`markers.size = 0`)으로 개별 포인트가 그려지지 않았음.
- line/area는 포인트가 2개 이상이어야 보이므로, 샘플이 1개면 hover 시 툴팁 점만 나타나고 평소에는 빈 화면처럼 보였음. (메트릭 수집 직후 데이터가 1개일 때 발생)

## Changes
- 시리즈 최대 포인트 수가 2개 이하이면 마커 `size`를 5로, 그 이상이면 0으로 설정해 단일/희소 샘플도 점으로 표시. 데이터가 쌓이면(2개 이상) 기존처럼 선만 깔끔하게 표시.
