### PR TITLE
fix: java: Replace trigger policy channels on update

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/service/TriggerService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/service/TriggerService.java
@@ -141,6 +141,15 @@ public class TriggerService implements TriggerServiceInternal {
 
         List<NotiChannel> notiChannels = notiChannelRepository.findByNameIn(notiChannelNames);
 
+        // Replace the policy's channels: remove existing rows before saving the new set
+        // so repeated saves don't accumulate duplicates.
+        List<TriggerPolicyNotiChannel> existing =
+                triggerPolicyNotiChannelRepository.findByTriggerPolicy(triggerPolicy);
+        if (!existing.isEmpty()) {
+            triggerPolicyNotiChannelRepository.deleteAll(existing);
+            triggerPolicyNotiChannelRepository.flush();
+        }
+
         List<TriggerPolicyNotiChannel> triggerPolicyNotiChannels =
                 TriggerPolicyNotiChannel.create(triggerPolicy, notiChannels, channelRecipientMap);
 


### PR DESCRIPTION
## Summary
트리거 정책의 알림 채널이 저장할 때마다 중복으로 쌓이던 문제 수정. (예: `email, sms` 저장을 두 번 하면 `email, sms, email, sms`)

## Why
- `updateTriggerPolicyNotiChannelByName`가 기존 `TriggerPolicyNotiChannel` 행을 지우지 않고 새 채널을 `saveAll`만 해서, 저장할 때마다 같은 채널이 누적 삽입됨.

## Changes
- 새 채널을 저장하기 전에 해당 정책의 기존 채널 행을 삭제(`findByTriggerPolicy` → `deleteAll` → `flush`)하도록 변경. 채널 저장이 누적이 아니라 교체로 동작.
