### PR TITLE
fix: java: Accept renamed infra/node scopes when resolving trigger InfluxDB UID

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
@@ -24,10 +24,10 @@ public class ManagerAdapter implements ManagerPort {
         Long influxId;
 
         // 1. Check whether vmScope is "infra_id" or "node_id"
-        if ("mci".equalsIgnoreCase(vmScope)) {
+        if ("infra".equalsIgnoreCase(vmScope)) {
             final String infraId = nodeId;
 
-            // 2. Map influx id using the combination of ns id and mci id
+            // 2. Map influx id using the combination of ns id and infra id
             List<VMDTO> vms = vmService.getByNsMci(nsId, infraId);
             influxId =
                     vms.stream()
@@ -36,8 +36,8 @@ public class ManagerAdapter implements ManagerPort {
                             .findFirst() // Can choose first/latest/minimum based on rules
                             .orElseGet(() -> influxDbService.resolveInfluxDb(nsId, infraId));
 
-        } else if ("vm".equalsIgnoreCase(vmScope)) {
-            // 3. Map mci id using ns and vm
+        } else if ("node".equalsIgnoreCase(vmScope)) {
+            // 3. Map infra id using ns and node
             VMDTO t = vmService.getByNsVm(nsId, nodeId);
 
             influxId = t.getInfluxSeq();


### PR DESCRIPTION
## Summary
Alerts에서 트리거 정책에 타겟(노드) 추가 시 500 에러가 나던 문제 수정.

## Why
- MCI/VM → Infra/Node 리네임 리팩터(`9ae4ee726`) 이후 프론트는 타겟을 `targetScope: "node"` 단위로 전송(인프라 선택 시에도 각 VM이 node)하는데, `ManagerAdapter.getInfluxUid`는 옛 스코프 `mci`/`vm`만 처리하고 있어 `IllegalArgumentException: unknown vmScope: node` → 500 발생.

## Changes
- `getInfluxUid`가 새 스코프 `infra`/`node`를 인식하도록 수정. 옛 스코프(`mci`/`vm`) 처리는 제거.
