### PR TITLE
feat: Alerts trigger policies

### DIFF
--- a/front/src/api/trigger.js
+++ b/front/src/api/trigger.js
@@ -52,6 +52,12 @@ export async function getNotiHistory(page = 1, size = 20) {
   return res.data?.data || {};
 }
 
+// Send a test notification through RabbitMQ to a single channel (verifies end-to-end delivery).
+// body: { channelName, recipients[], title?, message? }
+export async function sendTestNotification(body) {
+  return client.post('/api/o11y/trigger/noti/test', body);
+}
+
 // Trigger history
 export async function getTriggerHistory(page = 1, size = 20) {
   const res = await client.get('/api/o11y/trigger/history', { params: { page, size } });

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -1,11 +1,30 @@
-import { useState, useEffect } from 'react';
-import { getPolicies, createPolicy, deletePolicy, addNodeToPolicy } from '../api/trigger';
-import { getNotiChannels, getNotiHistory } from '../api/trigger';
+import { useState, useEffect, Fragment } from 'react';
+import {
+  getPolicies, createPolicy, deletePolicy,
+  addNodeToPolicy, removeNodeFromPolicy, updatePolicyChannels,
+  getNotiChannels, getNotiHistory,
+} from '../api/trigger';
+import { getNodeList } from '../api/node';
 import { useParams } from 'react-router-dom';
 
 const TABS = ['Policies', 'Notification History'];
 const RESOURCE_TYPES = ['CPU', 'MEMORY', 'DISK'];
 const AGG_TYPES = ['AVG', 'MAX', 'MIN', 'LAST'];
+
+// Backend(/policy/{id}/channel)는 짧은 채널명만 허용: kakao, sms, email, slack, discord, teams.
+// NotiChannel.name("email_smtp.gmail.com" 등)에서 '_' 앞부분이 짧은 이름과 일치한다.
+const channelShortName = (name) => (name || '').split('_')[0].toLowerCase();
+const RECIPIENT_HINTS = {
+  email: 'a@b.com, c@d.com',
+  slack: '#alerts 또는 webhook URL',
+  discord: 'webhook URL',
+  teams: 'webhook URL',
+  sms: '01012345678, 01087654321',
+  kakao: '01012345678',
+};
+const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+const nodeIdOf = (n) => n.node_id ?? n.id ?? n.name;
+const nodeLabelOf = (n) => n.name ?? n.node_id ?? n.id;
 
 export default function AlertManager() {
   const { nsId, infraId } = useParams();
@@ -31,6 +50,9 @@ function PoliciesTab({ nsId, infraId }) {
   const [policies, setPolicies] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
+  const [channels, setChannels] = useState([]); // available noti channels
+  const [nodes, setNodes] = useState([]);       // VMs in this infra
+  const [expanded, setExpanded] = useState(null);
 
   const load = () => {
     setLoading(true);
@@ -40,15 +62,18 @@ function PoliciesTab({ nsId, infraId }) {
   };
   useEffect(load, []);
 
-  async function handleDelete(id) {
-    await deletePolicy(id);
-    load();
-  }
+  useEffect(() => {
+    getNotiChannels().then(d => setChannels((d.notiChannels || []).filter(c => c.isActive !== false))).catch(() => setChannels([]));
+  }, []);
 
-  async function handleAddInfra(policyId) {
-    if (!nsId || !infraId) { alert('NS/Infra not set'); return; }
-    // targetScope "infra" → trigger query tags by infra_id (matches Telegraf/InfluxDB tags)
-    await addNodeToPolicy(policyId, { namespaceId: nsId, targetScope: 'infra', targetId: infraId });
+  useEffect(() => {
+    if (!nsId || !infraId) { setNodes([]); return; }
+    getNodeList(nsId, infraId).then(list => setNodes(list || [])).catch(() => setNodes([]));
+  }, [nsId, infraId]);
+
+  async function handleDelete(id) {
+    if (!confirm('Delete this policy?')) return;
+    await deletePolicy(id);
     load();
   }
 
@@ -61,7 +86,12 @@ function PoliciesTab({ nsId, infraId }) {
             {showCreate ? 'Cancel' : '+ New Policy'}
           </button>
         </div>
-        {showCreate && <CreatePolicyForm onCreated={() => { setShowCreate(false); load(); }} />}
+        {showCreate && (
+          <CreatePolicyForm
+            nsId={nsId} infraId={infraId} channels={channels} nodes={nodes}
+            onCreated={() => { setShowCreate(false); load(); }}
+          />
+        )}
         <div className="p-4 overflow-auto">
           {loading ? <p className="text-sm text-gray-400">Loading...</p> : policies.length === 0 ? (
             <p className="text-sm text-gray-400">No policies</p>
@@ -72,24 +102,17 @@ function PoliciesTab({ nsId, infraId }) {
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Title</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Resource</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500">Thresholds</th>
-                <th className="px-3 py-2 border-b text-xs text-gray-500">Nodes</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Targets</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Channels</th>
                 <th className="px-3 py-2 border-b text-xs text-gray-500 text-right">Actions</th>
               </tr></thead>
               <tbody>
                 {policies.map(p => (
-                  <tr key={p.id} className="hover:bg-gray-50">
-                    <td className="px-3 py-2 border-b">{p.id}</td>
-                    <td className="px-3 py-2 border-b">{p.title}</td>
-                    <td className="px-3 py-2 border-b">{p.resourceType}</td>
-                    <td className="px-3 py-2 border-b text-xs">
-                      {p.thresholdCondition && `I:${p.thresholdCondition.info} W:${p.thresholdCondition.warning} C:${p.thresholdCondition.critical}`}
-                    </td>
-                    <td className="px-3 py-2 border-b text-xs">{p.vms?.length || 0}</td>
-                    <td className="px-3 py-2 border-b text-right space-x-2">
-                      <button onClick={() => handleAddInfra(p.id)} className="text-xs text-blue-500 hover:text-blue-700">+Infra</button>
-                      <button onClick={() => handleDelete(p.id)} className="text-xs text-red-500 hover:text-red-700">Delete</button>
-                    </td>
-                  </tr>
+                  <PolicyRow
+                    key={p.id} p={p} nsId={nsId} infraId={infraId} channels={channels} nodes={nodes}
+                    expanded={expanded === p.id} onToggle={() => setExpanded(expanded === p.id ? null : p.id)}
+                    onChanged={load} onDelete={() => handleDelete(p.id)}
+                  />
                 ))}
               </tbody>
             </table>
@@ -100,7 +123,112 @@ function PoliciesTab({ nsId, infraId }) {
   );
 }
 
-function CreatePolicyForm({ onCreated }) {
+function PolicyRow({ p, nsId, infraId, channels, nodes, expanded, onToggle, onChanged, onDelete }) {
+  const vms = p.vms || [];
+  const chans = p.notiChannels || [];
+  return (
+    <>
+      <tr className="hover:bg-gray-50">
+        <td className="px-3 py-2 border-b">{p.id}</td>
+        <td className="px-3 py-2 border-b">{p.title}</td>
+        <td className="px-3 py-2 border-b">{p.resourceType}</td>
+        <td className="px-3 py-2 border-b text-xs">
+          {p.thresholdCondition && `I:${p.thresholdCondition.info} W:${p.thresholdCondition.warning} C:${p.thresholdCondition.critical}`}
+        </td>
+        <td className="px-3 py-2 border-b text-xs">{vms.length}</td>
+        <td className="px-3 py-2 border-b text-xs">
+          {chans.length ? chans.map(c => channelShortName(c.name)).join(', ') : <span className="text-gray-400">none</span>}
+        </td>
+        <td className="px-3 py-2 border-b text-right space-x-2 whitespace-nowrap">
+          <button onClick={onToggle} className="text-xs text-blue-500 hover:text-blue-700">{expanded ? 'Close' : 'Manage'}</button>
+          <button onClick={onDelete} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={7} className="border-b bg-gray-50 px-4 py-3">
+            <ManagePanel p={p} nsId={nsId} infraId={infraId} channels={channels} nodes={nodes} onChanged={onChanged} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function ManagePanel({ p, nsId, infraId, channels, nodes, onChanged }) {
+  const vms = p.vms || [];
+  const [busy, setBusy] = useState(false);
+
+  // 채널 편집: 기존 설정으로 초기화
+  const [chanSel, setChanSel] = useState(() => {
+    const init = {};
+    (p.notiChannels || []).forEach(c => {
+      init[channelShortName(c.name)] = { checked: true, recipients: (c.recipients || []).join(', ') };
+    });
+    return init;
+  });
+
+  async function removeTarget(vm) {
+    setBusy(true);
+    try {
+      await removeNodeFromPolicy(p.id, { namespaceId: vm.namespaceId, targetScope: vm.targetScope, targetId: vm.targetId });
+      onChanged();
+    } catch (e) { alert('Remove failed: ' + (e?.message || e)); }
+    finally { setBusy(false); }
+  }
+
+  async function addTargets(targets) {
+    if (!targets.length) return;
+    setBusy(true);
+    try {
+      for (const t of targets) {
+        await addNodeToPolicy(p.id, { namespaceId: nsId, targetScope: t.targetScope, targetId: t.targetId });
+      }
+      onChanged();
+    } catch (e) { alert('Add target failed: ' + (e?.message || e)); }
+    finally { setBusy(false); }
+  }
+
+  async function saveChannels() {
+    const payload = buildChannelPayload(chanSel);
+    setBusy(true);
+    try {
+      await updatePolicyChannels(p.id, payload);
+      onChanged();
+      alert('Channels updated');
+    } catch (e) { alert('Channel update failed: ' + (e?.message || e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-xs font-semibold text-gray-600 mb-1">Alarm targets</div>
+        {vms.length === 0 ? <p className="text-xs text-gray-400 mb-2">No targets</p> : (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {vms.map(vm => (
+              <span key={`${vm.targetScope}-${vm.targetId}`} className="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1">
+                <span className="text-gray-400">{vm.targetScope}</span> {vm.targetId}
+                <button disabled={busy} onClick={() => removeTarget(vm)} className="text-red-500 hover:text-red-700 ml-1">×</button>
+              </span>
+            ))}
+          </div>
+        )}
+        <TargetPicker nsId={nsId} infraId={infraId} nodes={nodes} busy={busy} onAdd={addTargets} addLabel="Add targets" />
+      </div>
+
+      <div>
+        <div className="text-xs font-semibold text-gray-600 mb-1">Notification channels</div>
+        <ChannelPicker channels={channels} value={chanSel} onChange={setChanSel} />
+        <button disabled={busy} onClick={saveChannels} className="mt-2 bg-gray-700 text-white px-3 py-1 rounded text-xs hover:bg-gray-800 disabled:opacity-50">
+          Save channels
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CreatePolicyForm({ nsId, infraId, channels, nodes, onCreated }) {
   const [title, setTitle] = useState('');
   const [desc, setDesc] = useState('');
   const [resource, setResource] = useState('CPU');
@@ -110,19 +238,46 @@ function CreatePolicyForm({ onCreated }) {
   const [critical, setCritical] = useState(80);
   const [hold, setHold] = useState('5m');
   const [repeat, setRepeat] = useState('1h');
+  const [chanSel, setChanSel] = useState({});
+  const [pendingTargets, setPendingTargets] = useState([]); // [{targetScope, targetId, label}]
+  const [busy, setBusy] = useState(false);
+
+  function addPending(targets) {
+    setPendingTargets(prev => {
+      const map = new Map(prev.map(t => [`${t.targetScope}-${t.targetId}`, t]));
+      targets.forEach(t => map.set(`${t.targetScope}-${t.targetId}`, t));
+      return [...map.values()];
+    });
+  }
 
   async function submit(e) {
     e.preventDefault();
-    await createPolicy({
-      title, description: desc, resourceType: resource, aggregationType: agg,
-      holdDuration: hold, repeatInterval: repeat,
-      thresholdCondition: { info: +info, warning: +warning, critical: +critical },
-    });
-    onCreated();
+    setBusy(true);
+    try {
+      const created = await createPolicy({
+        title, description: desc, resourceType: resource, aggregationType: agg,
+        holdDuration: hold, repeatInterval: repeat,
+        thresholdCondition: { info: +info, warning: +warning, critical: +critical },
+      });
+      const policyId = created?.id ?? created?.data?.id;
+      if (!policyId) throw new Error('No policy id returned');
+
+      const channelPayload = buildChannelPayload(chanSel);
+      if (channelPayload.length) await updatePolicyChannels(policyId, channelPayload);
+
+      for (const t of pendingTargets) {
+        await addNodeToPolicy(policyId, { namespaceId: nsId, targetScope: t.targetScope, targetId: t.targetId });
+      }
+      onCreated();
+    } catch (err) {
+      alert('Create failed: ' + (err?.message || err));
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
-    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
+    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-4">
       <div className="grid grid-cols-2 gap-3">
         <input placeholder="Title" required value={title} onChange={e => setTitle(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
         <input placeholder="Description" value={desc} onChange={e => setDesc(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
@@ -142,14 +297,159 @@ function CreatePolicyForm({ onCreated }) {
         <input placeholder="Hold (e.g. 5m)" value={hold} onChange={e => setHold(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
         <input placeholder="Repeat (e.g. 1h)" value={repeat} onChange={e => setRepeat(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
       </div>
-      <button type="submit" className="bg-red-600 text-white px-4 py-1.5 rounded text-sm hover:bg-red-700">Create</button>
+
+      {/* Alarm targets */}
+      <div className="border-t pt-3">
+        <div className="text-xs font-semibold text-gray-600 mb-2">Alarm targets</div>
+        {pendingTargets.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {pendingTargets.map(t => (
+              <span key={`${t.targetScope}-${t.targetId}`} className="inline-flex items-center gap-1 text-xs bg-white border rounded px-2 py-1">
+                <span className="text-gray-400">{t.targetScope}</span> {t.label || t.targetId}
+                <button type="button" onClick={() => setPendingTargets(prev => prev.filter(x => !(x.targetScope === t.targetScope && x.targetId === t.targetId)))}
+                  className="text-red-500 hover:text-red-700 ml-1">×</button>
+              </span>
+            ))}
+          </div>
+        )}
+        <TargetPicker nsId={nsId} infraId={infraId} nodes={nodes} onAdd={addPending} addLabel="Add" />
+      </div>
+
+      {/* Notification channels */}
+      <div className="border-t pt-3">
+        <div className="text-xs font-semibold text-gray-600 mb-2">Notification channels</div>
+        <ChannelPicker channels={channels} value={chanSel} onChange={setChanSel} />
+      </div>
+
+      <button type="submit" disabled={busy} className="bg-red-600 text-white px-4 py-1.5 rounded text-sm hover:bg-red-700 disabled:opacity-50">
+        {busy ? 'Creating...' : 'Create'}
+      </button>
     </form>
   );
+}
+
+// 채널 선택 + 채널별 수신자 입력. value = { [shortName]: { checked, recipients } }
+function ChannelPicker({ channels, value, onChange }) {
+  if (!channels || channels.length === 0) {
+    return <p className="text-xs text-gray-400">No notification channels configured on the server.</p>;
+  }
+  const toggle = (short) => {
+    const cur = value[short] || { checked: false, recipients: '' };
+    onChange({ ...value, [short]: { ...cur, checked: !cur.checked } });
+  };
+  const setRecipients = (short, recipients) => {
+    const cur = value[short] || { checked: true, recipients: '' };
+    onChange({ ...value, [short]: { ...cur, recipients, checked: true } });
+  };
+  return (
+    <div className="space-y-2">
+      {channels.map(c => {
+        const short = channelShortName(c.name);
+        const sel = value[short] || { checked: false, recipients: '' };
+        return (
+          <div key={c.id ?? c.name} className="flex items-center gap-2">
+            <label className="flex items-center gap-1.5 text-xs w-28 shrink-0 cursor-pointer">
+              <input type="checkbox" checked={!!sel.checked} onChange={() => toggle(short)} />
+              {cap(short)}
+            </label>
+            <input
+              disabled={!sel.checked}
+              placeholder={RECIPIENT_HINTS[short] || 'recipients (comma-separated)'}
+              value={sel.recipients}
+              onChange={e => setRecipients(short, e.target.value)}
+              className="flex-1 border rounded px-2 py-1 text-xs disabled:bg-gray-100"
+            />
+          </div>
+        );
+      })}
+      <p className="text-[11px] text-gray-400">Comma-separate multiple recipients. Checked channels need at least one recipient.</p>
+    </div>
+  );
+}
+
+// Infra 레벨 = 인프라 내 VM 다중선택, Node 레벨 = 단일 VM. 둘 다 node 타깃으로 추가.
+function TargetPicker({ nsId, infraId, nodes, busy, onAdd, addLabel }) {
+  const [level, setLevel] = useState('infra');
+  const [checked, setChecked] = useState({}); // nodeId -> bool (infra level)
+  const [single, setSingle] = useState('');   // node level
+
+  if (!nsId || !infraId) {
+    return <p className="text-xs text-gray-400">Open the alert page from a specific infra to choose target VMs.</p>;
+  }
+  if (!nodes || nodes.length === 0) {
+    return <p className="text-xs text-gray-400">No VMs found in this infra.</p>;
+  }
+
+  const toggle = (id) => setChecked(prev => ({ ...prev, [id]: !prev[id] }));
+
+  const commit = () => {
+    let targets = [];
+    if (level === 'infra') {
+      targets = nodes.filter(n => checked[nodeIdOf(n)]).map(n => ({ targetScope: 'node', targetId: nodeIdOf(n), label: nodeLabelOf(n) }));
+    } else if (single) {
+      const n = nodes.find(x => String(nodeIdOf(x)) === String(single));
+      if (n) targets = [{ targetScope: 'node', targetId: nodeIdOf(n), label: nodeLabelOf(n) }];
+    }
+    if (!targets.length) { alert('Select at least one VM.'); return; }
+    onAdd(targets);
+    setChecked({}); setSingle('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-4 text-xs">
+        <label className="flex items-center gap-1 cursor-pointer">
+          <input type="radio" name={`level-${infraId}`} checked={level === 'infra'} onChange={() => setLevel('infra')} /> Infra (select VMs)
+        </label>
+        <label className="flex items-center gap-1 cursor-pointer">
+          <input type="radio" name={`level-${infraId}`} checked={level === 'node'} onChange={() => setLevel('node')} /> Node (single VM)
+        </label>
+      </div>
+
+      {level === 'infra' ? (
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {nodes.map(n => {
+            const id = nodeIdOf(n);
+            return (
+              <label key={id} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input type="checkbox" checked={!!checked[id]} onChange={() => toggle(id)} />
+                {nodeLabelOf(n)} <span className="text-gray-400">({id})</span>
+              </label>
+            );
+          })}
+        </div>
+      ) : (
+        <select value={single} onChange={e => setSingle(e.target.value)} className="border rounded px-2 py-1 text-xs">
+          <option value="">Select VM...</option>
+          {nodes.map(n => {
+            const id = nodeIdOf(n);
+            return <option key={id} value={id}>{nodeLabelOf(n)} ({id})</option>;
+          })}
+        </select>
+      )}
+
+      <button type="button" disabled={busy} onClick={commit} className="bg-blue-600 text-white px-3 py-1 rounded text-xs hover:bg-blue-700 disabled:opacity-50">
+        {addLabel || 'Add'}
+      </button>
+    </div>
+  );
+}
+
+// chanSel({ [short]: { checked, recipients } }) -> [{ channelName, recipients[] }]
+function buildChannelPayload(chanSel) {
+  return Object.entries(chanSel)
+    .filter(([, v]) => v && v.checked)
+    .map(([short, v]) => ({
+      channelName: short,
+      recipients: (v.recipients || '').split(',').map(s => s.trim()).filter(Boolean),
+    }))
+    .filter(c => c.recipients.length > 0);
 }
 
 function NotiHistoryTab() {
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(null);
 
   useEffect(() => {
     getNotiHistory(1, 50).then(d => setHistory(d.content || []))
@@ -166,6 +466,7 @@ function NotiHistoryTab() {
         ) : (
           <table className="w-full text-sm">
             <thead><tr className="bg-gray-50 text-left">
+              <th className="px-3 py-2 border-b text-xs text-gray-500 w-6"></th>
               <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
               <th className="px-3 py-2 border-b text-xs text-gray-500">Channel</th>
               <th className="px-3 py-2 border-b text-xs text-gray-500">Recipients</th>
@@ -173,19 +474,46 @@ function NotiHistoryTab() {
               <th className="px-3 py-2 border-b text-xs text-gray-500">Time</th>
             </tr></thead>
             <tbody>
-              {history.map(h => (
-                <tr key={h.id} className="hover:bg-gray-50">
-                  <td className="px-3 py-2 border-b">{h.id}</td>
-                  <td className="px-3 py-2 border-b">{h.channel}</td>
-                  <td className="px-3 py-2 border-b text-xs">{h.recipients?.join(', ')}</td>
-                  <td className="px-3 py-2 border-b">
-                    <span className={`text-xs px-2 py-0.5 rounded-full ${h.isSucceeded ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-                      {h.isSucceeded ? 'OK' : 'FAIL'}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
-                </tr>
-              ))}
+              {history.map(h => {
+                const isOpen = open === h.id;
+                return (
+                  <Fragment key={h.id}>
+                    <tr className="hover:bg-gray-50 cursor-pointer" onClick={() => setOpen(isOpen ? null : h.id)}>
+                      <td className="px-3 py-2 border-b text-gray-400 text-xs">{isOpen ? '▼' : '▶'}</td>
+                      <td className="px-3 py-2 border-b">{h.id}</td>
+                      <td className="px-3 py-2 border-b">{h.channel}</td>
+                      <td className="px-3 py-2 border-b text-xs">{h.recipients?.join(', ')}</td>
+                      <td className="px-3 py-2 border-b">
+                        <span className={`text-xs px-2 py-0.5 rounded-full ${h.isSucceeded ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+                          {h.isSucceeded ? 'OK' : 'FAIL'}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
+                    </tr>
+                    {isOpen && (
+                      <tr>
+                        <td colSpan={6} className="border-b bg-gray-50 px-4 py-3">
+                          <div className="space-y-2 text-xs">
+                            <div><span className="text-gray-500">Channel:</span> {h.channel}</div>
+                            <div><span className="text-gray-500">Recipients:</span> {h.recipients?.join(', ') || '-'}</div>
+                            <div><span className="text-gray-500">Time:</span> {h.createdAt}</div>
+                            {h.isSucceeded ? (
+                              <div className="text-green-700">Delivered successfully.</div>
+                            ) : (
+                              <div>
+                                <div className="text-red-700 font-semibold mb-1">Failure cause</div>
+                                <pre className="whitespace-pre-wrap break-all bg-red-50 border border-red-200 rounded p-2 text-[11px] text-red-800 max-h-64 overflow-auto">
+{h.exception || 'No error detail recorded.'}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
             </tbody>
           </table>
         )}

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, Fragment } from 'react';
 import {
   getPolicies, createPolicy, deletePolicy,
   addNodeToPolicy, removeNodeFromPolicy, updatePolicyChannels,
-  getNotiChannels, getNotiHistory,
+  getNotiChannels, getNotiHistory, sendTestNotification,
 } from '../api/trigger';
 import { getNodeList } from '../api/node';
 import { useParams } from 'react-router-dom';
@@ -10,21 +10,41 @@ import { useParams } from 'react-router-dom';
 const TABS = ['Policies', 'Notification History'];
 const RESOURCE_TYPES = ['CPU', 'MEMORY', 'DISK'];
 const AGG_TYPES = ['AVG', 'MAX', 'MIN', 'LAST'];
+const HISTORY_PAGE_SIZE = 20;
 
-// Backend(/policy/{id}/channel)는 짧은 채널명만 허용: kakao, sms, email, slack, discord, teams.
-// NotiChannel.name("email_smtp.gmail.com" 등)에서 '_' 앞부분이 짧은 이름과 일치한다.
+// Backend (/policy/{id}/channel and /noti/test) accepts only the short channel name:
+// kakao, sms, email, slack, discord, teams. NotiChannel.name (e.g. "email_smtp.gmail.com")
+// matches that short name in its part before the first '_'.
 const channelShortName = (name) => (name || '').split('_')[0].toLowerCase();
 const RECIPIENT_HINTS = {
-  email: 'a@b.com, c@d.com',
-  slack: '#alerts 또는 webhook URL',
-  discord: 'webhook URL',
-  teams: 'webhook URL',
-  sms: '01012345678, 01087654321',
-  kakao: '01012345678',
+  email: 'Email addresses (e.g. a@b.com, c@d.com)',
+  slack: 'Channel name or ID (e.g. #alerts, C0123ABCD)',
+  discord: 'Webhook URL (e.g. https://discord.com/api/webhooks/...)',
+  teams: 'Webhook URL (Teams Workflows incoming webhook)',
+  sms: 'Phone numbers (e.g. 01012345678, 01087654321)',
+  kakao: 'Phone number (e.g. 01012345678)',
 };
 const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 const nodeIdOf = (n) => n.node_id ?? n.id ?? n.name;
 const nodeLabelOf = (n) => n.name ?? n.node_id ?? n.id;
+const parseRecipients = (s) => (s || '').split(',').map(x => x.trim()).filter(Boolean);
+
+// Strip the raw Java exception class names and stack trace, leaving only the
+// human-readable failure message.
+function cleanError(raw) {
+  if (!raw) return 'No error detail recorded.';
+  const out = [];
+  for (const line of String(raw).split(/\r?\n/)) {
+    if (/^\s*at\s+/.test(line)) continue;                 // stack frame
+    if (/^\s*\.\.\.\s*\d+\s*more\s*$/.test(line)) continue; // "... N more"
+    let l = line.replace(/^\s*Caused by:\s*/, '');         // keep the cause message
+    // remove a leading fully-qualified exception class name (e.g. java.lang.RuntimeException: )
+    l = l.replace(/^([\w$]+\.)+[\w$]*(Exception|Error|Throwable)(:\s*|\s*$)/, '');
+    l = l.trim();
+    if (l) out.push(l);
+  }
+  return out.join(' ').trim() || 'Delivery failed.';
+}
 
 export default function AlertManager() {
   const { nsId, infraId } = useParams();
@@ -159,7 +179,7 @@ function ManagePanel({ p, nsId, infraId, channels, nodes, onChanged }) {
   const vms = p.vms || [];
   const [busy, setBusy] = useState(false);
 
-  // 채널 편집: 기존 설정으로 초기화
+  // Initialize channel editor from the policy's current channels.
   const [chanSel, setChanSel] = useState(() => {
     const init = {};
     (p.notiChannels || []).forEach(c => {
@@ -190,10 +210,9 @@ function ManagePanel({ p, nsId, infraId, channels, nodes, onChanged }) {
   }
 
   async function saveChannels() {
-    const payload = buildChannelPayload(chanSel);
     setBusy(true);
     try {
-      await updatePolicyChannels(p.id, payload);
+      await updatePolicyChannels(p.id, buildChannelPayload(chanSel));
       onChanged();
       alert('Channels updated');
     } catch (e) { alert('Channel update failed: ' + (e?.message || e)); }
@@ -277,25 +296,44 @@ function CreatePolicyForm({ nsId, infraId, channels, nodes, onCreated }) {
   }
 
   return (
-    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-4">
-      <div className="grid grid-cols-2 gap-3">
-        <input placeholder="Title" required value={title} onChange={e => setTitle(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-        <input placeholder="Description" value={desc} onChange={e => setDesc(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-        <select value={resource} onChange={e => setResource(e.target.value)} className="border rounded px-3 py-1.5 text-sm">
+    <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
+      <Field label="Title" hint="Unique name to identify this policy">
+        <input required value={title} onChange={e => setTitle(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+      </Field>
+      <Field label="Description" hint="Optional note about this policy">
+        <input value={desc} onChange={e => setDesc(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+      </Field>
+      <Field label="Resource" hint="Metric type to evaluate against the thresholds">
+        <select value={resource} onChange={e => setResource(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
           {RESOURCE_TYPES.map(r => <option key={r}>{r}</option>)}
         </select>
-        <select value={agg} onChange={e => setAgg(e.target.value)} className="border rounded px-3 py-1.5 text-sm">
+      </Field>
+      <Field label="Aggregation" hint="How to evaluate values over the interval (avg / max / min / last)">
+        <select value={agg} onChange={e => setAgg(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
           {AGG_TYPES.map(a => <option key={a}>{a}</option>)}
         </select>
+      </Field>
+
+      <div className="border-t pt-3 space-y-3">
+        <div className="text-xs font-semibold text-gray-600">Thresholds (%) — per-level alert criteria</div>
+        <Field label="Info" hint="Lowest alert level">
+          <input type="number" value={info} onChange={e => setInfo(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+        </Field>
+        <Field label="Warning" hint="Middle alert level">
+          <input type="number" value={warning} onChange={e => setWarning(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+        </Field>
+        <Field label="Critical" hint="Highest alert level">
+          <input type="number" value={critical} onChange={e => setCritical(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+        </Field>
       </div>
-      <div className="grid grid-cols-3 gap-3">
-        <input type="number" placeholder="Info" value={info} onChange={e => setInfo(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-        <input type="number" placeholder="Warning" value={warning} onChange={e => setWarning(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-        <input type="number" placeholder="Critical" value={critical} onChange={e => setCritical(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <input placeholder="Hold (e.g. 5m)" value={hold} onChange={e => setHold(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
-        <input placeholder="Repeat (e.g. 1h)" value={repeat} onChange={e => setRepeat(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+
+      <div className="border-t pt-3 space-y-3">
+        <Field label="Hold Duration" hint="Exceed threshold continuously this long before firing (e.g. 5m, 0s)">
+          <input value={hold} onChange={e => setHold(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+        </Field>
+        <Field label="Repeat Interval" hint="How often to re-notify while firing (e.g. 1h)">
+          <input value={repeat} onChange={e => setRepeat(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+        </Field>
       </div>
 
       {/* Alarm targets */}
@@ -328,8 +366,24 @@ function CreatePolicyForm({ nsId, infraId, channels, nodes, onCreated }) {
   );
 }
 
-// 채널 선택 + 채널별 수신자 입력. value = { [shortName]: { checked, recipients } }
+// Label shown to the LEFT of the input (with a small description underneath).
+function Field({ label, hint, children }) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="w-48 shrink-0 pt-1.5">
+        <div className="text-xs font-medium text-gray-700">{label}</div>
+        {hint && <div className="text-[11px] text-gray-400 leading-tight">{hint}</div>}
+      </div>
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
+  );
+}
+
+// Channel selection + per-channel recipients + per-channel Test button.
+// value = { [shortName]: { checked, recipients } }
 function ChannelPicker({ channels, value, onChange }) {
+  const [testing, setTesting] = useState('');
+
   if (!channels || channels.length === 0) {
     return <p className="text-xs text-gray-400">No notification channels configured on the server.</p>;
   }
@@ -341,6 +395,26 @@ function ChannelPicker({ channels, value, onChange }) {
     const cur = value[short] || { checked: true, recipients: '' };
     onChange({ ...value, [short]: { ...cur, recipients, checked: true } });
   };
+
+  async function test(short) {
+    const recipients = parseRecipients((value[short] || {}).recipients);
+    if (!recipients.length) { alert('Enter at least one recipient first.'); return; }
+    setTesting(short);
+    try {
+      await sendTestNotification({
+        channelName: short,
+        recipients,
+        title: 'Test notification',
+        message: 'This is a test alert from mc-observability.',
+      });
+      alert(`Test sent to ${short}. Check the Notification History tab for the delivery result.`);
+    } catch (e) {
+      alert('Test send failed: ' + (e?.message || e));
+    } finally {
+      setTesting('');
+    }
+  }
+
   return (
     <div className="space-y-2">
       {channels.map(c => {
@@ -359,15 +433,25 @@ function ChannelPicker({ channels, value, onChange }) {
               onChange={e => setRecipients(short, e.target.value)}
               className="flex-1 border rounded px-2 py-1 text-xs disabled:bg-gray-100"
             />
+            <button
+              type="button"
+              disabled={!sel.checked || testing === short}
+              onClick={() => test(short)}
+              className="text-xs border border-blue-300 text-blue-600 px-2 py-1 rounded hover:bg-blue-50 disabled:opacity-40 shrink-0"
+              title="Send a test notification via RabbitMQ to this channel"
+            >
+              {testing === short ? 'Sending...' : 'Test'}
+            </button>
           </div>
         );
       })}
-      <p className="text-[11px] text-gray-400">Comma-separate multiple recipients. Checked channels need at least one recipient.</p>
+      <p className="text-[11px] text-gray-400">Comma-separate multiple recipients. Checked channels need at least one recipient. Test delivers a real message through RabbitMQ.</p>
     </div>
   );
 }
 
-// Infra 레벨 = 인프라 내 VM 다중선택, Node 레벨 = 단일 VM. 둘 다 node 타깃으로 추가.
+// Infra level = multi-select VMs in the infra; Node level = a single VM.
+// Both are added as `node` targets.
 function TargetPicker({ nsId, infraId, nodes, busy, onAdd, addLabel }) {
   const [level, setLevel] = useState('infra');
   const [checked, setChecked] = useState({}); // nodeId -> bool (infra level)
@@ -439,83 +523,106 @@ function TargetPicker({ nsId, infraId, nodes, busy, onAdd, addLabel }) {
 function buildChannelPayload(chanSel) {
   return Object.entries(chanSel)
     .filter(([, v]) => v && v.checked)
-    .map(([short, v]) => ({
-      channelName: short,
-      recipients: (v.recipients || '').split(',').map(s => s.trim()).filter(Boolean),
-    }))
+    .map(([short, v]) => ({ channelName: short, recipients: parseRecipients(v.recipients) }))
     .filter(c => c.recipients.length > 0);
 }
 
 function NotiHistoryTab() {
-  const [history, setHistory] = useState([]);
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState({ content: [], totalPages: 1, totalElements: 0 });
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(null);
 
   useEffect(() => {
-    getNotiHistory(1, 50).then(d => setHistory(d.content || []))
-      .catch(() => setHistory([]))
+    setLoading(true);
+    getNotiHistory(page, HISTORY_PAGE_SIZE)
+      .then(d => setData({ content: d.content || [], totalPages: d.totalPages || 1, totalElements: d.totalElements || 0 }))
+      .catch(() => setData({ content: [], totalPages: 1, totalElements: 0 }))
       .finally(() => setLoading(false));
-  }, []);
+  }, [page]);
+
+  const { content, totalPages, totalElements } = data;
 
   return (
     <div className="bg-white rounded-lg shadow">
-      <div className="px-4 py-3 border-b font-semibold text-sm">Notification History</div>
+      <div className="px-4 py-3 border-b font-semibold text-sm flex justify-between items-center">
+        <span>Notification History</span>
+        {totalElements > 0 && <span className="text-xs font-normal text-gray-400">{totalElements} total</span>}
+      </div>
       <div className="p-4 overflow-auto">
-        {loading ? <p className="text-sm text-gray-400">Loading...</p> : history.length === 0 ? (
+        {loading ? <p className="text-sm text-gray-400">Loading...</p> : content.length === 0 ? (
           <p className="text-sm text-gray-400">No notifications</p>
         ) : (
-          <table className="w-full text-sm">
-            <thead><tr className="bg-gray-50 text-left">
-              <th className="px-3 py-2 border-b text-xs text-gray-500 w-6"></th>
-              <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
-              <th className="px-3 py-2 border-b text-xs text-gray-500">Channel</th>
-              <th className="px-3 py-2 border-b text-xs text-gray-500">Recipients</th>
-              <th className="px-3 py-2 border-b text-xs text-gray-500">Status</th>
-              <th className="px-3 py-2 border-b text-xs text-gray-500">Time</th>
-            </tr></thead>
-            <tbody>
-              {history.map(h => {
-                const isOpen = open === h.id;
-                return (
-                  <Fragment key={h.id}>
-                    <tr className="hover:bg-gray-50 cursor-pointer" onClick={() => setOpen(isOpen ? null : h.id)}>
-                      <td className="px-3 py-2 border-b text-gray-400 text-xs">{isOpen ? '▼' : '▶'}</td>
-                      <td className="px-3 py-2 border-b">{h.id}</td>
-                      <td className="px-3 py-2 border-b">{h.channel}</td>
-                      <td className="px-3 py-2 border-b text-xs">{h.recipients?.join(', ')}</td>
-                      <td className="px-3 py-2 border-b">
-                        <span className={`text-xs px-2 py-0.5 rounded-full ${h.isSucceeded ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-                          {h.isSucceeded ? 'OK' : 'FAIL'}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
-                    </tr>
-                    {isOpen && (
-                      <tr>
-                        <td colSpan={6} className="border-b bg-gray-50 px-4 py-3">
-                          <div className="space-y-2 text-xs">
-                            <div><span className="text-gray-500">Channel:</span> {h.channel}</div>
-                            <div><span className="text-gray-500">Recipients:</span> {h.recipients?.join(', ') || '-'}</div>
-                            <div><span className="text-gray-500">Time:</span> {h.createdAt}</div>
-                            {h.isSucceeded ? (
-                              <div className="text-green-700">Delivered successfully.</div>
-                            ) : (
-                              <div>
-                                <div className="text-red-700 font-semibold mb-1">Failure cause</div>
-                                <pre className="whitespace-pre-wrap break-all bg-red-50 border border-red-200 rounded p-2 text-[11px] text-red-800 max-h-64 overflow-auto">
-{h.exception || 'No error detail recorded.'}
-                                </pre>
-                              </div>
-                            )}
-                          </div>
+          <>
+            <table className="w-full text-sm">
+              <thead><tr className="bg-gray-50 text-left">
+                <th className="px-3 py-2 border-b text-xs text-gray-500 w-6"></th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">ID</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Channel</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Recipients</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Status</th>
+                <th className="px-3 py-2 border-b text-xs text-gray-500">Time</th>
+              </tr></thead>
+              <tbody>
+                {content.map(h => {
+                  const isOpen = open === h.id;
+                  return (
+                    <Fragment key={h.id}>
+                      <tr className="hover:bg-gray-50 cursor-pointer" onClick={() => setOpen(isOpen ? null : h.id)}>
+                        <td className="px-3 py-2 border-b text-gray-400 text-xs">{isOpen ? '▼' : '▶'}</td>
+                        <td className="px-3 py-2 border-b">{h.id}</td>
+                        <td className="px-3 py-2 border-b">{h.channel}</td>
+                        <td className="px-3 py-2 border-b text-xs">{h.recipients?.join(', ')}</td>
+                        <td className="px-3 py-2 border-b">
+                          <span className={`text-xs px-2 py-0.5 rounded-full ${h.isSucceeded ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+                            {h.isSucceeded ? 'OK' : 'FAIL'}
+                          </span>
                         </td>
+                        <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
                       </tr>
-                    )}
-                  </Fragment>
-                );
-              })}
-            </tbody>
-          </table>
+                      {isOpen && (
+                        <tr>
+                          <td colSpan={6} className="border-b bg-gray-50 px-4 py-3">
+                            <div className="space-y-2 text-xs">
+                              <div><span className="text-gray-500">Channel:</span> {h.channel}</div>
+                              <div><span className="text-gray-500">Recipients:</span> {h.recipients?.join(', ') || '-'}</div>
+                              <div><span className="text-gray-500">Time:</span> {h.createdAt}</div>
+                              {h.isSucceeded ? (
+                                <div className="text-green-700">Delivered successfully.</div>
+                              ) : (
+                                <div>
+                                  <div className="text-red-700 font-semibold mb-1">Failure cause</div>
+                                  <div className="whitespace-pre-wrap break-words bg-red-50 border border-red-200 rounded p-2 text-[12px] text-red-800">
+                                    {cleanError(h.exception)}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+
+            <div className="flex items-center justify-between mt-3 text-xs text-gray-500">
+              <button
+                disabled={page <= 1}
+                onClick={() => { setOpen(null); setPage(p => Math.max(1, p - 1)); }}
+                className="px-3 py-1 border rounded disabled:opacity-40 hover:bg-gray-50">
+                ‹ Prev
+              </button>
+              <span>Page {page} / {totalPages || 1}</span>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => { setOpen(null); setPage(p => p + 1); }}
+                className="px-3 py-1 border rounded disabled:opacity-40 hover:bg-gray-50">
+                Next ›
+              </button>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/NotiController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/NotiController.java
@@ -1,22 +1,29 @@
 package com.mcmp.o11ymanager.trigger.application.controller;
 
 import com.mcmp.o11ymanager.manager.global.vm.ResBody;
+import com.mcmp.o11ymanager.trigger.application.controller.dto.request.DirectAlertTestRequest;
 import com.mcmp.o11ymanager.trigger.application.controller.dto.response.NotiChannelAllResponse;
 import com.mcmp.o11ymanager.trigger.application.controller.dto.response.NotiHistoryPageResponse;
 import com.mcmp.o11ymanager.trigger.application.service.NotiService;
 import com.mcmp.o11ymanager.trigger.application.service.dto.CustomPageDto;
 import com.mcmp.o11ymanager.trigger.application.service.dto.NotiChannelDetailDto;
 import com.mcmp.o11ymanager.trigger.application.service.dto.NotiHistoryDetailDto;
+import com.mcmp.o11ymanager.trigger.infrastructure.external.message.alert.DirectAlertPublisher;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -29,15 +36,37 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotiController {
 
     private final NotiService notiService;
+    private final DirectAlertPublisher directAlertPublisher;
 
     /**
      * Constructor for NotiController
      *
      * @param notiService Service that handles notification channel and history related business
      *     logic
+     * @param directAlertPublisher Publisher for sending test notifications through RabbitMQ
      */
-    public NotiController(NotiService notiService) {
+    public NotiController(NotiService notiService, DirectAlertPublisher directAlertPublisher) {
         this.notiService = notiService;
+        this.directAlertPublisher = directAlertPublisher;
+    }
+
+    /**
+     * Sends a test notification to a single channel through RabbitMQ (alert-manual queue). The
+     * message is processed by the normal consumer, delivered to the channel, and recorded in the
+     * notification history.
+     *
+     * @param request channel name, recipients, and optional title/message
+     * @return empty response (delivery result appears in the notification history)
+     */
+    @Operation(
+            summary = "SendTestNotification",
+            description = "Send a test notification to a channel via RabbitMQ",
+            operationId = "SendTestNotification")
+    @PostMapping("/test")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResBody<Void> sendTestNotification(@Valid @RequestBody DirectAlertTestRequest request) {
+        directAlertPublisher.publish(request.toDirectAlert());
+        return new ResBody<>();
     }
 
     /**

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/DirectAlertTestRequest.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/dto/request/DirectAlertTestRequest.java
@@ -1,0 +1,28 @@
+package com.mcmp.o11ymanager.trigger.application.controller.dto.request;
+
+import com.mcmp.o11ymanager.trigger.application.persistence.model.DirectAlert;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * Request to send a test notification to a single channel. {@code channelName} is the short channel
+ * name (sms, email, slack, kakao, discord, teams).
+ */
+public record DirectAlertTestRequest(
+        @Schema(description = "Channel short name", example = "slack") @NotNull @NotBlank String channelName,
+        @Schema(description = "Recipients for the channel") @NotNull @NotEmpty List<String> recipients,
+        @Schema(description = "Optional title") String title,
+        @Schema(description = "Optional message body") String message) {
+
+    public DirectAlert toDirectAlert() {
+        String t = (title == null || title.isBlank()) ? "Test notification" : title;
+        String m =
+                (message == null || message.isBlank())
+                        ? "This is a test alert from mc-observability."
+                        : message;
+        return new DirectAlert(t, m, channelName, recipients);
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/message/alert/DirectAlertPublisher.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/infrastructure/external/message/alert/DirectAlertPublisher.java
@@ -1,0 +1,31 @@
+package com.mcmp.o11ymanager.trigger.infrastructure.external.message.alert;
+
+import com.mcmp.o11ymanager.trigger.application.persistence.model.DirectAlert;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes a {@link DirectAlert} to the direct (manual) alert exchange so it flows through the
+ * normal RabbitMQ consumer ({@code alert-manual.queue}) and is delivered to a single channel. Used
+ * by the "Test" button to verify end-to-end notification delivery.
+ */
+@Component
+public class DirectAlertPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${spring.rabbitmq.direct.exchangeName}")
+    private String exchangeName;
+
+    @Value("${spring.rabbitmq.direct.routingKey}")
+    private String routingKey;
+
+    public DirectAlertPublisher(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void publish(DirectAlert directAlert) {
+        rabbitTemplate.convertAndSend(exchangeName, routingKey, directAlert);
+    }
+}


### PR DESCRIPTION
## Summary
Alerts(트리거 정책) 기능 추가 및 보완. 알림 채널 선택, infra/node 타겟 지정, 채널별 테스트 발송, 알림 이력 페이징 등을 포함하며, 이번에 네임스페이스 레벨 타겟 선택과 정책 description 선택 입력을 추가.

## Changes
- **front: Alerts UI** — 정책별 알림 채널 선택, infra/node 타겟 피커, 알림 이력 에러 원인 펼치기.
- **front: 타겟 피커 infra 선택** — 라우트에 infraId가 없어도(네임스페이스 레벨) infra 드롭다운으로 VM 선택이 동작하도록 `getInfraList(ns)` 기반으로 변경.
- **trigger: 채널별 테스트 발송** — RabbitMQ 경유 채널 테스트, 알림 이력 페이징, 에러 원인 정리, 알림 폼 라벨 좌측 정렬.
- **java: 정책 description 선택 입력** — `TriggerPolicyCreateRequest.description`에서 `@NotNull @NotBlank` 제거(선택값).
- **front: .dockerignore 추가** — 이미지 빌드 컨텍스트에서 `node_modules`/`dist` 등 제외.
