### PR TITLE
feat: namespace-scoped iframe UI, agent-not-installed guidance, Ollama default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -399,7 +399,7 @@ services:
       - 9001:9001
     environment:
       - TZ=Asia/Seoul
-      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://210.207.104.224:11434}
     volumes:
       - shared_logs:/mc-insight/log:rw
     depends_on:

--- a/docs/how_to_integrate_iframe.md
+++ b/docs/how_to_integrate_iframe.md
@@ -1,0 +1,124 @@
+# iframe 연동 가이드 (How to integrate via iframe)
+
+mc-observability 프론트(`mc-observability-front`, 기본 포트 `18081`)를 다른 콘솔/포털에 **iframe으로 임베드**하는 방법을 설명합니다. 네임스페이스 기반 URL만 넘기면 상단 메뉴로 모든 기능(Monitoring / Logs / Config / Insight / Alerts / Tracing)을 제어할 수 있습니다.
+
+---
+
+## 1. 한눈에 보기 — URL 패턴
+
+| URL | 화면 | 용도 |
+|---|---|---|
+| `/` | 네임스페이스 선택 화면 | ns를 모를 때(미전달 시) 사용자가 직접 선택 |
+| `/{ns}` | 네임스페이스 개요 (상단 메뉴 + Infra 셀렉터, 로고 없음) | ns 단위 전체 보기 |
+| `/{ns}/{infra}` | **Infra 레벨 스코프 화면** (로고 없음, 셀렉터 없음) | iframe 임베드 |
+| `/{ns}/{infra}/{node}` | **Node 레벨 스코프 화면** (로고 없음, 셀렉터 없음, 뒤로가기 버튼) | iframe 임베드 |
+| `/console` | 개발/테스트 콘솔(토큰·ns·infra·node 수동 선택) | 로컬 디버깅 |
+| `/embed/{section}/{ns}/...` | 메뉴 없는 단일 패널(예: `/embed/monitoring/{ns}/{infra}/{node}`) | 특정 패널 1개만 임베드 |
+
+> 예시(원격): `http://20.41.115.17:18081/testns01/test01`, `http://20.41.115.17:18081/testns01/test01/vm-1`
+
+---
+
+## 2. 네임스페이스 스코프 화면 동작 (`/{ns}/{infra}`, `/{ns}/{infra}/{node}`)
+
+iframe 임베드에 최적화된 화면입니다.
+
+- **제품 로고("MC-Observability") 미표시.**
+- **상단 메뉴(Monitoring/Logs/Config/Insight/Alerts/Tracing)는 표시**되며, 클릭 시 **URL을 바꾸지 않고** 화면 내용만 그 자리에서 전환됩니다(in-place). → iframe `src`가 고정 유지됩니다.
+- **셀렉터 규칙**: 경로에 이미 들어간 식별자의 셀렉터는 숨깁니다. ns가 경로에 있으면 NS 셀렉터, infra가 경로에 있으면 Infra 셀렉터를 표시하지 않습니다. 따라서 `/{ns}/{infra}`·`/{ns}/{infra}/{node}` 화면에는 우측 상단 셀렉터가 없습니다.
+- **Node 레벨(`/{ns}/{infra}/{node}`)**: 좌측 상단에 **뒤로가기(← Back) 버튼**이 있어 다시 Infra 레벨(`/{ns}/{infra}`)로 돌아갑니다.
+
+---
+
+## 3. 기본 임베드
+
+```html
+<!-- Infra 레벨 -->
+<iframe src="http://<HOST>:18081/testns01/test01"
+        style="width:100%;height:100%;border:0;"></iframe>
+
+<!-- Node 레벨 -->
+<iframe src="http://<HOST>:18081/testns01/test01/vm-1"
+        style="width:100%;height:100%;border:0;"></iframe>
+```
+
+네임스페이스를 모를 때는 `src`를 `/`로 두면 사용자가 네임스페이스를 직접 고를 수 있습니다.
+
+```html
+<iframe src="http://<HOST>:18081/" style="width:100%;height:100%;border:0;"></iframe>
+```
+
+---
+
+## 4. 네임스페이스 자동 감지 (부모 페이지 `#select-current-project`)
+
+`src="/"`(네임스페이스 미지정)로 임베드한 경우, 프론트는 **iframe을 품은 부모 페이지**의 프로젝트 선택 `<select>`를 보고 네임스페이스를 자동으로 반영합니다.
+
+- 부모 페이지에 **`id="select-current-project"`** 인 `<select>`가 있으면,
+- 현재 **선택된 option의 "표시 텍스트"**(option의 `value`가 아니라 화면에 보이는 글자)를 읽어,
+- 해당 네임스페이스 화면(`/{ns}`)으로 자동 이동합니다. 부모에서 선택을 바꾸면 이를 감지해 따라갑니다.
+
+```html
+<!-- 부모(임베드하는 쪽) 페이지 -->
+<select id="select-current-project">
+  <option value="prj-001">testns01</option>   <!-- 표시 텍스트 "testns01"이 namespace로 사용됨 -->
+  <option value="prj-002" selected>testns02</option>
+</select>
+<iframe src="http://<HOST>:18081/" ...></iframe>
+```
+
+> **읽지 못하면 그냥 건너뜁니다(에러 아님).** iframe과 부모가 **다른 오리진**이면 브라우저 정책상 부모 DOM을 읽을 수 없습니다. 이때는 자동 감지를 조용히 포기하고, 사용자가 직접 고르는 **네임스페이스 선택 화면**으로 폴백합니다. (확실히 쓰려면 부모-iframe을 같은 오리진으로 두거나, 아래 postMessage 방식을 사용하세요.)
+
+> 참고: 임베드용 첫 화면(`/`)에는 제품 로고와 Dev 버튼이 표시되지 않습니다.
+
+---
+
+## 5. 인증 토큰 전달 (postMessage)
+
+프론트는 부모 창에서 `window.postMessage`로 보내는 **액세스 토큰**을 받아 백엔드 호출에 사용합니다. (`AppContext`가 `message` 이벤트를 수신)
+
+부모가 보내는 메시지 형식:
+
+```js
+const iframe = document.getElementById('o11y');
+iframe.onload = () => {
+  iframe.contentWindow.postMessage({
+    accessToken: "Bearer eyJhbGciOi...",   // 필수: 이 값이 있어야 인증 처리됨
+    projectInfo:   { ns_id: "testns01" },   // 선택: 네임스페이스 정보
+    workspaceInfo: { /* ... */ }            // 선택
+  }, "http://<HOST>:18081");                // targetOrigin: iframe origin과 일치시킬 것
+};
+```
+
+- 수신측은 `accessToken`이 있는 메시지만 처리합니다(없으면 무시).
+- 토큰은 이후 `/api/o11y/*` 호출의 `Authorization` 헤더로 사용됩니다.
+
+### URL 파라미터로 토큰 전달(개발용)
+
+postMessage 대신 쿼리스트링으로도 가능합니다.
+
+```
+http://<HOST>:18081/testns01/test01?token=Bearer%20eyJ...&ns_id=testns01
+```
+
+---
+
+## 6. 백엔드 프록시 경로 (nginx)
+
+프론트 nginx가 동일 오리진에서 백엔드로 프록시하므로 CORS 설정이 필요 없습니다.
+
+| 프론트 경로 | 프록시 대상 |
+|---|---|
+| `/api/o11y/` | `mc-observability-manager:18080` (관측 매니저 API) |
+| `/tumblebug/` | `mc-infra-manager:1323` (cb-tumblebug, Basic auth 자동 주입) |
+| `/spider/` | `mc-infra-connector:1024` (cb-spider, Basic auth 자동 주입) |
+
+SPA 라우팅은 `try_files $uri /index.html` 폴백으로 처리되므로 `/{ns}/{infra}/{node}` 같은 경로로 **직접 진입**해도 정상 동작합니다.
+
+---
+
+## 7. 참고 사항
+
+- **에이전트 미설치 노드**: 메트릭이 없을 때 빈 "No data" 대신, **Config 메뉴에서 에이전트를 설치하라는 안내**가 표시됩니다.
+- **`/embed/*`**: 상단 메뉴까지 빼고 패널 하나만 임베드하고 싶을 때 사용합니다(예: 대시보드 카드에 차트 하나만 넣기).
+- 식별자 명명: cb-tumblebug 리네임에 맞춰 경로/필드는 `ns`(네임스페이스) · `infra`(구 MCI) · `node`(구 VM)를 사용합니다.

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -14,6 +14,8 @@ import AlertManager from './pages/AlertManager';
 import TraceViewer from './pages/TraceViewer';
 import K8sNodeDashboard from './pages/K8sNodeDashboard';
 import HomePage from './pages/HomePage';
+import NamespaceHome from './pages/NamespaceHome';
+import NsScopedApp from './pages/NsScopedApp';
 
 export default function App() {
   const { token } = useAppContext();
@@ -25,9 +27,20 @@ export default function App() {
   return (
     <ErrorBoundary>
     <Routes>
-      {/* Standalone — full nav + test console */}
-      <Route path="/" element={<HomePage />} />
+      {/* Dev/test console (was at "/") */}
+      <Route path="/console" element={<HomePage />} />
+
+      {/* Namespace-scoped iframe app: no logo, in-place section switching.
+          Infra level → Infra selector only; Node level → no selectors + Back. */}
+      <Route path="/:nsId/:infraId" element={<NsScopedApp />} />
+      <Route path="/:nsId/:infraId/:nodeId" element={<NsScopedApp />} />
+
+      {/* Standalone — full nav + NS/Infra selectors */}
       <Route element={<Layout />}>
+        {/* Namespace-rooted entry: `/` shows NS picker, `/:nsId` shows the
+            namespace overview with full nav (NS selector). */}
+        <Route path="/" element={<NamespaceHome />} />
+        <Route path="/:nsId" element={<InfraOverview />} />
         <Route path="/monitoring/:nsId/k8s/:connectionName/:clusterName/:nodeGroupName/:nodeNumber" element={<K8sNodeDashboard />} />
         <Route path="/monitoring/:nsId/:infraId/:nodeId" element={<MonitoringDashboard />} />
         <Route path="/monitoring/:nsId/:infraId" element={<InfraOverview />} />

--- a/front/src/components/AgentNotInstalled.jsx
+++ b/front/src/components/AgentNotInstalled.jsx
@@ -1,0 +1,45 @@
+import { useNavigate } from 'react-router-dom';
+import useBasePath from '../hooks/useBasePath';
+
+/**
+ * Shown instead of an empty "No data" state when a node's monitoring agent
+ * is not installed. Guides the user to the Config menu to install it.
+ *
+ * Props: nsId, infraId, nodeId (optional), height (optional)
+ */
+export default function AgentNotInstalled({ nsId, infraId, nodeId, height = 220, compact = false }) {
+  const navigate = useNavigate();
+  const base = useBasePath();
+
+  const goConfig = () => {
+    if (!nsId) return;
+    let path = `${base}/config/${nsId}`;
+    if (infraId) path += `/${infraId}`;
+    navigate(path);
+  };
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center gap-2 text-gray-500"
+      style={{ minHeight: height }}
+    >
+      <svg className="w-8 h-8 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0 3.75h.008M10.34 3.94l-7.5 12.99A1.5 1.5 0 004.14 19.5h15.72a1.5 1.5 0 001.3-2.57l-7.5-12.99a1.5 1.5 0 00-2.62 0z" />
+      </svg>
+      <p className="text-sm font-medium text-gray-600">Monitoring agent is not installed.</p>
+      {!compact && (
+        <p className="text-xs text-gray-400">
+          Install the agent from the Config menu to start collecting metrics.
+        </p>
+      )}
+      {nsId && (
+        <button
+          onClick={goConfig}
+          className="mt-1 px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Go to Config to install agent
+        </button>
+      )}
+    </div>
+  );
+}

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -2,15 +2,18 @@ import { useState, useEffect, useCallback } from 'react';
 import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
 import { setApiToken } from '../api/client';
-import { getNsList, getInfraList, getInfra } from '../api/tumblebug';
+import { getInfraList, getInfra } from '../api/tumblebug';
 
+// Idle = black text (no color). Active = per-feature colored background + white
+// text. Explicit class strings so Tailwind keeps them.
+const IDLE = 'text-gray-800 hover:bg-gray-100';
 const navItems = [
-  { label: 'Monitoring', path: 'monitoring' },
-  { label: 'Logs', path: 'logs' },
-  { label: 'Config', path: 'config' },
-  { label: 'Insight', path: 'insight' },
-  { label: 'Alerts', path: 'alerts' },
-  { label: 'Tracing', path: 'trace' },
+  { label: 'Monitoring', path: 'monitoring', active: 'bg-blue-600 text-white' },
+  { label: 'Logs', path: 'logs', active: 'bg-emerald-600 text-white' },
+  { label: 'Config', path: 'config', active: 'bg-amber-600 text-white' },
+  { label: 'Insight', path: 'insight', active: 'bg-purple-600 text-white' },
+  { label: 'Alerts', path: 'alerts', active: 'bg-red-600 text-white' },
+  { label: 'Tracing', path: 'trace', active: 'bg-teal-600 text-white' },
 ];
 
 export default function Layout() {
@@ -21,21 +24,14 @@ export default function Layout() {
 
   const currentSection = navItems.find((n) => location.pathname.includes(`/${n.path}/`))?.path || 'monitoring';
 
-  const [showDevTools, setShowDevTools] = useState(false);
-  const [bypassAuth, setBypassAuth] = useState(true);
+  const [bypassAuth] = useState(true);
 
-  const [nsList, setNsList] = useState([]);
   const [infraList, setInfraList] = useState([]);
   const [nodeList, setNodeList] = useState([]);
 
   useEffect(() => {
     if (bypassAuth) setApiToken('bypass');
   }, [bypassAuth]);
-
-  // Load NS list
-  useEffect(() => {
-    getNsList().then(setNsList).catch(() => setNsList([]));
-  }, []);
 
   // NS change -> refresh Infra list
   const loadInfraList = useCallback(async (ns) => {
@@ -61,24 +57,6 @@ export default function Layout() {
   useEffect(() => { loadInfraList(nsId); }, [nsId, loadInfraList]);
   useEffect(() => { loadNodeList(nsId, infraId); }, [nsId, infraId, loadNodeList]);
 
-  // NS dropdown change
-  async function handleNsChange(newNs) {
-    const infras = await loadInfraList(newNs);
-    const firstInfra = infras[0]?.id;
-    if (firstInfra) {
-      navigate(`${base}/${currentSection}/${newNs}/${firstInfra}`);
-    }
-  }
-
-  // Infra dropdown change
-  function handleInfraChange(newInfra) {
-    if (!newInfra) {
-      navigate(`${base}/${currentSection}/${nsId}`);
-      return;
-    }
-    navigate(`${base}/${currentSection}/${nsId}/${newInfra}`);
-  }
-
   // Node dropdown change
   function handleNodeChange(newNode) {
     if (!nsId || !infraId) return;
@@ -87,87 +65,54 @@ export default function Layout() {
     navigate(path);
   }
 
+  // Top menu always navigates to the namespace level for the section,
+  // dropping any selected infra/node.
   const buildNavPath = (section) => {
-    if (infraId) return `${base}/${section}/${nsId}/${infraId}`;
+    if (!nsId) return `${base}/`;
     return `${base}/${section}/${nsId}`;
   };
 
   return (
     <div className="flex flex-col h-screen">
       <nav className="flex items-center gap-1 px-4 py-2 bg-white border-b border-gray-200 text-sm shrink-0 flex-wrap">
-        <a href="/" className="font-semibold text-gray-700 mr-3 hover:text-blue-600">MC-Observability</a>
-
-        {navItems.map((item) => (
-          <NavLink key={item.path} to={buildNavPath(item.path)}
-            className={({ isActive }) =>
-              `px-3 py-1.5 rounded-md transition-colors ${isActive ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`
-            }>
-            {item.label}
-          </NavLink>
-        ))}
+        {nsId ? (
+          navItems.map((item) => (
+            <NavLink key={item.path} to={buildNavPath(item.path)}
+              className={`px-3 py-1.5 rounded-md transition-colors ${currentSection === item.path ? item.active : IDLE}`}>
+              {item.label}
+            </NavLink>
+          ))
+        ) : (
+          <>
+            {navItems.map((item) => (
+              <span key={item.path}
+                className="px-3 py-1.5 rounded-md text-gray-300 cursor-not-allowed select-none">
+                {item.label}
+              </span>
+            ))}
+            <span className="ml-2 text-xs text-gray-400">← Select a namespace</span>
+          </>
+        )}
 
         <div className="ml-auto flex items-center gap-1">
-          {/* NS */}
-          <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={nsId || ''}
-            onChange={(e) => handleNsChange(e.target.value)}>
-            <option value="">NS</option>
-            {nsList.map((ns) => <option key={ns.id} value={ns.id}>{ns.id}</option>)}
-          </select>
-          {infraId && <>
-            <span className="text-gray-300">/</span>
-            {/* Infra */}
-            <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={infraId || ''}
-              onChange={(e) => handleInfraChange(e.target.value)}>
-              <option value="">Infra</option>
-              {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
-            </select>
-            <span className="text-gray-300">/</span>
-            {/* Node */}
-            <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={nodeId || ''}
-              onChange={(e) => handleNodeChange(e.target.value)}>
-              <option value="">(Overview)</option>
-              {nodeList.map((node) => <option key={node.id} value={node.id}>{node.name || node.id}</option>)}
-            </select>
-          </>}
-          {!infraId && infraList.length > 0 && <>
-            <span className="text-gray-300">/</span>
+          {/* Infra selector — shown only when an infra is NOT yet in the path */}
+          {nsId && !infraId && infraList.length > 0 && (
             <select className="border border-gray-200 rounded px-2 py-1 text-xs" value=""
               onChange={(e) => { if (e.target.value) navigate(`${base}/${currentSection}/${nsId}/${e.target.value}`); }}>
               <option value="">Infra</option>
               {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
             </select>
-          </>}
-
-          <button onClick={() => setShowDevTools(!showDevTools)}
-            className={`ml-2 text-xs border rounded px-2 py-1 ${showDevTools ? 'bg-gray-800 text-white border-gray-800' : 'text-gray-400 border-gray-200 hover:text-gray-600'}`}>
-            Dev
-          </button>
+          )}
+          {/* Node selector — when an infra is in the path */}
+          {infraId && (
+            <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={nodeId || ''}
+              onChange={(e) => handleNodeChange(e.target.value)}>
+              <option value="">(Overview)</option>
+              {nodeList.map((node) => <option key={node.id} value={node.id}>{node.name || node.id}</option>)}
+            </select>
+          )}
         </div>
       </nav>
-
-      {showDevTools && (
-        <div className="bg-gray-800 text-gray-200 px-4 py-3 text-xs space-y-2 shrink-0">
-          <div className="flex items-center gap-4">
-            <label className="flex items-center gap-1 cursor-pointer">
-              <input type="checkbox" checked={bypassAuth} onChange={(e) => { setBypassAuth(e.target.checked); if (e.target.checked) setApiToken('bypass'); }} />
-              Token Bypass
-            </label>
-            <span className="text-gray-500">|</span>
-            <span>Path: <code className="text-green-400">/{currentSection}/{nsId}/{infraId}{nodeId ? '/' + nodeId : ''}</code></span>
-          </div>
-          <div className="border-t border-gray-700 pt-2">
-            <p className="text-yellow-300 font-semibold mb-1">iframe Integration</p>
-            <code className="block bg-gray-900 p-2 rounded text-green-300 whitespace-pre-wrap">{`<iframe src="${window.location.origin}/embed/${currentSection}/${nsId || '{nsId}'}/${infraId || '{infraId}'}${nodeId ? '/' + nodeId : ''}" />
-
-<script>
-iframe.onload = () => iframe.contentWindow.postMessage({
-  accessToken: "Bearer ...",
-  projectInfo: { ns_id: "${nsId || 'ns-1'}" }
-}, "${window.location.origin}");
-</script>`}</code>
-          </div>
-        </div>
-      )}
 
       <main className="flex-1 overflow-auto p-4 bg-gray-50">
         <Outlet />

--- a/front/src/hooks/useParentNamespace.js
+++ b/front/src/hooks/useParentNamespace.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+
+// The embedding (parent) page is expected to have a project selector with this id.
+// We read the *displayed text* of the selected option (not its value) and use it
+// as the namespace. If the parent DOM cannot be read (cross-origin, not embedded,
+// element missing), we silently return '' — no error — so the app falls back to
+// the manual namespace picker.
+const SELECT_ID = 'select-current-project';
+
+function readParentNamespace() {
+  try {
+    if (typeof window === 'undefined' || window.parent === window) return '';
+    const doc = window.parent.document; // throws on cross-origin → caught below
+    const sel = doc.getElementById(SELECT_ID);
+    if (!sel) return '';
+    const opt = sel.options && sel.selectedIndex >= 0 ? sel.options[sel.selectedIndex] : null;
+    const text = opt ? (opt.text ?? opt.label ?? opt.textContent ?? '') : '';
+    return String(text).trim();
+  } catch {
+    return ''; // cross-origin or any access issue → just skip, not an error
+  }
+}
+
+/**
+ * Watches the parent page's `#select-current-project` selected option text and
+ * returns it as the namespace. Returns '' when it cannot be read.
+ */
+export default function useParentNamespace() {
+  const [ns, setNs] = useState(readParentNamespace);
+
+  useEffect(() => {
+    let sel = null;
+    const update = () => setNs(readParentNamespace());
+    try {
+      if (window.parent !== window) {
+        sel = window.parent.document.getElementById(SELECT_ID);
+        if (sel) sel.addEventListener('change', update);
+      }
+    } catch {
+      sel = null; // cross-origin: cannot attach listener, fall back to polling only
+    }
+    // Poll as a fallback in case the parent updates the selection without a
+    // reachable change event. Cheap DOM read; stops on unmount.
+    const timer = setInterval(update, 1500);
+    return () => {
+      if (sel) { try { sel.removeEventListener('change', update); } catch { /* ignore */ } }
+      clearInterval(timer);
+    };
+  }, []);
+
+  return ns;
+}

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -5,8 +5,10 @@ import { getInfraList } from '../api/tumblebug';
 import { getMetricsByNode } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
 import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
+import { getNodeList } from '../api/node';
 import MetricChart from '../components/MetricChart';
 import ProviderBadge from '../components/ProviderBadge';
+import AgentNotInstalled from '../components/AgentNotInstalled';
 
 const AGENT_METRICS = [
   { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
@@ -53,12 +55,21 @@ export default function InfraOverview() {
       } else {
         // Node: load all Infras in NS, show grouped
         const infras = await getInfraList(nsId);
-        setAllInfras(infras);
-        const allNodes = infras.flatMap(i => i.node || []);
+        // Enrich each Node with its Infra id + whether the monitoring agent is
+        // installed (present in the o11y node list). Used to show an install
+        // hint instead of an empty "No data" chart.
+        const enriched = await Promise.all((infras || []).map(async (infra) => {
+          let o11yNodes = [];
+          try { o11yNodes = await getNodeList(nsId, infra.id); } catch {}
+          const reg = new Set(o11yNodes.map((n) => n.node_id || n.id));
+          return { ...infra, node: (infra.node || []).map((n) => ({ ...n, infraId: infra.id, registered: reg.has(n.id) })) };
+        }));
+        setAllInfras(enriched);
+        const allNodes = enriched.flatMap(i => i.node || []);
         setNodes(allNodes);
         if (allNodes.length > 0) {
           setMetricsLoading(true);
-          if (dataSource === 'agent') await loadAgentData(allNodes, infras);
+          if (dataSource === 'agent') await loadAgentData(allNodes, enriched);
           else await loadCspData(allNodes);
           setMetricsLoading(false);
         }
@@ -415,6 +426,7 @@ function NodeCard({ node, nodeMetrics, dataSource, metricsLoading, selectedChart
 }
 
 function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectChart, onClickChart, cspSupported }) {
+  const { nsId } = useParams();
   const gauges = AGENT_METRICS.map((m) => {
     const d = metrics[m.key];
     const last = d?.res ? getLastValue(d.res) : null;
@@ -425,6 +437,16 @@ function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectC
   const activeMetric = AGENT_METRICS.find((m) => m.key === selectedChart) || AGENT_METRICS[0];
   const chartData = metrics[selectedChart];
   const chartSeries = chartData?.res ? toSeries(chartData.res, activeMetric.label, activeMetric.invert) : [];
+
+  // Agent not installed → guide to Config instead of rendering empty charts.
+  if (node.registered === false) {
+    return (
+      <div className="bg-white rounded-lg shadow">
+        <NodeHeader node={node} showCspBadge={false} cspAvailable={cspSupported} />
+        <AgentNotInstalled nsId={nsId} infraId={node.infraId} nodeId={node.id} height={180} />
+      </div>
+    );
+  }
 
   return (
     <div className="bg-white rounded-lg shadow">

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -6,6 +6,7 @@ import {
   getPredictionHistory, runPrediction, getPredictionOptions,
   getServerErrorRecords, getServerErrorRecord, detectServerError, rerunServerErrorAnalysis,
 } from '../api/insight';
+import { getInfraList, getInfra } from '../api/tumblebug';
 import MetricChart from '../components/MetricChart';
 
 const TABS = ['Anomaly Detection', 'Prediction', 'Server Error Analysis'];
@@ -23,18 +24,7 @@ export default function InsightDashboard() {
             {t}
           </button>
         ))}
-        <span className="ml-auto self-center text-xs pr-2 flex items-center gap-1.5">
-          <span className="text-gray-400">Scope</span>
-          {nodeId
-            ? <span className="px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700" title={`${nsId} / ${infraId} / ${nodeId}`}>Node: {nodeId}</span>
-            : <span className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700" title={`${nsId} / ${infraId}`}>Infra: {infraId} (all nodes)</span>}
-        </span>
       </div>
-      {!nodeId && tab !== 2 && (
-        <p className="text-xs text-gray-400 px-1">
-          No node selected — using Infra-level (averaged across nodes). Select a Node above to scope to a specific VM.
-        </p>
-      )}
       {tab === 0 && <AnomalyTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
       {tab === 1 && <PredictionTab nsId={nsId} infraId={infraId} nodeId={nodeId} />}
       {tab === 2 && <ServerErrorTab />}
@@ -148,22 +138,37 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
 function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
   const [measurement, setMeasurement] = useState('');
   const [interval, setInterval] = useState('');
-  const [scope, setScope] = useState(nodeId ? 'node' : 'infra');
+  // Scope: pick Infra, then optionally a Node (empty = all nodes).
+  const [infra, setInfra] = useState(infraId || '');
+  const [node, setNode] = useState(nodeId || '');
+  const [infraList, setInfraList] = useState([]);
+  const [nodeList, setNodeList] = useState([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
 
   const measurements = options.measurements || [];
   const intervals = options.execution_intervals || [];
 
+  useEffect(() => {
+    if (!nsId) { setInfraList([]); return; }
+    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
+  }, [nsId]);
+
+  useEffect(() => {
+    if (!nsId || !infra) { setNodeList([]); return; }
+    getInfra(nsId, infra).then((d) => setNodeList(d.node || [])).catch(() => setNodeList([]));
+  }, [nsId, infra]);
+
   async function submit(e) {
     e.preventDefault();
+    if (!infra) { setErr('Infra is required.'); return; }
     if (!measurement || !interval) { setErr('Measurement and interval are required.'); return; }
     setBusy(true); setErr('');
     try {
       const body = {
         ns_id: nsId,
-        infra_id: infraId,
-        node_id: scope === 'node' ? nodeId : null,
+        infra_id: infra,
+        node_id: node || null,
         measurement,
         execution_interval: interval,
       };
@@ -177,12 +182,22 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
 
   return (
     <form onSubmit={submit} className="p-4 border-b bg-gray-50 space-y-3">
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {/* Infra selector only when not already fixed by the path */}
+        {!infraId && (
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Scope — Infra</label>
+            <select value={infra} onChange={(e) => { setInfra(e.target.value); setNode(''); }} className="w-full border rounded px-3 py-1.5 text-sm">
+              <option value="">Select Infra</option>
+              {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+            </select>
+          </div>
+        )}
         <div>
-          <label className="block text-xs text-gray-600 mb-1">Scope</label>
-          <select value={scope} onChange={(e) => setScope(e.target.value)} className="w-full border rounded px-3 py-1.5 text-sm">
-            <option value="infra">Infra: {infraId} (all nodes)</option>
-            {nodeId && <option value="node">Node: {nodeId}</option>}
+          <label className="block text-xs text-gray-600 mb-1">Scope — Node</label>
+          <select value={node} onChange={(e) => setNode(e.target.value)} disabled={!infra} className="w-full border rounded px-3 py-1.5 text-sm disabled:bg-gray-100">
+            <option value="">All nodes</option>
+            {nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
           </select>
         </div>
         <div>
@@ -229,16 +244,32 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   const [loadedMeasurement, setLoadedMeasurement] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
+  // Scope: pick Infra, then optionally a Node (empty = all nodes).
+  const [pInfra, setPInfra] = useState(infraId || '');
+  const [pNode, setPNode] = useState(nodeId || '');
+  const [infraList, setInfraList] = useState([]);
+  const [nodeList, setNodeList] = useState([]);
 
   useEffect(() => {
     getPredictionOptions().then((o) => setOptions(o || {})).catch(() => {});
   }, []);
 
+  useEffect(() => {
+    if (!nsId) { setInfraList([]); return; }
+    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
+  }, [nsId]);
+
+  useEffect(() => {
+    if (!nsId || !pInfra) { setNodeList([]); return; }
+    getInfra(nsId, pInfra).then((d) => setNodeList(d.node || [])).catch(() => setNodeList([]));
+  }, [nsId, pInfra]);
+
   async function loadHistory() {
+    if (!pInfra) { setMsg('Select an Infra first.'); return; }
     if (!measurement) return;
     setLoading(true); setMsg('');
     try {
-      const data = await getPredictionHistory(nsId, infraId, nodeId, measurement);
+      const data = await getPredictionHistory(nsId, pInfra, pNode, measurement);
       setHistory(data.values || []);
       setLoadedMeasurement(measurement);
     } catch { setHistory([]); }
@@ -246,10 +277,11 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   }
 
   async function handleRun() {
+    if (!pInfra) { setMsg('Select an Infra first.'); return; }
     if (!measurement || !range) { setMsg('Measurement and range are required.'); return; }
     setLoading(true); setMsg('');
     try {
-      await runPrediction(nsId, infraId, nodeId, { measurement, prediction_range: range });
+      await runPrediction(nsId, pInfra, pNode, { measurement, prediction_range: range });
       setMsg('Prediction started. Loading history…');
       await loadHistory();
     } catch (e) {
@@ -276,7 +308,28 @@ function PredictionTab({ nsId, infraId, nodeId }) {
     <div className="bg-white rounded-lg shadow">
       <div className="px-4 py-3 border-b font-semibold text-sm">Prediction</div>
       <div className="p-4">
+        <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 mb-3">
+          Predictions become available about <strong>one day</strong> after the monitoring agent is installed
+          (from the <strong>Config</strong> menu), once enough metric history has been collected.
+        </p>
         <div className="flex gap-3 mb-2 flex-wrap items-end">
+          {/* Infra selector only when not already fixed by the path */}
+          {!infraId && (
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">Scope — Infra</label>
+              <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={pInfra} onChange={(e) => { setPInfra(e.target.value); setPNode(''); }}>
+                <option value="">Select Infra</option>
+                {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+              </select>
+            </div>
+          )}
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Scope — Node</label>
+            <select className="border border-gray-300 rounded px-3 py-1.5 text-sm disabled:bg-gray-100" value={pNode} onChange={(e) => setPNode(e.target.value)} disabled={!pInfra}>
+              <option value="">All nodes</option>
+              {nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
+            </select>
+          </div>
           <div>
             <label className="block text-xs text-gray-600 mb-1">Measurement</label>
             <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={measurement} onChange={(e) => setMeasurement(e.target.value)}>

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -4,8 +4,9 @@ import { getMeasurementFields, getMetricsByNode } from '../api/monitoring';
 import { getInfra } from '../api/tumblebug';
 import { getPlugins, getPrediction, getDetectionHistory } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
-import { getNodeItems } from '../api/node';
+import { getNodeItems, getNodeList } from '../api/node';
 import MetricChart from '../components/MetricChart';
+import AgentNotInstalled from '../components/AgentNotInstalled';
 
 const RANGE_OPTIONS = [
   { value: '1h', label: '1H' },
@@ -94,6 +95,23 @@ export default function MonitoringDashboard() {
   useEffect(() => {
     getMeasurementFields().then(setAllFields).catch(() => setAllFields([]));
   }, []);
+
+  // Detect whether the monitoring agent is installed on the selected Node.
+  // null = unknown (don't show the notice), true/false otherwise.
+  const [agentInstalled, setAgentInstalled] = useState(null);
+  useEffect(() => {
+    if (!nsId || !infraId || !selectedNodeId) { setAgentInstalled(null); return; }
+    let alive = true;
+    getNodeList(nsId, infraId)
+      .then((list) => {
+        if (!alive) return;
+        const found = (list || []).find((n) => (n.node_id || n.id) === selectedNodeId);
+        // A node only appears in the o11y list once its agent has been installed.
+        setAgentInstalled(!!found);
+      })
+      .catch(() => { if (alive) setAgentInstalled(null); });
+    return () => { alive = false; };
+  }, [nsId, infraId, selectedNodeId]);
 
   // Load active items for selected Node → filter measurements
   useEffect(() => {
@@ -425,7 +443,9 @@ export default function MonitoringDashboard() {
             <div className="mb-2 text-sm font-medium">
               Node: {nodes.find(n => n.id === selectedNodeId)?.name || selectedNodeId}
             </div>
-            {(overviewLoading || !overviewCharts) ? (
+            {agentInstalled === false ? (
+              <AgentNotInstalled nsId={nsId} infraId={infraId} nodeId={selectedNodeId} height={160} />
+            ) : (overviewLoading || !overviewCharts) ? (
               <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading metrics...</div>
             ) : overviewCharts.length > 0 ? (
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">

--- a/front/src/pages/NamespaceHome.jsx
+++ b/front/src/pages/NamespaceHome.jsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getNsList, getInfraList } from '../api/tumblebug';
+import useParentNamespace from '../hooks/useParentNamespace';
+
+/**
+ * Landing shown at `/` when no namespace is passed in the path.
+ * Lets the user pick a namespace; selecting one navigates to `/:nsId`,
+ * which renders the full menu-driven app scoped to that namespace.
+ * Designed so an iframe can point at `/` (no ns) and still drive everything.
+ */
+export default function NamespaceHome() {
+  const navigate = useNavigate();
+  const parentNs = useParentNamespace(); // namespace from the embedding page (if any)
+  const [nsList, setNsList] = useState([]);
+  const [counts, setCounts] = useState({}); // ns -> infra count
+  const [loading, setLoading] = useState(true);
+
+  // If the parent page exposes a selected project, reflect it automatically:
+  // resolve the displayed text against the ns list (by id or name) and open it.
+  // When it can't be read, parentNs is '' and we just show the picker below.
+  useEffect(() => {
+    if (!parentNs || loading) return;
+    const match = nsList.find((n) => n.id === parentNs || (n.name && n.name === parentNs));
+    navigate(`/${match ? match.id : parentNs}`, { replace: true });
+  }, [parentNs, loading, nsList, navigate]);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    getNsList()
+      .then(async (list) => {
+        const arr = Array.isArray(list) ? list : [];
+        if (alive) setNsList(arr);
+        // best-effort infra counts per namespace
+        const entries = await Promise.all(
+          arr.map(async (ns) => {
+            try {
+              const infras = await getInfraList(ns.id);
+              return [ns.id, Array.isArray(infras) ? infras.length : 0];
+            } catch {
+              return [ns.id, null];
+            }
+          })
+        );
+        if (alive) setCounts(Object.fromEntries(entries));
+      })
+      .catch(() => alive && setNsList([]))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-lg font-bold text-gray-800">Select a Namespace</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Choose a namespace to open its monitoring, logs, config, insight, alerts and tracing.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="text-sm text-gray-400">Loading namespaces…</div>
+      ) : nsList.length === 0 ? (
+        <div className="text-sm text-gray-400">No namespaces found.</div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {nsList.map((ns) => (
+            <button
+              key={ns.id}
+              onClick={() => navigate(`/${ns.id}`)}
+              className="text-left bg-white border border-gray-200 rounded-lg p-4 hover:border-blue-500 hover:shadow-sm transition-colors"
+            >
+              <div className="font-semibold text-gray-800 break-all">{ns.name || ns.id}</div>
+              {ns.name && ns.name !== ns.id && (
+                <div className="text-xs text-gray-400 break-all">{ns.id}</div>
+              )}
+              <div className="mt-2 text-xs text-gray-500">
+                {counts[ns.id] == null ? '—' : `${counts[ns.id]} infra`}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/pages/NsScopedApp.jsx
+++ b/front/src/pages/NsScopedApp.jsx
@@ -1,0 +1,71 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import useBasePath from '../hooks/useBasePath';
+import InfraOverview from './InfraOverview';
+import MonitoringDashboard from './MonitoringDashboard';
+
+// Idle = black text (no color). Active = per-feature colored background + white
+// text. Explicit class strings so Tailwind keeps them.
+const IDLE = 'text-gray-800 hover:bg-gray-100';
+const navItems = [
+  { label: 'Monitoring', key: 'monitoring', active: 'bg-blue-600 text-white' },
+  { label: 'Logs', key: 'logs', active: 'bg-emerald-600 text-white' },
+  { label: 'Config', key: 'config', active: 'bg-amber-600 text-white' },
+  { label: 'Insight', key: 'insight', active: 'bg-purple-600 text-white' },
+  { label: 'Alerts', key: 'alerts', active: 'bg-red-600 text-white' },
+  { label: 'Tracing', key: 'trace', active: 'bg-teal-600 text-white' },
+];
+
+/**
+ * Namespace-scoped iframe entry used by `/:nsId/:infraId` (Infra level) and
+ * `/:nsId/:infraId/:nodeId` (Node level).
+ *
+ * - No product logo, no NS/Infra selectors (ns + infra are in the path).
+ * - Shows the Monitoring view of the embedded target (Infra overview / Node
+ *   dashboard) — Monitoring is the landing section.
+ * - The top menu keeps the current infra/node scope, navigating to
+ *   `/{section}/{ns}/{infra}[/{node}]` so the target context follows the user
+ *   (e.g. Insight opens scoped to the same infra/node).
+ * - Node level: a Back button returns to the Infra level.
+ */
+export default function NsScopedApp() {
+  const { nsId, infraId, nodeId } = useParams();
+  const navigate = useNavigate();
+  const base = useBasePath();
+
+  return (
+    <div className="flex flex-col h-screen">
+      <nav className="flex items-center gap-1 px-4 py-2 bg-white border-b border-gray-200 text-sm shrink-0 flex-wrap">
+        {/* Node level → Back button (replaces the logo area) */}
+        {nodeId && (
+          <button
+            onClick={() => navigate(`${base}/${nsId}/${infraId}`)}
+            className="mr-2 px-2.5 py-1.5 rounded-md text-gray-600 hover:bg-gray-100 inline-flex items-center gap-1"
+            title="Back to Infra"
+          >
+            <span aria-hidden>←</span> Back
+          </button>
+        )}
+
+        {navItems.map((item) => {
+          // Config has no node-level route; cap it at the infra level.
+          const suffix = nodeId && item.key !== 'config' ? `/${nodeId}` : '';
+          return (
+            <button
+              key={item.key}
+              onClick={() => navigate(`${base}/${item.key}/${nsId}/${infraId}${suffix}`)}
+              className={`px-3 py-1.5 rounded-md transition-colors ${
+                item.key === 'monitoring' ? item.active : IDLE
+              }`}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <main className="flex-1 overflow-auto p-4 bg-gray-50">
+        {nodeId ? <MonitoringDashboard /> : <InfraOverview />}
+      </main>
+    </div>
+  );
+}

--- a/python/insight/.env.example
+++ b/python/insight/.env.example
@@ -1,1 +1,1 @@
-OLLAMA_BASE_URL=http://{ip}:{port}
+OLLAMA_BASE_URL=http://210.207.104.224:11434


### PR DESCRIPTION
## 변경 사항

### 프론트엔드 — 네임스페이스 기반 iframe 연동
- `/{ns}` · `/{ns}/{infra}` · `/{ns}/{infra}/{node}` 경로로 진입 가능 (iframe에 네임스페이스/인프라/노드만 넘기면 동작).
- 스코프 화면(`/{ns}/{infra}[/{node}]`): 제품 로고 미표시, 상단 메뉴는 현재 infra/node 스코프를 유지한 채 이동. Node 레벨엔 Infra 단계로 돌아가는 Back 버튼 제공.
- 경로에 포함된 식별자의 셀렉터는 숨김 (ns/infra가 경로에 있으면 해당 Select Box 제거, 내부적으로 선택값 사용).
- 부모 페이지의 `#select-current-project` 선택 옵션의 표시 텍스트를 읽어 네임스페이스 자동 반영 (읽을 수 없으면 조용히 폴백, 에러 없음).
- 메뉴 버튼 색상: 기본 검정 글자, 선택 시 기능별 색상 배경 + 흰 글자.

### 에이전트 미설치 안내
- 메트릭이 없을 때 빈 "No data" 대신, Config 메뉴에서 에이전트를 설치하라는 안내 표시 (Monitoring 대시보드 · Infra 개요).

### Insight 스코프
- Anomaly Detection 설정 추가 폼과 Prediction 탭에 Infra/Node 스코프 선택 추가. 경로에 infraId가 있으면 Infra 셀렉터 숨기고 내부 선택, nodeId가 있으면 해당 노드 선택.
- Prediction 화면에 "에이전트 설치 후 약 1일 경과해야 예측 가능" 안내 문구(영문) 추가.

### Insight — Ollama
- 기본 Ollama base URL 등록 (`OLLAMA_BASE_URL` 기본값).

### 문서
- `docs/how_to_integrate_iframe.md` 추가 (iframe 연동 가이드).
