### PR TITLE
fix: front: Display timestamps in the browser's local timezone

### DIFF
--- a/front/src/components/LogTable.jsx
+++ b/front/src/components/LogTable.jsx
@@ -38,7 +38,7 @@ export default function LogTable({ logs }) {
               {paged.map((log, i) => (
                 <tr key={page * PAGE_SIZE + i} onClick={() => setSelected(log)}
                   className={`cursor-pointer hover:bg-blue-50 ${selected === log ? 'bg-blue-100' : ''}`}>
-                  <td className="px-3 py-2 border-b whitespace-nowrap text-sm text-gray-500">{log.timestamp || '-'}</td>
+                  <td className="px-3 py-2 border-b whitespace-nowrap text-sm text-gray-500">{formatLocalTime(log.timestamp) || '-'}</td>
                   <td className="px-3 py-2 border-b text-sm"><LevelBadge level={log.level} /></td>
                   <td className="px-3 py-2 border-b whitespace-nowrap text-sm">{log.node_id || '-'}</td>
                   <td className="px-3 py-2 border-b whitespace-nowrap text-sm">{log.service || '-'}</td>
@@ -54,7 +54,7 @@ export default function LogTable({ logs }) {
           <div className="w-96 bg-gray-50 rounded-md p-4 overflow-auto max-h-[600px] shrink-0 text-sm">
             <h4 className="font-semibold mb-3">Log Detail</h4>
             <div className="space-y-1.5 mb-3">
-              <Row label="Timestamp" value={selected.timestamp} />
+              <Row label="Timestamp" value={formatLocalTime(selected.timestamp)} />
               <Row label="Level" value={selected.level} />
               <Row label="Node" value={selected.node_id} />
               <Row label="Host" value={selected.host} />

--- a/front/src/components/MetricChart.jsx
+++ b/front/src/components/MetricChart.jsx
@@ -1,4 +1,5 @@
 import Chart from 'react-apexcharts';
+import { formatLocalTime } from '../utils/time';
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16'];
 
@@ -40,7 +41,7 @@ export default function MetricChart({ title, series, height = 240, chartType = '
     legend: { show: true, position: 'top', horizontalAlign: 'left', fontSize: '11px' },
     tooltip: {
       theme: 'dark',
-      x: { format: 'yyyy-MM-dd HH:mm:ss' },
+      x: { formatter: (val) => formatLocalTime(val) },
       y: { formatter },
     },
     grid: { strokeDashArray: 4 },

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -5,6 +5,7 @@ import {
   getNotiChannels, getNotiHistory, sendTestNotification,
 } from '../api/trigger';
 import { getInfraList } from '../api/tumblebug';
+import { formatLocalTime } from '../utils/time';
 import { useParams } from 'react-router-dom';
 
 const TABS = ['Policies', 'Notification History'];
@@ -604,7 +605,7 @@ function NotiHistoryTab() {
                             {h.isSucceeded ? 'OK' : 'FAIL'}
                           </span>
                         </td>
-                        <td className="px-3 py-2 border-b text-xs">{h.createdAt}</td>
+                        <td className="px-3 py-2 border-b text-xs">{formatLocalTime(h.createdAt)}</td>
                       </tr>
                       {isOpen && (
                         <tr>
@@ -612,7 +613,7 @@ function NotiHistoryTab() {
                             <div className="space-y-2 text-xs">
                               <div><span className="text-gray-500">Channel:</span> {h.channel}</div>
                               <div><span className="text-gray-500">Recipients:</span> {h.recipients?.join(', ') || '-'}</div>
-                              <div><span className="text-gray-500">Time:</span> {h.createdAt}</div>
+                              <div><span className="text-gray-500">Time:</span> {formatLocalTime(h.createdAt)}</div>
                               {h.isSucceeded ? (
                                 <div className="text-green-700">Delivered successfully.</div>
                               ) : (

--- a/front/src/utils/time.js
+++ b/front/src/utils/time.js
@@ -1,0 +1,8 @@
+// Format an ISO/epoch timestamp in the browser's local timezone (YYYY-MM-DD HH:mm:ss).
+export function formatLocalTime(value) {
+  if (value == null || value === '') return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}


### PR DESCRIPTION
## Summary
앱에서 보여주는 시간을 브라우저(로컬) 시간대로 통일.

## Why
- 백엔드는 시간을 UTC(예: `2026-06-12T09:48:00Z`)로 내려주는데, 차트 툴팁/로그/알림 이력은 UTC 그대로 표시돼 사용자 시간대와 달랐음.

## Changes
- `utils/time.js` 추가 — ISO/epoch 값을 브라우저 로컬 `YYYY-MM-DD HH:mm:ss`로 변환하는 `formatLocalTime` 헬퍼.
- 차트(MetricChart) 툴팁: x축 시간을 로컬로 포맷(축 라벨은 이미 `datetimeUTC: false`로 로컬).
- 로그(LogTable): timestamp 컬럼·상세를 로컬로 표시.
- 알림 이력(AlertManager): `createdAt`을 로컬로 표시.

(TraceViewer/InsightDashboard는 이미 `toLocaleString()`으로 로컬 표시 중이라 변경 없음.)
