### PR TITLE
feat: Edit trigger policy thresholds and settings after creation

### DIFF
--- a/front/src/api/trigger.js
+++ b/front/src/api/trigger.js
@@ -18,6 +18,10 @@ export async function deletePolicy(id) {
   return client.delete(`/api/o11y/trigger/policy/${id}`);
 }
 
+export async function updatePolicy(id, body) {
+  return client.put(`/api/o11y/trigger/policy/${id}`, body);
+}
+
 export async function addNodeToPolicy(policyId, body) {
   return client.post(`/api/o11y/trigger/policy/${policyId}/node`, body);
 }

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, Fragment } from 'react';
 import {
-  getPolicies, createPolicy, deletePolicy,
+  getPolicies, createPolicy, deletePolicy, updatePolicy,
   addNodeToPolicy, removeNodeFromPolicy, updatePolicyChannels,
   getNotiChannels, getNotiHistory, sendTestNotification,
 } from '../api/trigger';
@@ -11,6 +11,8 @@ import { useParams } from 'react-router-dom';
 const TABS = ['Policies', 'Notification History'];
 const RESOURCE_TYPES = ['CPU', 'MEMORY', 'DISK'];
 const AGG_TYPES = ['AVG', 'MAX', 'MIN', 'LAST'];
+// Backend stores resourceType as the measurement (cpu/mem/disk); map back to the enum name.
+const RESOURCE_BY_MEASUREMENT = { cpu: 'CPU', mem: 'MEMORY', disk: 'DISK' };
 const HISTORY_PAGE_SIZE = 20;
 
 // Backend (/policy/{id}/channel and /noti/test) accepts only the short channel name:
@@ -224,6 +226,8 @@ function ManagePanel({ p, nsId, infraId, channels, infras, onChanged }) {
 
   return (
     <div className="space-y-4">
+      <PolicySettingsEditor p={p} onChanged={onChanged} />
+
       <div>
         <div className="text-xs font-semibold text-gray-600 mb-1">Alarm targets</div>
         {vms.length === 0 ? <p className="text-xs text-gray-400 mb-2">No targets</p> : (
@@ -246,6 +250,88 @@ function ManagePanel({ p, nsId, infraId, channels, infras, onChanged }) {
           Save channels
         </button>
       </div>
+    </div>
+  );
+}
+
+// Edit an existing policy's settings (title, thresholds, resource, aggregation, hold/repeat).
+function PolicySettingsEditor({ p, onChanged }) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(p.title || '');
+  const [desc, setDesc] = useState(p.description || '');
+  const [resource, setResource] = useState(RESOURCE_BY_MEASUREMENT[(p.resourceType || '').toLowerCase()] || 'CPU');
+  const [agg, setAgg] = useState((p.aggregationType || 'AVG').toUpperCase());
+  const [info, setInfo] = useState(p.thresholdCondition?.info ?? 0);
+  const [warning, setWarning] = useState(p.thresholdCondition?.warning ?? 0);
+  const [critical, setCritical] = useState(p.thresholdCondition?.critical ?? 0);
+  const [hold, setHold] = useState(p.holdDuration || '5m');
+  const [repeat, setRepeat] = useState(p.repeatInterval || '1h');
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    setBusy(true);
+    try {
+      await updatePolicy(p.id, {
+        title, description: desc, resourceType: resource, aggregationType: agg,
+        holdDuration: hold, repeatInterval: repeat,
+        thresholdCondition: { info: +info, warning: +warning, critical: +critical },
+      });
+      onChanged();
+      alert('Policy updated');
+    } catch (e) { alert('Update failed: ' + (e?.response?.data?.message || e?.message || e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(o => !o)}
+        className="text-xs font-semibold text-gray-600 hover:text-gray-800">
+        {open ? '▾' : '▸'} Policy settings (title, thresholds, resource, hold/repeat)
+      </button>
+      {open && (
+        <div className="mt-2 space-y-3 bg-white border rounded p-3">
+          <Field label="Title" hint="Unique name to identify this policy">
+            <input value={title} onChange={e => setTitle(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+          </Field>
+          <Field label="Description" hint="Optional note about this policy">
+            <input value={desc} onChange={e => setDesc(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+          </Field>
+          <Field label="Resource" hint="Metric type to evaluate against the thresholds">
+            <select value={resource} onChange={e => setResource(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
+              {RESOURCE_TYPES.map(r => <option key={r}>{r}</option>)}
+            </select>
+          </Field>
+          <Field label="Aggregation" hint="How to evaluate values over the interval (avg / max / min / last)">
+            <select value={agg} onChange={e => setAgg(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
+              {AGG_TYPES.map(a => <option key={a}>{a}</option>)}
+            </select>
+          </Field>
+          <div className="border-t pt-3 space-y-3">
+            <div className="text-xs font-semibold text-gray-600">Thresholds (%) — per-level alert criteria</div>
+            <Field label="Info" hint="Lowest alert level">
+              <input type="number" value={info} onChange={e => setInfo(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+            </Field>
+            <Field label="Warning" hint="Middle alert level">
+              <input type="number" value={warning} onChange={e => setWarning(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+            </Field>
+            <Field label="Critical" hint="Highest alert level">
+              <input type="number" value={critical} onChange={e => setCritical(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+            </Field>
+          </div>
+          <div className="border-t pt-3 space-y-3">
+            <Field label="Hold Duration" hint="Exceed threshold continuously this long before firing (e.g. 5m, 0s)">
+              <input value={hold} onChange={e => setHold(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+            </Field>
+            <Field label="Repeat Interval" hint="How often to re-notify while firing (e.g. 1h)">
+              <input value={repeat} onChange={e => setRepeat(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm" />
+            </Field>
+          </div>
+          <button disabled={busy} onClick={save}
+            className="bg-blue-600 text-white px-3 py-1 rounded text-xs hover:bg-blue-700 disabled:opacity-50">
+            Save settings
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/TriggerController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/controller/TriggerController.java
@@ -73,6 +73,19 @@ public class TriggerController {
     }
 
     @Operation(
+            summary = "UpdateTriggerPolicy",
+            description = "Update trigger policy (title, thresholds, resource, aggregation, etc.)",
+            operationId = "UpdateTriggerPolicy")
+    @PutMapping("/{id}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResBody<Void> updateTriggerPolicy(
+            @Parameter(name = "id", description = "trigger policy id") @PathVariable long id,
+            @Valid @RequestBody TriggerPolicyCreateRequest request) {
+        triggerService.updateTriggerPolicy(id, request.toDto());
+        return new ResBody<>();
+    }
+
+    @Operation(
             summary = "GetPaginatedTriggerPolicies",
             description = "Get paginated trigger policies",
             operationId = "GetPaginatedTriggerPolicies")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/persistence/model/TriggerPolicy.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/persistence/model/TriggerPolicy.java
@@ -87,6 +87,23 @@ public class TriggerPolicy extends BaseEntity {
         return entity;
     }
 
+    public void update(
+            String title,
+            String description,
+            String thresholdCondition,
+            String resourceType,
+            String aggregationType,
+            String holdDuration,
+            String repeatInterval) {
+        this.title = title;
+        this.description = description;
+        this.thresholdCondition = thresholdCondition;
+        this.resourceType = resourceType;
+        this.aggregationType = aggregationType;
+        this.holdDuration = holdDuration;
+        this.repeatInterval = repeatInterval;
+    }
+
     public TriggerPolicyDetailDto toDto() {
         List<TriggerVMDetailDto> vms = triggerVMs.stream().map(TriggerVM::toDto).toList();
         List<TriggerPolicyNotiChannelDto> notiChannels =

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/service/TriggerService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/trigger/application/service/TriggerService.java
@@ -78,6 +78,41 @@ public class TriggerService implements TriggerServiceInternal {
         return triggerPolicy.getId();
     }
 
+    @Transactional
+    public void updateTriggerPolicy(long id, TriggerPolicyCreateDto dto) {
+        TriggerPolicy triggerPolicy =
+                triggerPolicyRepository
+                        .findById(id)
+                        .orElseThrow(() -> new TriggerPolicyNotFoundException(id));
+
+        triggerPolicy.update(
+                dto.title(),
+                dto.description(),
+                dto.thresholdCondition().toJson(),
+                dto.resourceType().getMeasurement(),
+                dto.aggregationType().getName(),
+                dto.holdDuration(),
+                dto.repeatInterval());
+        triggerPolicyRepository.save(triggerPolicy);
+
+        // Re-sync each target's alert rule so the updated thresholds/settings take effect.
+        TriggerPolicyDetailDto policyDto = triggerPolicy.toDto();
+        for (TriggerVM triggerVM : triggerPolicy.getTriggerVMs()) {
+            String datasourceUid =
+                    managerPort.getInfluxUid(
+                            triggerVM.getNamespaceId(),
+                            triggerVM.getTargetScope(),
+                            triggerVM.getTargetId());
+            try {
+                alertManager.deleteAlertRule(triggerVM.getUuid());
+            } catch (Exception ignored) {
+                // Rule may not exist yet (e.g. earlier creation failed); recreate below.
+            }
+            alertManager.createAlertRule(
+                    AlertRuleCreateDto.from(policyDto, triggerVM.toDto()), datasourceUid);
+        }
+    }
+
     public void deleteTriggerPolicy(long id) {
         TriggerPolicy triggerPolicy =
                 triggerPolicyRepository


### PR DESCRIPTION
## Summary
트리거 정책을 만든 뒤에도 **임계값(thresholds) 등 정책 설정을 수정**할 수 있게 함. 기존엔 생성/삭제만 가능하고 수정 수단이 없었음.

## Why
- Alerts 화면에서 정책의 Thresholds(Info/Warning/Critical)를 바꿀 방법이 없었음.

## Changes
- **java**: `PUT /api/o11y/trigger/policy/{id}` 추가 (`updateTriggerPolicy`). 정책 필드(title/description/threshold/resource/aggregation/hold/repeat)를 갱신하고, **해당 정책의 모든 타겟에 대해 Grafana 알림 룰을 재동기화**(삭제 후 재생성)해서 변경된 임계값이 즉시 반영되게 함. 생성 요청 DTO(`TriggerPolicyCreateRequest`)를 그대로 재사용.
- **front**: Manage 패널에 "Policy settings" 편집 영역 추가 — 현재 값으로 미리 채워지고, 저장 시 `PUT`으로 갱신. resourceType은 측정값(cpu/mem/disk) ↔ enum(CPU/MEMORY/DISK) 매핑 처리.
