### PR TITLE
feat: K8s node host agent (monitoring + logs)

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -11,6 +11,10 @@ server {
         proxy_set_header Authorization $http_authorization;
         proxy_set_header Origin "";
         proxy_hide_header Access-Control-Allow-Origin;
+        # Agent install/uninstall (kubeconfig + Job) can run long; avoid 504 on slow nodes.
+        proxy_connect_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
     }
 
     location /tumblebug/ {

--- a/front/src/api/k8s.js
+++ b/front/src/api/k8s.js
@@ -12,6 +12,13 @@ export async function getCluster(connectionName, clusterName) {
   return res.data || {};
 }
 
+// Cached (manager-side, ~30s) cluster list WITH node-group detail for a connection.
+// One call instead of getClusters + N×getCluster, and no cb-spider hit on every load.
+export async function getClustersDetailed(connectionName) {
+  const res = await client.get('/api/o11y/monitoring/csp/clusters', { params: { ConnectionName: connectionName } });
+  return Array.isArray(res.data) ? res.data : [];
+}
+
 export async function getClusterNodeMetric(connectionName, clusterName, nodeGroupName, nodeNumber, metricType, periodMinute = '5', timeBeforeHour = '1') {
   const res = await client.get(
     `/api/o11y/monitoring/csp/cluster/${clusterName}/${nodeGroupName}/${nodeNumber}/${metricType}`,

--- a/front/src/api/k8sAgent.js
+++ b/front/src/api/k8sAgent.js
@@ -1,0 +1,46 @@
+import client from './client';
+
+// K8s clusters in a namespace (from cb-tumblebug, proxied by nginx).
+export async function getK8sClusters(nsId) {
+  const res = await client.get(`/tumblebug/ns/${nsId}/k8sCluster`);
+  return res.data?.K8sClusterInfo || res.data?.k8sClusterInfo || [];
+}
+
+// Host Telegraf agent on K8s cluster nodes (mc-observability manager).
+export async function getK8sAgentStatus(nsId, clusterId) {
+  const res = await client.get(`/api/o11y/monitoring/k8s/${nsId}/${clusterId}/agent`);
+  return res.data?.data || [];
+}
+
+export async function installK8sAgent(nsId, clusterId) {
+  const res = await client.post(`/api/o11y/monitoring/k8s/${nsId}/${clusterId}/agent`);
+  return res.data?.data || [];
+}
+
+export async function uninstallK8sAgent(nsId, clusterId) {
+  const res = await client.delete(`/api/o11y/monitoring/k8s/${nsId}/${clusterId}/agent`);
+  return res.data?.data || [];
+}
+
+// Per-node operations (like VM nodes).
+export async function installK8sNode(nsId, clusterId, nodeName, metrics) {
+  const res = await client.post(
+    `/api/o11y/monitoring/k8s/${nsId}/${clusterId}/node/${encodeURIComponent(nodeName)}/agent`,
+    metrics ? { metrics } : {}
+  );
+  return res.data?.data;
+}
+
+export async function uninstallK8sNode(nsId, clusterId, nodeName) {
+  const res = await client.delete(
+    `/api/o11y/monitoring/k8s/${nsId}/${clusterId}/node/${encodeURIComponent(nodeName)}/agent`
+  );
+  return res.data?.data;
+}
+
+export async function getK8sNodeMetrics(nsId, clusterId, nodeName) {
+  const res = await client.get(
+    `/api/o11y/monitoring/k8s/${nsId}/${clusterId}/node/${encodeURIComponent(nodeName)}/agent/metrics`
+  );
+  return res.data?.data || { available: [], active: [] };
+}

--- a/front/src/api/k8sAgent.js
+++ b/front/src/api/k8sAgent.js
@@ -44,3 +44,23 @@ export async function getK8sNodeMetrics(nsId, clusterId, nodeName) {
   );
   return res.data?.data || { available: [], active: [] };
 }
+
+// Log agent (fluent-bit via podman) on K8s cluster nodes.
+export async function getK8sLogStatus(nsId, clusterId) {
+  const res = await client.get(`/api/o11y/monitoring/k8s/${nsId}/${clusterId}/log-agent`);
+  return res.data?.data || [];
+}
+
+export async function installK8sLogNode(nsId, clusterId, nodeName) {
+  const res = await client.post(
+    `/api/o11y/monitoring/k8s/${nsId}/${clusterId}/node/${encodeURIComponent(nodeName)}/log-agent`
+  );
+  return res.data?.data;
+}
+
+export async function uninstallK8sLogNode(nsId, clusterId, nodeName) {
+  const res = await client.delete(
+    `/api/o11y/monitoring/k8s/${nsId}/${clusterId}/node/${encodeURIComponent(nodeName)}/log-agent`
+  );
+  return res.data?.data;
+}

--- a/front/src/components/AgentNotInstalled.jsx
+++ b/front/src/components/AgentNotInstalled.jsx
@@ -1,15 +1,20 @@
 import { useNavigate } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
+import { nodeRunState, nodeStateMessage } from '../utils/nodeState';
 
 /**
- * Shown instead of an empty "No data" state when a node's monitoring agent
- * is not installed. Guides the user to the Config menu to install it.
+ * Shown instead of an empty "No data" state for a node with no metrics. The message depends on the
+ * node run-state:
+ *  - running  → agent genuinely not installed → guide to Config to install.
+ *  - stopped  → node not running → nothing to collect; no install CTA.
+ *  - unknown  → status undefined/unknown → "agent state unknown"; no install CTA.
  *
- * Props: nsId, infraId, nodeId (optional), height (optional)
+ * Props: nsId, infraId, nodeId (optional), nodeStatus, height, compact
  */
-export default function AgentNotInstalled({ nsId, infraId, nodeId, height = 220, compact = false }) {
+export default function AgentNotInstalled({ nsId, infraId, nodeId, nodeStatus, height = 220, compact = false }) {
   const navigate = useNavigate();
   const base = useBasePath();
+  const run = nodeRunState(nodeStatus);
 
   const goConfig = () => {
     if (!nsId) return;
@@ -26,19 +31,25 @@ export default function AgentNotInstalled({ nsId, infraId, nodeId, height = 220,
       <svg className="w-8 h-8 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0 3.75h.008M10.34 3.94l-7.5 12.99A1.5 1.5 0 004.14 19.5h15.72a1.5 1.5 0 001.3-2.57l-7.5-12.99a1.5 1.5 0 00-2.62 0z" />
       </svg>
-      <p className="text-sm font-medium text-gray-600">Monitoring agent is not installed.</p>
-      {!compact && (
-        <p className="text-xs text-gray-400">
-          Install the agent from the Config menu to start collecting metrics.
-        </p>
-      )}
-      {nsId && (
-        <button
-          onClick={goConfig}
-          className="mt-1 px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
-        >
-          Go to Config to install agent
-        </button>
+      {run === 'running' ? (
+        <>
+          <p className="text-sm font-medium text-gray-600">Monitoring agent is not installed.</p>
+          {!compact && (
+            <p className="text-xs text-gray-400">
+              Install the agent from the Config menu to start collecting metrics.
+            </p>
+          )}
+          {nsId && (
+            <button
+              onClick={goConfig}
+              className="mt-1 px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Go to Config to install agent
+            </button>
+          )}
+        </>
+      ) : (
+        <p className="text-sm font-medium text-gray-600">{nodeStateMessage(nodeStatus)}</p>
       )}
     </div>
   );

--- a/front/src/components/K8sAgentMonitor.jsx
+++ b/front/src/components/K8sAgentMonitor.jsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react';
+import { getK8sClusters, getK8sAgentStatus } from '../api/k8sAgent';
+import { getMetricsByNode } from '../api/monitoring';
+import MetricChart from './MetricChart';
+import ProviderBadge from './ProviderBadge';
+
+// Host-agent (telegraf) metrics for K8s nodes, queried from InfluxDB by
+// (ns_id, infra_id=clusterId, node_id=k8s node name) — same schema as VM agents.
+const METRICS = [
+  { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
+  { key: 'mem', measurement: 'mem', field: 'used_percent', label: 'Memory Used', unit: '%' },
+  { key: 'disk', measurement: 'disk', field: 'used_percent', label: 'Disk Used', unit: '%' },
+];
+
+function getLastValue(res) {
+  if (!res || res.length === 0) return null;
+  const m = res[0];
+  if (!m.values || m.values.length === 0) return null;
+  const tIdx = (m.columns || []).indexOf('timestamp') < 0 ? 0 : (m.columns || []).indexOf('timestamp');
+  const vIdx = tIdx === 0 ? 1 : 0;
+  let bestTs = -Infinity, best = null;
+  for (const row of m.values) {
+    if (row[vIdx] == null) continue;
+    const raw = row[tIdx];
+    const ts = typeof raw === 'string' ? new Date(raw).getTime() : Number(raw);
+    if (ts > bestTs) { bestTs = ts; best = parseFloat(row[vIdx]); }
+  }
+  return best;
+}
+
+function toSeries(res, name, invert) {
+  if (!res || res.length === 0) return [];
+  return res.map((m) => {
+    const tIdx = (m.columns || []).indexOf('timestamp');
+    const vIdx = tIdx === 0 ? 1 : 0;
+    return {
+      name: name || 'value',
+      data: (m.values || []).filter((row) => row[vIdx] != null).map((row) => ({
+        x: typeof row[tIdx] === 'string' ? new Date(row[tIdx]).getTime() : row[tIdx],
+        y: invert ? 100 - parseFloat(row[vIdx]) : parseFloat(row[vIdx]),
+      })),
+    };
+  });
+}
+
+export default function K8sAgentMonitor({ nsId }) {
+  const [clusters, setClusters] = useState([]);
+  const [nodesMap, setNodesMap] = useState({}); // clusterId -> [nodeName]
+  const [data, setData] = useState({}); // `${clusterId}/${node}` -> { cpu:{res}, ... }
+  const [selectedChart, setSelectedChart] = useState('cpu');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!nsId) { setClusters([]); setLoading(false); return; }
+    let alive = true;
+    setLoading(true);
+    setData({}); setNodesMap({});
+    getK8sClusters(nsId)
+      .then(async (cs) => {
+        const arr = Array.isArray(cs) ? cs : [];
+        if (!alive) return;
+        setClusters(arr);
+        for (const c of arr) {
+          let nodes = [];
+          try {
+            const st = await getK8sAgentStatus(nsId, c.id);
+            nodes = (Array.isArray(st) ? st : []).map((n) => n.node);
+          } catch { nodes = []; }
+          if (!alive) return;
+          setNodesMap((m) => ({ ...m, [c.id]: nodes }));
+          for (const node of nodes) {
+            METRICS.forEach(async (mt) => {
+              try {
+                const res = await getMetricsByNode(nsId, c.id, node, {
+                  measurement: mt.measurement, range: '1h', groupTime: '1m',
+                  fields: [{ function: 'mean', field: mt.field }],
+                });
+                if (!alive) return;
+                setData((d) => ({ ...d, [`${c.id}/${node}`]: { ...(d[`${c.id}/${node}`] || {}), [mt.key]: { res } } }));
+              } catch { /* node may have no data yet */ }
+            });
+          }
+        }
+      })
+      .catch(() => alive && setClusters([]))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [nsId]);
+
+  if (loading) return <div className="text-sm text-gray-400 animate-pulse p-4">Loading K8s agent metrics…</div>;
+  if (clusters.length === 0) return <div className="bg-white rounded-lg shadow p-8 text-center text-sm text-gray-400">No K8s clusters in this namespace</div>;
+
+  return (
+    <>
+      {clusters.map((c) => {
+        const nodes = nodesMap[c.id] || [];
+        return (
+          <div key={c.id} className="bg-white rounded-lg shadow">
+            <div className="px-4 py-3 border-b flex items-center gap-3">
+              <ProviderBadge connectionName={c.connectionName} />
+              <span className="text-[10px] uppercase tracking-wide text-gray-400 font-medium">Cluster</span>
+              <span className="font-semibold text-sm truncate">{c.name || c.id}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${(c.status || '').includes('Active') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{c.status || '-'}</span>
+              <span className="text-xs text-gray-400 ml-auto">{nodes.length} agent node(s)</span>
+            </div>
+            <div className="p-3 space-y-3">
+              {nodes.length === 0
+                ? <div className="p-6 text-center text-xs text-gray-400">No host agent installed — install from the Config menu.</div>
+                : nodes.map((node) => (
+                  <NodeCard key={node} node={node} metrics={data[`${c.id}/${node}`] || {}}
+                    selectedChart={selectedChart} onSelectChart={setSelectedChart} />
+                ))}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
+  const gauges = METRICS.map((m) => {
+    const d = metrics[m.key];
+    const last = d?.res ? getLastValue(d.res) : null;
+    const val = last != null ? (m.invert ? 100 - last : last) : null;
+    return { ...m, display: val != null ? val.toFixed(1) + '%' : '-' };
+  });
+  const active = METRICS.find((m) => m.key === selectedChart) || METRICS[0];
+  const cd = metrics[selectedChart];
+  const series = cd?.res ? toSeries(cd.res, active.label, active.invert) : [];
+  return (
+    <div className="bg-white rounded-lg border">
+      <div className="px-4 py-2 border-b">
+        <span className="font-mono text-sm text-gray-700">{node}</span>
+      </div>
+      <div className="flex">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
+          {gauges.map((g) => (
+            <button key={g.key} onClick={() => onSelectChart(g.key)}
+              className={`text-left px-2 py-1.5 rounded ${selectedChart === g.key ? 'bg-blue-50 ring-1 ring-blue-200' : 'hover:bg-gray-50'}`}>
+              <div className="text-xs text-gray-500">{g.label}</div>
+              <div className="text-sm font-semibold">{g.display}</div>
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 px-2 py-1 min-w-0">
+          <MetricChart title={active.label} series={series} height={200} measurement={active.measurement} metric={active.field} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/K8sAgentMonitor.jsx
+++ b/front/src/components/K8sAgentMonitor.jsx
@@ -6,11 +6,36 @@ import ProviderBadge from './ProviderBadge';
 
 // Host-agent (telegraf) metrics for K8s nodes, queried from InfluxDB by
 // (ns_id, infra_id=clusterId, node_id=k8s node name) — same schema as VM agents.
+// Mirrors the full set of telegraf inputs the agent collects (cpu/mem/disk/diskio/
+// net/system/processes/swap) so the Agent tab shows varied graphs like the API tab.
 const METRICS = [
   { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
+  { key: 'cpu_user', measurement: 'cpu', field: 'usage_user', label: 'CPU User', unit: '%' },
+  { key: 'cpu_system', measurement: 'cpu', field: 'usage_system', label: 'CPU System', unit: '%' },
+  { key: 'cpu_iowait', measurement: 'cpu', field: 'usage_iowait', label: 'CPU IOWait', unit: '%' },
   { key: 'mem', measurement: 'mem', field: 'used_percent', label: 'Memory Used', unit: '%' },
+  { key: 'swap', measurement: 'swap', field: 'used_percent', label: 'Swap Used', unit: '%' },
   { key: 'disk', measurement: 'disk', field: 'used_percent', label: 'Disk Used', unit: '%' },
+  { key: 'diskio_read', measurement: 'diskio', field: 'read_bytes', label: 'Disk Read', unit: 'B' },
+  { key: 'diskio_write', measurement: 'diskio', field: 'write_bytes', label: 'Disk Write', unit: 'B' },
+  { key: 'net_recv', measurement: 'net', field: 'bytes_recv', label: 'Net Recv', unit: 'B' },
+  { key: 'net_sent', measurement: 'net', field: 'bytes_sent', label: 'Net Sent', unit: 'B' },
+  { key: 'load1', measurement: 'system', field: 'load1', label: 'Load (1m)', unit: '' },
+  { key: 'procs', measurement: 'processes', field: 'total', label: 'Processes', unit: '' },
 ];
+
+function fmtValue(val, unit) {
+  if (val == null) return '-';
+  if (unit === 'B') {
+    const u = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let n = val, i = 0;
+    while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+    return n.toFixed(n >= 100 || i === 0 ? 0 : 1) + ' ' + u[i];
+  }
+  if (unit === '%') return val.toFixed(1) + '%';
+  if (unit === '') return Number.isInteger(val) ? String(val) : val.toFixed(2);
+  return val.toFixed(1) + ' ' + unit;
+}
 
 function getLastValue(res) {
   if (!res || res.length === 0) return null;
@@ -123,10 +148,10 @@ function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
     const d = metrics[m.key];
     const last = d?.res ? getLastValue(d.res) : null;
     const val = last != null ? (m.invert ? 100 - last : last) : null;
-    return { ...m, display: val != null ? val.toFixed(1) + '%' : '-' };
+    return { ...m, display: fmtValue(val, m.unit) };
   });
   const active = METRICS.find((m) => m.key === selectedChart) || METRICS[0];
-  const cd = metrics[selectedChart];
+  const cd = metrics[active.key];
   const series = cd?.res ? toSeries(cd.res, active.label, active.invert) : [];
   return (
     <div className="bg-white rounded-lg border">
@@ -134,7 +159,7 @@ function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
         <span className="font-mono text-sm text-gray-700">{node}</span>
       </div>
       <div className="flex">
-        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r max-h-[360px] overflow-auto">
           {gauges.map((g) => (
             <button key={g.key} onClick={() => onSelectChart(g.key)}
               className={`text-left px-2 py-1.5 rounded ${selectedChart === g.key ? 'bg-blue-50 ring-1 ring-blue-200' : 'hover:bg-gray-50'}`}>
@@ -144,7 +169,11 @@ function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
           ))}
         </div>
         <div className="flex-1 px-2 py-1 min-w-0">
-          <MetricChart title={active.label} series={series} height={200} measurement={active.measurement} metric={active.field} />
+          {cd?.res ? (
+            <MetricChart title={`${active.label}${active.unit ? ` (${active.unit})` : ''}`} series={series} height={200} measurement={active.measurement} metric={active.field} />
+          ) : (
+            <div className="flex items-center justify-center h-[200px] text-gray-400 text-sm animate-pulse">Loading {active.label}…</div>
+          )}
         </div>
       </div>
     </div>

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  getK8sClusters, getK8sAgentStatus,
+  installK8sNode, uninstallK8sNode, getK8sNodeMetrics,
+} from '../api/k8sAgent';
+import ProviderBadge from './ProviderBadge';
+
+/**
+ * Config-menu panel for Kubernetes clusters. Each cluster is shown as a group (like a VM Infra)
+ * and its nodes as rows with per-node install state and Install/Uninstall actions. Clicking a node
+ * opens a metric-selection panel directly under the group (like VM nodes).
+ */
+export default function K8sAgentPanel({ nsId }) {
+  const [clusters, setClusters] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [statusMap, setStatusMap] = useState({}); // clusterId -> [{node,running,lastSeen}]
+  const [sel, setSel] = useState(null); // { clusterId, node }
+  const [metrics, setMetrics] = useState({ available: [], active: [] });
+  const [picked, setPicked] = useState(new Set());
+  const [metricLoading, setMetricLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [busyMsg, setBusyMsg] = useState('');
+
+  const load = useCallback(() => {
+    if (!nsId) { setClusters([]); setLoading(false); return; }
+    setLoading(true);
+    getK8sClusters(nsId)
+      .then((cs) => setClusters(Array.isArray(cs) ? cs : []))
+      .catch(() => setClusters([]))
+      .finally(() => setLoading(false));
+  }, [nsId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const loadStatus = useCallback(async (clusterId) => {
+    try {
+      const s = await getK8sAgentStatus(nsId, clusterId);
+      setStatusMap((m) => ({ ...m, [clusterId]: Array.isArray(s) ? s : [] }));
+    } catch { setStatusMap((m) => ({ ...m, [clusterId]: [] })); }
+  }, [nsId]);
+
+  useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);
+
+  async function selectNode(clusterId, node) {
+    setSel({ clusterId, node });
+    setMetricLoading(true);
+    setMetrics({ available: [], active: [] });
+    try {
+      const m = await getK8sNodeMetrics(nsId, clusterId, node);
+      setMetrics(m);
+      setPicked(new Set(m.active || []));
+    } catch { setMetrics({ available: [], active: [] }); setPicked(new Set()); }
+    setMetricLoading(false);
+  }
+
+  function togglePick(name) {
+    setPicked((p) => { const n = new Set(p); n.has(name) ? n.delete(name) : n.add(name); return n; });
+  }
+
+  async function applyInstall(clusterId, node) {
+    setBusy(true); setBusyMsg(`Installing agent on ${node}…`);
+    try {
+      await installK8sNode(nsId, clusterId, node, [...picked]);
+      await loadStatus(clusterId);
+      setTimeout(() => selectNode(clusterId, node), 1000);
+    } catch (e) { alert('Install failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)); }
+    setBusy(false); setBusyMsg('');
+  }
+
+  async function doUninstall(clusterId, node) {
+    if (!confirm(`Uninstall the agent from node "${node}"?`)) return;
+    setBusy(true); setBusyMsg(`Uninstalling agent from ${node}…`);
+    try {
+      await uninstallK8sNode(nsId, clusterId, node);
+      await loadStatus(clusterId);
+      if (sel?.clusterId === clusterId && sel?.node === node) setSel(null);
+    } catch (e) { alert('Uninstall failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)); }
+    setBusy(false); setBusyMsg('');
+  }
+
+  if (loading) return null;
+  if (clusters.length === 0) return null;
+
+  return (
+    <>
+      {clusters.map((c) => {
+        const nodes = statusMap[c.id] || [];
+        return (
+          <div key={c.id} className="bg-white rounded-lg shadow relative">
+            {busy && sel?.clusterId === c.id && (
+              <div className="absolute inset-0 bg-white/60 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg">
+                <div className="text-center">
+                  <div className="w-7 h-7 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
+                  <p className="text-sm text-gray-700">{busyMsg}</p>
+                </div>
+              </div>
+            )}
+            <div className="px-4 py-3 border-b flex items-center gap-3">
+              <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 font-medium">K8s</span>
+              <span className="font-semibold text-sm">{c.name || c.id}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${(c.status || '').includes('Active') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{c.status || '-'}</span>
+              <span className="text-xs text-gray-400">{nodes.length} Nodes</span>
+            </div>
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead><tr className="bg-gray-50 text-left">
+                  <th className="px-4 py-2.5 border-b text-gray-500">Name</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">Monitoring Agent</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">Last Seen</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500 text-right">Actions</th>
+                </tr></thead>
+                <tbody>
+                  {nodes.length === 0 ? <tr><td colSpan={4} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
+                  : nodes.map((n) => (
+                    <tr key={n.node} onClick={() => selectNode(c.id, n.node)}
+                      className={`cursor-pointer hover:bg-blue-50 ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
+                      <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={c.connectionName} showLabel={false} />{n.node}</span></td>
+                      <td className="px-4 py-2.5 border-b">
+                        {n.running ? <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">Running</span>
+                          : <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Not installed</span>}
+                      </td>
+                      <td className="px-4 py-2.5 border-b text-gray-500 text-xs">{n.lastSeen || '-'}</td>
+                      <td className="px-4 py-2.5 border-b text-right whitespace-nowrap">
+                        {!n.running
+                          ? <button onClick={(e) => { e.stopPropagation(); applyInstallDefault(c.id, n.node); }} disabled={busy} className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install Agent</button>
+                          : <button onClick={(e) => { e.stopPropagation(); doUninstall(c.id, n.node); }} disabled={busy} className="text-sm text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Metric selection panel for the selected node of THIS cluster */}
+            {sel?.clusterId === c.id && (
+              <div className="border-t bg-gray-50 p-4">
+                <div className="font-semibold text-sm mb-3">Metrics — {sel.node}</div>
+                {metricLoading ? <p className="text-sm text-gray-400 animate-pulse">Loading metrics…</p> : (
+                  <>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+                      {(metrics.available || []).map((m) => {
+                        const on = picked.has(m);
+                        return (
+                          <label key={m} className="flex items-center gap-2 text-sm bg-white border rounded px-3 py-2 cursor-pointer">
+                            <input type="checkbox" checked={on} onChange={() => togglePick(m)} />
+                            <span>{m}</span>
+                            {(metrics.active || []).includes(m) && <span className="ml-auto text-xs text-green-600">active</span>}
+                          </label>
+                        );
+                      })}
+                    </div>
+                    <button onClick={() => applyInstall(c.id, sel.node)} disabled={busy || picked.size === 0}
+                      className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50">
+                      Apply (install selected)
+                    </button>
+                    <span className="ml-3 text-xs text-gray-400">Re-installs the node agent with the selected inputs.</span>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+
+  function applyInstallDefault(clusterId, node) {
+    // Install with the default full metric set (then user can refine via the panel).
+    setBusy(true); setBusyMsg(`Installing agent on ${node}…`);
+    installK8sNode(nsId, clusterId, node, null)
+      .then(() => loadStatus(clusterId))
+      .then(() => setTimeout(() => selectNode(clusterId, node), 1000))
+      .catch((e) => alert('Install failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)))
+      .finally(() => { setBusy(false); setBusyMsg(''); });
+  }
+}

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -101,10 +101,9 @@ export default function K8sAgentPanel({ nsId }) {
                   <th className="px-4 py-2.5 border-b text-gray-500">Name</th>
                   <th className="px-4 py-2.5 border-b text-gray-500">Monitoring Agent</th>
                   <th className="px-4 py-2.5 border-b text-gray-500">Log Agent</th>
-                  <th className="px-4 py-2.5 border-b text-gray-500 text-right">Actions</th>
                 </tr></thead>
                 <tbody>
-                  {nodes.length === 0 ? <tr><td colSpan={4} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
+                  {nodes.length === 0 ? <tr><td colSpan={3} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
                   : nodes.map((n) => {
                     const monOn = n.running;
                     const logOn = logRunning(c.id, n.node);
@@ -112,18 +111,21 @@ export default function K8sAgentPanel({ nsId }) {
                       <tr key={n.node} onClick={() => selectNode(c.id, n.node)}
                         className={`cursor-pointer hover:bg-blue-50 ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
                         <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={c.connectionName} showLabel={false} />{n.node}</span></td>
-                        <td className="px-4 py-2.5 border-b"><AgentBadge running={monOn} /></td>
-                        <td className="px-4 py-2.5 border-b"><AgentBadge running={logOn} /></td>
-                        <td className="px-4 py-2.5 border-b text-right whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
-                          <span className="text-xs text-gray-400 mr-1">Mon</span>
-                          {!monOn
-                            ? <button onClick={() => run(`${c.id}/${n.node}/mon`, `Installing agent on ${n.node}…`, () => installK8sNode(nsId, c.id, n.node, null), c.id)} disabled={!!busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
-                            : <button onClick={() => run(`${c.id}/${n.node}/mon`, `Uninstalling agent from ${n.node}…`, () => uninstallK8sNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
-                          <span className="text-xs text-gray-300 mx-2">|</span>
-                          <span className="text-xs text-gray-400 mr-1">Log</span>
-                          {!logOn
-                            ? <button onClick={() => run(`${c.id}/${n.node}/log`, `Installing log agent on ${n.node}…`, () => installK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
-                            : <button onClick={() => run(`${c.id}/${n.node}/log`, `Uninstalling log agent from ${n.node}…`, () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                        <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
+                          <div className="flex items-center gap-2">
+                            <AgentBadge running={monOn} />
+                            {!monOn
+                              ? <button onClick={() => run(`${c.id}/${n.node}/mon`, `Installing agent on ${n.node}…`, () => installK8sNode(nsId, c.id, n.node, null), c.id)} disabled={!!busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
+                              : <button onClick={() => run(`${c.id}/${n.node}/mon`, `Uninstalling agent from ${n.node}…`, () => uninstallK8sNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
+                          <div className="flex items-center gap-2">
+                            <AgentBadge running={logOn} />
+                            {!logOn
+                              ? <button onClick={() => run(`${c.id}/${n.node}/log`, `Installing log agent on ${n.node}…`, () => installK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
+                              : <button onClick={() => run(`${c.id}/${n.node}/log`, `Uninstalling log agent from ${n.node}…`, () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                          </div>
                         </td>
                       </tr>
                     );

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -1,24 +1,26 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
-  getK8sClusters, getK8sAgentStatus,
+  getK8sClusters, getK8sAgentStatus, getK8sLogStatus,
   installK8sNode, uninstallK8sNode, getK8sNodeMetrics,
+  installK8sLogNode, uninstallK8sLogNode,
 } from '../api/k8sAgent';
 import ProviderBadge from './ProviderBadge';
 
 /**
- * Config-menu panel for Kubernetes clusters. Each cluster is shown as a group (like a VM Infra)
- * and its nodes as rows with per-node install state and Install/Uninstall actions. Clicking a node
- * opens a metric-selection panel directly under the group (like VM nodes).
+ * Config-menu panel for Kubernetes clusters. Each cluster is a group (like a VM Infra); its nodes
+ * are rows with Monitoring Agent (telegraf) and Log Agent (fluent-bit) install state + per-node
+ * Install/Uninstall. Clicking a node opens the monitoring metric-selection panel under the group.
  */
 export default function K8sAgentPanel({ nsId }) {
   const [clusters, setClusters] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [statusMap, setStatusMap] = useState({}); // clusterId -> [{node,running,lastSeen}]
+  const [statusMap, setStatusMap] = useState({}); // clusterId -> [{node,running}]
+  const [logMap, setLogMap] = useState({}); // clusterId -> [{node,running}]
   const [sel, setSel] = useState(null); // { clusterId, node }
   const [metrics, setMetrics] = useState({ available: [], active: [] });
   const [picked, setPicked] = useState(new Set());
   const [metricLoading, setMetricLoading] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [busy, setBusy] = useState('');
   const [busyMsg, setBusyMsg] = useState('');
 
   const load = useCallback(() => {
@@ -37,6 +39,10 @@ export default function K8sAgentPanel({ nsId }) {
       const s = await getK8sAgentStatus(nsId, clusterId);
       setStatusMap((m) => ({ ...m, [clusterId]: Array.isArray(s) ? s : [] }));
     } catch { setStatusMap((m) => ({ ...m, [clusterId]: [] })); }
+    try {
+      const l = await getK8sLogStatus(nsId, clusterId);
+      setLogMap((m) => ({ ...m, [clusterId]: Array.isArray(l) ? l : [] }));
+    } catch { setLogMap((m) => ({ ...m, [clusterId]: [] })); }
   }, [nsId]);
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);
@@ -57,26 +63,14 @@ export default function K8sAgentPanel({ nsId }) {
     setPicked((p) => { const n = new Set(p); n.has(name) ? n.delete(name) : n.add(name); return n; });
   }
 
-  async function applyInstall(clusterId, node) {
-    setBusy(true); setBusyMsg(`Installing agent on ${node}…`);
-    try {
-      await installK8sNode(nsId, clusterId, node, [...picked]);
-      await loadStatus(clusterId);
-      setTimeout(() => selectNode(clusterId, node), 1000);
-    } catch (e) { alert('Install failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)); }
-    setBusy(false); setBusyMsg('');
+  async function run(key, msg, fn, clusterId) {
+    setBusy(key); setBusyMsg(msg);
+    try { await fn(); await loadStatus(clusterId); }
+    catch (e) { alert((e.response?.data?.error_message || e.response?.data?.message || e.message)); }
+    setBusy(''); setBusyMsg('');
   }
 
-  async function doUninstall(clusterId, node) {
-    if (!confirm(`Uninstall the agent from node "${node}"?`)) return;
-    setBusy(true); setBusyMsg(`Uninstalling agent from ${node}…`);
-    try {
-      await uninstallK8sNode(nsId, clusterId, node);
-      await loadStatus(clusterId);
-      if (sel?.clusterId === clusterId && sel?.node === node) setSel(null);
-    } catch (e) { alert('Uninstall failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)); }
-    setBusy(false); setBusyMsg('');
-  }
+  const logRunning = (cid, node) => (logMap[cid] || []).find((n) => n.node === node)?.running;
 
   if (loading) return null;
   if (clusters.length === 0) return null;
@@ -87,7 +81,7 @@ export default function K8sAgentPanel({ nsId }) {
         const nodes = statusMap[c.id] || [];
         return (
           <div key={c.id} className="bg-white rounded-lg shadow relative">
-            {busy && sel?.clusterId === c.id && (
+            {busy && busy.startsWith(c.id) && (
               <div className="absolute inset-0 bg-white/60 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg">
                 <div className="text-center">
                   <div className="w-7 h-7 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
@@ -106,35 +100,42 @@ export default function K8sAgentPanel({ nsId }) {
                 <thead><tr className="bg-gray-50 text-left">
                   <th className="px-4 py-2.5 border-b text-gray-500">Name</th>
                   <th className="px-4 py-2.5 border-b text-gray-500">Monitoring Agent</th>
-                  <th className="px-4 py-2.5 border-b text-gray-500">Last Seen</th>
+                  <th className="px-4 py-2.5 border-b text-gray-500">Log Agent</th>
                   <th className="px-4 py-2.5 border-b text-gray-500 text-right">Actions</th>
                 </tr></thead>
                 <tbody>
                   {nodes.length === 0 ? <tr><td colSpan={4} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
-                  : nodes.map((n) => (
-                    <tr key={n.node} onClick={() => selectNode(c.id, n.node)}
-                      className={`cursor-pointer hover:bg-blue-50 ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
-                      <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={c.connectionName} showLabel={false} />{n.node}</span></td>
-                      <td className="px-4 py-2.5 border-b">
-                        {n.running ? <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">Running</span>
-                          : <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Not installed</span>}
-                      </td>
-                      <td className="px-4 py-2.5 border-b text-gray-500 text-xs">{n.lastSeen || '-'}</td>
-                      <td className="px-4 py-2.5 border-b text-right whitespace-nowrap">
-                        {!n.running
-                          ? <button onClick={(e) => { e.stopPropagation(); applyInstallDefault(c.id, n.node); }} disabled={busy} className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install Agent</button>
-                          : <button onClick={(e) => { e.stopPropagation(); doUninstall(c.id, n.node); }} disabled={busy} className="text-sm text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
-                      </td>
-                    </tr>
-                  ))}
+                  : nodes.map((n) => {
+                    const monOn = n.running;
+                    const logOn = logRunning(c.id, n.node);
+                    return (
+                      <tr key={n.node} onClick={() => selectNode(c.id, n.node)}
+                        className={`cursor-pointer hover:bg-blue-50 ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
+                        <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={c.connectionName} showLabel={false} />{n.node}</span></td>
+                        <td className="px-4 py-2.5 border-b"><AgentBadge running={monOn} /></td>
+                        <td className="px-4 py-2.5 border-b"><AgentBadge running={logOn} /></td>
+                        <td className="px-4 py-2.5 border-b text-right whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
+                          <span className="text-xs text-gray-400 mr-1">Mon</span>
+                          {!monOn
+                            ? <button onClick={() => run(`${c.id}/${n.node}/mon`, `Installing agent on ${n.node}…`, () => installK8sNode(nsId, c.id, n.node, null), c.id)} disabled={!!busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
+                            : <button onClick={() => run(`${c.id}/${n.node}/mon`, `Uninstalling agent from ${n.node}…`, () => uninstallK8sNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                          <span className="text-xs text-gray-300 mx-2">|</span>
+                          <span className="text-xs text-gray-400 mr-1">Log</span>
+                          {!logOn
+                            ? <button onClick={() => run(`${c.id}/${n.node}/log`, `Installing log agent on ${n.node}…`, () => installK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
+                            : <button onClick={() => run(`${c.id}/${n.node}/log`, `Uninstalling log agent from ${n.node}…`, () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
 
-            {/* Metric selection panel for the selected node of THIS cluster */}
+            {/* Monitoring metric selection for the selected node */}
             {sel?.clusterId === c.id && (
               <div className="border-t bg-gray-50 p-4">
-                <div className="font-semibold text-sm mb-3">Metrics — {sel.node}</div>
+                <div className="font-semibold text-sm mb-3">Monitoring Metrics — {sel.node}</div>
                 {metricLoading ? <p className="text-sm text-gray-400 animate-pulse">Loading metrics…</p> : (
                   <>
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
@@ -149,11 +150,12 @@ export default function K8sAgentPanel({ nsId }) {
                         );
                       })}
                     </div>
-                    <button onClick={() => applyInstall(c.id, sel.node)} disabled={busy || picked.size === 0}
+                    <button onClick={() => run(`${c.id}/${sel.node}/mon`, `Applying metrics on ${sel.node}…`, async () => { await installK8sNode(nsId, c.id, sel.node, [...picked]); setTimeout(() => selectNode(c.id, sel.node), 1200); }, c.id)}
+                      disabled={!!busy || picked.size === 0}
                       className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50">
                       Apply (install selected)
                     </button>
-                    <span className="ml-3 text-xs text-gray-400">Re-installs the node agent with the selected inputs.</span>
+                    <span className="ml-3 text-xs text-gray-400">Re-installs the monitoring agent with the selected inputs.</span>
                   </>
                 )}
               </div>
@@ -163,14 +165,10 @@ export default function K8sAgentPanel({ nsId }) {
       })}
     </>
   );
+}
 
-  function applyInstallDefault(clusterId, node) {
-    // Install with the default full metric set (then user can refine via the panel).
-    setBusy(true); setBusyMsg(`Installing agent on ${node}…`);
-    installK8sNode(nsId, clusterId, node, null)
-      .then(() => loadStatus(clusterId))
-      .then(() => setTimeout(() => selectNode(clusterId, node), 1000))
-      .catch((e) => alert('Install failed: ' + (e.response?.data?.error_message || e.response?.data?.message || e.message)))
-      .finally(() => { setBusy(false); setBusyMsg(''); });
-  }
+function AgentBadge({ running }) {
+  return running
+    ? <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">Running</span>
+    : <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Not installed</span>;
 }

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -12,11 +12,30 @@ import ProviderBadge from '../components/ProviderBadge';
 import AgentNotInstalled from '../components/AgentNotInstalled';
 import K8sAgentMonitor from '../components/K8sAgentMonitor';
 
+// Mirrors the full telegraf input set the host agent collects (cpu/mem/disk/diskio/
+// net/system/processes/swap) so the Agent tab shows varied graphs like the API tab.
 const AGENT_METRICS = [
   { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
+  { key: 'cpu_user', measurement: 'cpu', field: 'usage_user', label: 'CPU User', unit: '%' },
+  { key: 'cpu_system', measurement: 'cpu', field: 'usage_system', label: 'CPU System', unit: '%' },
+  { key: 'cpu_iowait', measurement: 'cpu', field: 'usage_iowait', label: 'CPU IOWait', unit: '%' },
   { key: 'mem', measurement: 'mem', field: 'used_percent', label: 'Memory Used', unit: '%' },
+  { key: 'swap', measurement: 'swap', field: 'used_percent', label: 'Swap Used', unit: '%' },
   { key: 'disk', measurement: 'disk', field: 'used_percent', label: 'Disk Used', unit: '%' },
+  { key: 'diskio_read', measurement: 'diskio', field: 'read_bytes', label: 'Disk Read', unit: 'bytes' },
+  { key: 'diskio_write', measurement: 'diskio', field: 'write_bytes', label: 'Disk Write', unit: 'bytes' },
+  { key: 'net_recv', measurement: 'net', field: 'bytes_recv', label: 'Net Recv', unit: 'bytes' },
+  { key: 'net_sent', measurement: 'net', field: 'bytes_sent', label: 'Net Sent', unit: 'bytes' },
+  { key: 'load1', measurement: 'system', field: 'load1', label: 'Load (1m)', unit: '' },
+  { key: 'procs', measurement: 'processes', field: 'total', label: 'Processes', unit: '' },
 ];
+
+function fmtAgentValue(v, unit) {
+  if (v == null) return '-';
+  if (unit === '%') return v.toFixed(1) + '%';
+  if (unit === 'bytes') return formatCspValue(v, 'bytes');
+  return Number.isInteger(v) ? String(v) : v.toFixed(2);
+}
 
 export default function InfraOverview() {
   const { nsId, infraId } = useParams();
@@ -440,7 +459,7 @@ function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectC
     const d = metrics[m.key];
     const last = d?.res ? getLastValue(d.res) : null;
     const val = last != null ? (m.invert ? 100 - last : last) : null;
-    return { ...m, value: val, display: val != null ? val.toFixed(1) + '%' : '-' };
+    return { ...m, value: m.unit === '%' ? val : null, display: fmtAgentValue(val, m.unit) };
   });
 
   const activeMetric = AGENT_METRICS.find((m) => m.key === selectedChart) || AGENT_METRICS[0];
@@ -462,16 +481,16 @@ function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectC
     <div className="bg-white rounded-lg shadow">
       <NodeHeader node={node} showCspBadge={false} cspAvailable={cspSupported} />
       <div className="flex">
-        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r max-h-[380px] overflow-auto">
           {gauges.map((g) => (
-            <GaugeItem key={g.key} g={g} active={selectedChart === g.key} onClick={() => onSelectChart(g.key)} />
+            <GaugeItem key={g.key} g={g} active={selectedChart === g.key} onClick={() => onSelectChart(g.key)} noBar={g.unit !== '%'} />
           ))}
         </div>
         <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
           {metricsLoading ? (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading Agent data...</div>
           ) : (
-            <MetricChart title={activeMetric.label} series={chartSeries} height={220} measurement={activeMetric.measurement} metric={activeMetric.field} />
+            <MetricChart title={`${activeMetric.label}${activeMetric.unit && activeMetric.unit !== '%' ? ` (${activeMetric.unit})` : ''}`} series={chartSeries} height={220} measurement={activeMetric.measurement} metric={activeMetric.field} />
           )}
         </div>
       </div>

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -9,6 +9,7 @@ import { getNodeList } from '../api/node';
 import MetricChart from '../components/MetricChart';
 import ProviderBadge from '../components/ProviderBadge';
 import AgentNotInstalled from '../components/AgentNotInstalled';
+import K8sAgentMonitor from '../components/K8sAgentMonitor';
 
 const AGENT_METRICS = [
   { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
@@ -235,7 +236,11 @@ export default function InfraOverview() {
       </div>
 
       {/* K8s Tab */}
-      {viewTab === 'k8s' && (
+      {/* K8s tab + Agent source → host telegraf metrics (InfluxDB, by clusterId/nodeName) */}
+      {viewTab === 'k8s' && dataSource === 'agent' && <K8sAgentMonitor nsId={nsId} />}
+
+      {/* K8s tab + CSP source → cb-spider API metrics */}
+      {viewTab === 'k8s' && dataSource === 'csp' && (
         clustersLoading ? (
           <div className="text-sm text-gray-400 animate-pulse p-4">Loading clusters...</div>
         ) : k8sNodes.length === 0 ? (
@@ -443,7 +448,8 @@ function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectC
     return (
       <div className="bg-white rounded-lg shadow">
         <NodeHeader node={node} showCspBadge={false} cspAvailable={cspSupported} />
-        <AgentNotInstalled nsId={nsId} infraId={node.infraId} nodeId={node.id} height={180} />
+        <AgentNotInstalled nsId={nsId} infraId={node.infraId} nodeId={node.id} height={180}
+          nodeStatus={node.status} />
       </div>
     );
   }

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -6,6 +6,7 @@ import { getMetricsByNode } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
 import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
 import { getNodeList } from '../api/node';
+import { getK8sClusters } from '../api/k8sAgent';
 import MetricChart from '../components/MetricChart';
 import ProviderBadge from '../components/ProviderBadge';
 import AgentNotInstalled from '../components/AgentNotInstalled';
@@ -128,8 +129,12 @@ export default function InfraOverview() {
       let infras = [];
       try { infras = await getInfraList(nsId); } catch {}
       setAllInfras(infras);
-      const allNodes = infras.flatMap(i => i.node || []);
-      const connNames = [...new Set(allNodes.map(n => n.connectionName).filter(Boolean))];
+      // Connections to search: from the namespace's K8s clusters (Tumblebug) primarily —
+      // VMs may not exist — unioned with any VM-derived connections.
+      let tbConns = [];
+      try { tbConns = (await getK8sClusters(nsId)).map((c) => c.connectionName).filter(Boolean); } catch {}
+      const vmConns = infras.flatMap(i => i.node || []).map(n => n.connectionName).filter(Boolean);
+      const connNames = [...new Set([...tbConns, ...vmConns])];
       // Search clusters across all connections
       const results = await Promise.allSettled(connNames.map(async (conn) => {
         const list = await getClusters(conn);

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -4,7 +4,7 @@ import useBasePath from '../hooks/useBasePath';
 import { getInfraList } from '../api/tumblebug';
 import { getMetricsByNode } from '../api/monitoring';
 import { getAllCspMetrics, CSP_METRICS, isCspSupported } from '../api/csp';
-import { getClusters, getCluster, getAllClusterNodeMetrics } from '../api/k8s';
+import { getClustersDetailed, getAllClusterNodeMetrics } from '../api/k8s';
 import { getNodeList } from '../api/node';
 import { getK8sClusters } from '../api/k8sAgent';
 import MetricChart from '../components/MetricChart';
@@ -135,11 +135,10 @@ export default function InfraOverview() {
       try { tbConns = (await getK8sClusters(nsId)).map((c) => c.connectionName).filter(Boolean); } catch {}
       const vmConns = infras.flatMap(i => i.node || []).map(n => n.connectionName).filter(Boolean);
       const connNames = [...new Set([...tbConns, ...vmConns])];
-      // Search clusters across all connections
+      // Search clusters across all connections (cached, single call per connection).
       const results = await Promise.allSettled(connNames.map(async (conn) => {
-        const list = await getClusters(conn);
-        const detailed = await Promise.allSettled(list.map(c => getCluster(conn, c.IId?.NameId)));
-        return detailed.filter(r => r.status === 'fulfilled').map(r => ({ ...r.value, connectionName: conn }));
+        const detailed = await getClustersDetailed(conn);
+        return detailed.map(c => ({ ...c, connectionName: conn }));
       }));
       setClusters(results.filter(r => r.status === 'fulfilled').flatMap(r => r.value));
     })().finally(() => setClustersLoading(false));

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -4,6 +4,8 @@ import { getNodeList, getNode, getNodeItems, installAgent, uninstallAgent, creat
 import { getPlugins } from '../api/monitoring';
 import { getInfra, getInfraList } from '../api/tumblebug';
 import ProviderBadge from '../components/ProviderBadge';
+import K8sAgentPanel from '../components/K8sAgentPanel';
+import { nodeRunState } from '../utils/nodeState';
 
 export default function MonitoringConfig() {
   const { nsId, infraId } = useParams();
@@ -13,6 +15,7 @@ export default function MonitoringConfig() {
   const [selectedNode, setSelectedNode] = useState(null);
   const [selectedNodeInfraId, setSelectedNodeInfraId] = useState(infraId || '');
   const [items, setItems] = useState([]);
+  const [picked, setPicked] = useState(new Set()); // pluginSeq selected in the metric panel
   const [plugins, setPlugins] = useState([]);
   const [loading, setLoading] = useState(true);
   const [itemLoading, setItemLoading] = useState(false);
@@ -72,6 +75,29 @@ export default function MonitoringConfig() {
     setItemLoading(true);
     try { setItems(await getNodeItems(nsId, node.infraId || infraId, node.id)); } catch { setItems([]); }
     setItemLoading(false);
+  }
+
+  // Keep the metric-panel selection in sync with the node's active items.
+  useEffect(() => { setPicked(new Set(items.map((it) => it.pluginSeq))); }, [items]);
+
+  // Apply the checkbox selection in one action (K8s-style): enable newly picked,
+  // disable newly unpicked.
+  async function handleApplyMetrics() {
+    if (!selectedNode || busy) return;
+    const infra = selectedNodeInfraId || infraId;
+    const active = new Set(items.map((it) => it.pluginSeq));
+    const toAdd = inputPlugins.filter((p) => picked.has(p.seq) && !active.has(p.seq));
+    const toRemove = items.filter((it) => !picked.has(it.pluginSeq));
+    if (toAdd.length === 0 && toRemove.length === 0) return;
+    setBusy(true); setBusyMsg('Applying metric selection...');
+    try {
+      for (const it of toRemove) await deleteNodeItem(nsId, infra, selectedNode.id, it.seq);
+      for (const p of toAdd) await createNodeItem(nsId, infra, selectedNode.id, { pluginSeq: p.seq });
+      setItems(await getNodeItems(nsId, infra, selectedNode.id));
+    } catch (err) {
+      alert('Failed: ' + (err.response?.data?.error_message || err.message));
+    }
+    setBusy(false); setBusyMsg('');
   }
 
   // --- Install / Uninstall with polling ---
@@ -184,6 +210,9 @@ export default function MonitoringConfig() {
         </div>
       </div>
 
+      {/* K8s cluster host-agent management */}
+      <K8sAgentPanel nsId={nsId} />
+
       {/* Server list — grouped by Infra */}
       {loading ? <div className="text-sm text-gray-400 p-4 animate-pulse">Loading...</div>
       : allInfras.map((infra) => {
@@ -214,10 +243,12 @@ export default function MonitoringConfig() {
                     <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={node.connectionName} showLabel={false} />{node.name || node.id}</span></td>
                     <td className="px-4 py-2.5 border-b text-gray-500">{node.id}</td>
                     <td className="px-4 py-2.5 border-b"><Badge status={node.status} /></td>
-                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.monitoring_agent_status} /></td>
-                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.log_agent_status} /></td>
+                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.monitoring_agent_status} run={nodeRunState(node.status)} /></td>
+                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.log_agent_status} run={nodeRunState(node.status)} /></td>
                     <td className="px-4 py-2.5 border-b text-right">
-                      {!node.registered
+                      {nodeRunState(node.status) !== 'running' && !node.registered
+                        ? <span className="text-xs text-gray-400" title="Node is not running; agent state unknown">—</span>
+                        : !node.registered
                         ? <button onClick={(e) => handleInstall(e, node)} disabled={busy} className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install Agent</button>
                         : node.monitoring_agent_status === 'INSTALLING'
                         ? <span className="text-sm text-yellow-600 animate-pulse">Installing...</span>
@@ -228,13 +259,18 @@ export default function MonitoringConfig() {
               </tbody>
             </table>
         </div>
+        {/* Metric panel renders directly under the group that owns the selected node */}
+        {selectedNode && (selectedNode.infraId || selectedNodeInfraId) === infra.id && renderMetricPanel()}
       </div>
       );
       })}
+    </div>
+  );
 
-      {/* Metric toggle table */}
-      {selectedNode && (
-        <div className="bg-white rounded-lg shadow">
+  function renderMetricPanel() {
+    if (!selectedNode) return null;
+    return (
+        <div className="bg-white rounded-lg shadow mt-3">
           <div className="px-4 py-3 border-b font-semibold">Monitoring Metrics — {selectedNode.name || selectedNode.id}</div>
           <div className="p-4 relative">
             {/* Metric toggle busy overlay */}
@@ -247,50 +283,47 @@ export default function MonitoringConfig() {
               </div>
             )}
             {!selectedNode.registered ? (
-              <div className="text-center py-6">
-                <p className="text-sm text-gray-500 mb-3">Agent not installed.</p>
-                <button onClick={(e) => handleInstall(e, selectedNode)} disabled={busy} className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50">Install Agent</button>
-              </div>
+              nodeRunState(selectedNode.status) === 'running' ? (
+                <div className="text-center py-6">
+                  <p className="text-sm text-gray-500 mb-3">Agent not installed.</p>
+                  <button onClick={(e) => handleInstall(e, selectedNode)} disabled={busy} className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50">Install Agent</button>
+                </div>
+              ) : (
+                <div className="text-center py-6 text-sm text-gray-500">
+                  {nodeRunState(selectedNode.status) === 'unknown'
+                    ? `Agent state unknown (node status: ${selectedNode.status || 'N/A'}).`
+                    : `Node is not running (${selectedNode.status}). Start the node before installing the agent.`}
+                </div>
+              )
             ) : itemLoading ? (
               <p className="text-sm text-gray-400 animate-pulse">Loading metrics...</p>
             ) : (
-              <table className="w-full text-sm">
-                <thead><tr className="bg-gray-50 text-left">
-                  <th className="px-4 py-2.5 border-b text-gray-500 w-20">Active</th>
-                  <th className="px-4 py-2.5 border-b text-gray-500">Metric</th>
-                  <th className="px-4 py-2.5 border-b text-gray-500">Plugin ID</th>
-                  <th className="px-4 py-2.5 border-b text-gray-500">State</th>
-                </tr></thead>
-                <tbody>
+              <>
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 mb-3">
                   {inputPlugins.map((plugin) => {
-                    const isActive = activeSeqs.has(plugin.seq);
-                    const item = items.find((it) => it.pluginSeq === plugin.seq);
+                    const on = picked.has(plugin.seq);
+                    const wasActive = activeSeqs.has(plugin.seq);
                     return (
-                      <tr key={plugin.seq} className={`hover:bg-gray-50 ${busy ? 'opacity-50 pointer-events-none' : ''}`}>
-                        <td className="px-4 py-2.5 border-b">
-                          <button onClick={() => handleToggle(plugin, isActive)} disabled={busy}
-                            className={`w-11 h-6 rounded-full relative transition-colors ${isActive ? 'bg-blue-600' : 'bg-gray-300'} disabled:opacity-50`}>
-                            <span className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${isActive ? 'left-6' : 'left-1'}`} />
-                          </button>
-                        </td>
-                        <td className="px-4 py-2.5 border-b font-medium">{plugin.name}</td>
-                        <td className="px-4 py-2.5 border-b text-gray-500">{plugin.pluginId}</td>
-                        <td className="px-4 py-2.5 border-b">
-                          {isActive
-                            ? <span className="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">{item?.state || 'ACTIVE'}</span>
-                            : <span className="text-gray-400 text-xs">Not configured</span>}
-                        </td>
-                      </tr>
+                      <label key={plugin.seq} className="flex items-center gap-2 text-sm bg-white border rounded px-3 py-2 cursor-pointer">
+                        <input type="checkbox" checked={on} disabled={busy}
+                          onChange={() => setPicked((p) => { const n = new Set(p); n.has(plugin.seq) ? n.delete(plugin.seq) : n.add(plugin.seq); return n; })} />
+                        <span className="font-medium">{plugin.name}</span>
+                        {wasActive && <span className="ml-auto text-xs text-green-600">active</span>}
+                      </label>
                     );
                   })}
-                </tbody>
-              </table>
+                </div>
+                <button onClick={handleApplyMetrics} disabled={busy}
+                  className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50">
+                  Apply
+                </button>
+                <span className="ml-3 text-xs text-gray-400">Enables the selected metrics and disables the rest.</span>
+              </>
             )}
           </div>
         </div>
-      )}
-    </div>
-  );
+    );
+  }
 }
 
 function Badge({ status }) {
@@ -299,8 +332,12 @@ function Badge({ status }) {
   return <span className={`text-xs px-2 py-0.5 rounded-full ${c}`}>{status || '-'}</span>;
 }
 
-function AgentBadge({ status }) {
-  if (!status) return <span className="text-xs text-gray-400">Not installed</span>;
+function AgentBadge({ status, run }) {
+  if (!status) {
+    // No agent status: only call it "Not installed" when the node is actually running.
+    // For stopped/terminated/undefined nodes we don't know the agent state.
+    return <span className="text-xs text-gray-400">{run === 'running' ? 'Not installed' : 'Unknown'}</span>;
+  }
   const s = status.toUpperCase();
   const c = s === 'SUCCESS' ? 'bg-green-100 text-green-700' : s === 'INSTALLING' ? 'bg-yellow-100 text-yellow-700' :
     s === 'SERVICE_INACTIVE' ? 'bg-orange-100 text-orange-700' : s === 'FAILED' ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500';

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -444,7 +444,8 @@ export default function MonitoringDashboard() {
               Node: {nodes.find(n => n.id === selectedNodeId)?.name || selectedNodeId}
             </div>
             {agentInstalled === false ? (
-              <AgentNotInstalled nsId={nsId} infraId={infraId} nodeId={selectedNodeId} height={160} />
+              <AgentNotInstalled nsId={nsId} infraId={infraId} nodeId={selectedNodeId} height={160}
+                nodeStatus={nodes.find(n => n.id === selectedNodeId)?.status} />
             ) : (overviewLoading || !overviewCharts) ? (
               <div className="flex items-center justify-center h-[160px] text-gray-400 animate-pulse">Loading metrics...</div>
             ) : overviewCharts.length > 0 ? (

--- a/front/src/utils/nodeState.js
+++ b/front/src/utils/nodeState.js
@@ -1,0 +1,30 @@
+// Classify a Tumblebug node status for agent-related UI decisions.
+//
+// - running:  the VM is up; "agent not installed" is meaningful → show install guidance.
+// - stopped:  the VM is suspended/terminated/etc; we can't know agent state and there's
+//             nothing to collect → show a state-specific message, not "install".
+// - unknown:  status missing/undefined → "agent state unknown".
+
+export function nodeRunState(status) {
+  const s = (status || '').toString().toLowerCase();
+  if (!s || s.includes('undefined')) return 'unknown';
+  if (s.includes('running')) return 'running';
+  if (
+    s.includes('suspend') || s.includes('terminat') || s.includes('stop') ||
+    s.includes('failed') || s.includes('creating') || s.includes('reboot')
+  ) {
+    return 'stopped';
+  }
+  return 'unknown';
+}
+
+/** Human label for a non-running state (used when agent install is not applicable). */
+export function nodeStateMessage(status) {
+  const s = (status || '').toString();
+  const run = nodeRunState(status);
+  if (run === 'unknown') {
+    return `Agent state unknown (node status: ${s || 'N/A'}).`;
+  }
+  // stopped
+  return `Node is not running (${s}). Start the node to collect metrics.`;
+}

--- a/java/mc-o11y-manager/build.gradle
+++ b/java/mc-o11y-manager/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.influxdb:influxdb-java'
+    // Version is managed by Spring Boot's dependency management (aligns all fabric8
+    // kubernetes-client modules to one version). Pinning here causes api/impl skew.
+    implementation 'io.fabric8:kubernetes-client'
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
@@ -1,5 +1,9 @@
 package com.mcmp.o11ymanager.manager.controller;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
+import com.mcmp.o11ymanager.manager.dto.SpiderClusterList;
 import com.mcmp.o11ymanager.manager.dto.SpiderMonitoringInfo;
 import com.mcmp.o11ymanager.manager.global.vm.ResBody;
 import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
@@ -8,6 +12,9 @@ import com.mcmp.o11ymanager.manager.service.cache.CspCacheService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,6 +38,36 @@ public class CspMonitoringController {
 
     private final SpiderClient spiderClient;
     private final CspCacheService cspCacheService;
+
+    /** Short-TTL cache for the (expensive) per-connection K8s cluster discovery + detail. */
+    private final Cache<String, List<SpiderClusterInfo>> clusterListCache =
+            Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(30)).maximumSize(200).build();
+
+    @GetMapping("/clusters")
+    @Operation(
+            summary = "GetK8sClusters (cached)",
+            description =
+                    "List K8s clusters (with node-group detail) for a connection, cached ~30s to"
+                            + " avoid hitting cb-spider on every page load.")
+    public List<SpiderClusterInfo> getClusters(
+            @RequestParam("ConnectionName") String connectionName) {
+        return clusterListCache.get(
+                connectionName,
+                conn -> {
+                    List<SpiderClusterInfo> out = new ArrayList<>();
+                    SpiderClusterList list = spiderClient.listClusters(conn);
+                    if (list != null && list.getCluster() != null) {
+                        for (SpiderClusterInfo c : list.getCluster()) {
+                            try {
+                                out.add(spiderClient.getCluster(c.getIId().getNameId(), conn));
+                            } catch (Exception e) {
+                                out.add(c);
+                            }
+                        }
+                    }
+                    return out;
+                });
+    }
 
     @GetMapping("/node/{nodeName}/{measurement}")
     @Operation(

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/K8sAgentController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/K8sAgentController.java
@@ -79,6 +79,47 @@ public class K8sAgentController {
                         "active", k8sAgentService.nodeActiveMetrics(nsId, clusterId, nodeName)));
     }
 
+    // --- Log agent (fluent-bit via podman) ---
+
+    @Operation(summary = "Per-node log agent status (running = node logs in Loki recently)")
+    @GetMapping("/{nsId}/{clusterId}/log-agent")
+    public ResBody<List<K8sAgentService.NodeStatus>> logStatus(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.logStatus(nsId, clusterId));
+    }
+
+    @Operation(summary = "Install fluent-bit log agent on every node of the cluster")
+    @PostMapping("/{nsId}/{clusterId}/log-agent")
+    public ResBody<List<K8sAgentService.NodeResult>> installLog(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.installLog(nsId, clusterId));
+    }
+
+    @Operation(summary = "Uninstall fluent-bit log agent from every node of the cluster")
+    @DeleteMapping("/{nsId}/{clusterId}/log-agent")
+    public ResBody<List<K8sAgentService.NodeResult>> uninstallLog(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.uninstallLog(nsId, clusterId));
+    }
+
+    @Operation(summary = "Install fluent-bit log agent on a single node")
+    @PostMapping("/{nsId}/{clusterId}/node/{nodeName}/log-agent")
+    public ResBody<K8sAgentService.NodeResult> installLogNode(
+            @PathVariable String nsId,
+            @PathVariable String clusterId,
+            @PathVariable String nodeName) {
+        return new ResBody<>(k8sAgentService.installLogNode(nsId, clusterId, nodeName));
+    }
+
+    @Operation(summary = "Uninstall fluent-bit log agent from a single node")
+    @DeleteMapping("/{nsId}/{clusterId}/node/{nodeName}/log-agent")
+    public ResBody<K8sAgentService.NodeResult> uninstallLogNode(
+            @PathVariable String nsId,
+            @PathVariable String clusterId,
+            @PathVariable String nodeName) {
+        return new ResBody<>(k8sAgentService.uninstallLogNode(nsId, clusterId, nodeName));
+    }
+
     @SuppressWarnings("unchecked")
     private static List<String> metrics(Map<String, Object> body) {
         if (body == null) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/K8sAgentController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/K8sAgentController.java
@@ -1,0 +1,90 @@
+package com.mcmp.o11ymanager.manager.controller;
+
+import com.mcmp.o11ymanager.manager.global.vm.ResBody;
+import com.mcmp.o11ymanager.manager.service.K8sAgentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Host-level Telegraf agent management for Kubernetes cluster nodes. Installs Telegraf as a systemd
+ * service on each node host via the cluster kubeconfig (no SSH / node IP required).
+ */
+@RestController
+@RequestMapping("/api/o11y/monitoring/k8s")
+@RequiredArgsConstructor
+@Tag(name = "K8s Node Agent", description = "Install/uninstall host Telegraf on K8s cluster nodes")
+public class K8sAgentController {
+
+    private final K8sAgentService k8sAgentService;
+
+    @Operation(summary = "Install host Telegraf agent on every node of the cluster")
+    @PostMapping("/{nsId}/{clusterId}/agent")
+    public ResBody<List<K8sAgentService.NodeResult>> install(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.install(nsId, clusterId));
+    }
+
+    @Operation(summary = "Uninstall host Telegraf agent from every node of the cluster")
+    @DeleteMapping("/{nsId}/{clusterId}/agent")
+    public ResBody<List<K8sAgentService.NodeResult>> uninstall(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.uninstall(nsId, clusterId));
+    }
+
+    @Operation(summary = "Per-node agent status (running = reported to InfluxDB recently)")
+    @GetMapping("/{nsId}/{clusterId}/agent")
+    public ResBody<List<K8sAgentService.NodeStatus>> status(
+            @PathVariable String nsId, @PathVariable String clusterId) {
+        return new ResBody<>(k8sAgentService.status(nsId, clusterId));
+    }
+
+    @Operation(summary = "Install host Telegraf agent on a single node (optional metric selection)")
+    @PostMapping("/{nsId}/{clusterId}/node/{nodeName}/agent")
+    public ResBody<K8sAgentService.NodeResult> installNode(
+            @PathVariable String nsId,
+            @PathVariable String clusterId,
+            @PathVariable String nodeName,
+            @RequestBody(required = false) Map<String, Object> body) {
+        return new ResBody<>(k8sAgentService.installNode(nsId, clusterId, nodeName, metrics(body)));
+    }
+
+    @Operation(summary = "Uninstall host Telegraf agent from a single node")
+    @DeleteMapping("/{nsId}/{clusterId}/node/{nodeName}/agent")
+    public ResBody<K8sAgentService.NodeResult> uninstallNode(
+            @PathVariable String nsId,
+            @PathVariable String clusterId,
+            @PathVariable String nodeName) {
+        return new ResBody<>(k8sAgentService.uninstallNode(nsId, clusterId, nodeName));
+    }
+
+    @Operation(summary = "Available metric inputs and the ones currently active on the node")
+    @GetMapping("/{nsId}/{clusterId}/node/{nodeName}/agent/metrics")
+    public ResBody<Map<String, Object>> nodeMetrics(
+            @PathVariable String nsId,
+            @PathVariable String clusterId,
+            @PathVariable String nodeName) {
+        return new ResBody<>(
+                Map.of(
+                        "available", List.copyOf(K8sAgentService.INPUTS.keySet()),
+                        "active", k8sAgentService.nodeActiveMetrics(nsId, clusterId, nodeName)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> metrics(Map<String, Object> body) {
+        if (body == null) {
+            return null;
+        }
+        Object m = body.get("metrics");
+        return (m instanceof List) ? (List<String>) m : null;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugK8sCluster.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugK8sCluster.java
@@ -1,0 +1,36 @@
+package com.mcmp.o11ymanager.manager.dto.tumblebug;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Minimal view of a cb-tumblebug K8sCluster (only the fields the agent install needs). */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TumblebugK8sCluster {
+    private String id;
+    private String name;
+    private String connectionName;
+    private String status;
+    private AccessInfo accessInfo;
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AccessInfo {
+        private String endpoint;
+        private String kubeconfig;
+    }
+
+    /** Wrapper for the list endpoint response: {"K8sClusterInfo":[...]}. */
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ListResponse {
+        @JsonProperty("K8sClusterInfo")
+        private List<TumblebugK8sCluster> k8sClusterInfo;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
@@ -3,6 +3,7 @@ package com.mcmp.o11ymanager.manager.infrastructure.tumblebug;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfraList;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -37,4 +38,10 @@ public interface TumblebugClient {
             @PathVariable String infraId,
             @RequestParam String nodeId,
             @RequestBody TumblebugCmd tumblebugCmd);
+
+    @GetMapping("/tumblebug/ns/{nsId}/k8sCluster")
+    TumblebugK8sCluster.ListResponse getK8sClusterList(@PathVariable String nsId);
+
+    @GetMapping("/tumblebug/ns/{nsId}/k8sCluster/{k8sClusterId}")
+    TumblebugK8sCluster getK8sCluster(@PathVariable String nsId, @PathVariable String k8sClusterId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -1,0 +1,466 @@
+package com.mcmp.o11ymanager.manager.service;
+
+import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
+import com.mcmp.o11ymanager.manager.facade.InfluxDbFacadeService;
+import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Installs/uninstalls a host-level Telegraf agent on every node of a Kubernetes cluster, using only
+ * the cluster kubeconfig (from cb-tumblebug). A short-lived privileged Job per node enters the host
+ * namespaces via {@code nsenter} and installs Telegraf as a systemd service on the node host (not a
+ * sidecar container). Metrics are shipped to InfluxDB with the same tag schema as VM agents ({@code
+ * ns_id} / {@code infra_id}=clusterId / {@code node_id}=k8s node name).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class K8sAgentService {
+
+    private final TumblebugClient tumblebugClient;
+    private final InfluxDbFacadeService influxDbFacadeService;
+
+    private static final String JOB_NS = "default";
+    private static final String TELEGRAF_VERSION = "1.29.5";
+    private static final String NSENTER_IMAGE = "alpine:3.20";
+
+    /** Node considered "running" if it reported within this window. */
+    private static final long FRESH_SECONDS = 180;
+
+    /** Host telegraf input plugins selectable per node, with their measurement name. */
+    public static final java.util.LinkedHashMap<String, String> INPUTS =
+            new java.util.LinkedHashMap<>();
+
+    static {
+        INPUTS.put("cpu", "[[inputs.cpu]]\n  totalcpu = true\n  percpu = false");
+        INPUTS.put("mem", "[[inputs.mem]]");
+        INPUTS.put("disk", "[[inputs.disk]]");
+        INPUTS.put("diskio", "[[inputs.diskio]]");
+        INPUTS.put("net", "[[inputs.net]]");
+        INPUTS.put("system", "[[inputs.system]]");
+        INPUTS.put("processes", "[[inputs.processes]]");
+        INPUTS.put("swap", "[[inputs.swap]]");
+    }
+
+    private static final List<String> DEFAULT_METRICS = new ArrayList<>(INPUTS.keySet());
+
+    private final HttpClient http =
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+    @Getter
+    @lombok.AllArgsConstructor
+    public static class NodeResult {
+        private String node;
+        private boolean ok;
+        private String message;
+    }
+
+    @Getter
+    @lombok.AllArgsConstructor
+    public static class NodeStatus {
+        private String node;
+        private boolean installed; // job-created marker / telegraf present
+        private boolean running; // reported to InfluxDB recently
+        private String lastSeen; // ISO timestamp or null
+    }
+
+    private KubernetesClient client(String nsId, String clusterId) {
+        TumblebugK8sCluster cluster = tumblebugClient.getK8sCluster(nsId, clusterId);
+        if (cluster == null
+                || cluster.getAccessInfo() == null
+                || cluster.getAccessInfo().getKubeconfig() == null
+                || cluster.getAccessInfo().getKubeconfig().isBlank()) {
+            throw new IllegalStateException(
+                    "kubeconfig not available for cluster " + nsId + "/" + clusterId);
+        }
+        Config cfg = Config.fromKubeconfig(cluster.getAccessInfo().getKubeconfig());
+        return new KubernetesClientBuilder().withConfig(cfg).build();
+    }
+
+    public List<NodeResult> install(String nsId, String clusterId) {
+        return install(nsId, clusterId, DEFAULT_METRICS);
+    }
+
+    public List<NodeResult> install(String nsId, String clusterId, List<String> metrics) {
+        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+        List<NodeResult> results = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                results.add(
+                        installOne(
+                                k8s,
+                                nsId,
+                                clusterId,
+                                node.getMetadata().getName(),
+                                influx,
+                                metrics));
+            }
+        }
+        return results;
+    }
+
+    public NodeResult installNode(
+            String nsId, String clusterId, String nodeName, List<String> metrics) {
+        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            return installOne(k8s, nsId, clusterId, nodeName, influx, metrics);
+        }
+    }
+
+    public List<NodeResult> uninstall(String nsId, String clusterId) {
+        List<NodeResult> results = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                results.add(uninstallOne(k8s, node.getMetadata().getName()));
+            }
+        }
+        return results;
+    }
+
+    public NodeResult uninstallNode(String nsId, String clusterId, String nodeName) {
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            return uninstallOne(k8s, nodeName);
+        }
+    }
+
+    private NodeResult installOne(
+            KubernetesClient k8s,
+            String nsId,
+            String clusterId,
+            String nodeName,
+            InfluxDTO influx,
+            List<String> metrics) {
+        try {
+            String script = installScript(nsId, clusterId, nodeName, influx, metrics);
+            runJob(k8s, "cmp-telegraf-install-", nodeName, script);
+            return new NodeResult(nodeName, true, "installed");
+        } catch (Exception e) {
+            log.error("k8s agent install failed node={}", nodeName, e);
+            return new NodeResult(nodeName, false, e.getMessage());
+        }
+    }
+
+    private NodeResult uninstallOne(KubernetesClient k8s, String nodeName) {
+        try {
+            runJob(k8s, "cmp-telegraf-uninstall-", nodeName, uninstallScript());
+            return new NodeResult(nodeName, true, "uninstalled");
+        } catch (Exception e) {
+            log.error("k8s agent uninstall failed node={}", nodeName, e);
+            return new NodeResult(nodeName, false, e.getMessage());
+        }
+    }
+
+    /** Input plugin names currently producing data for the node (recent measurements). */
+    public List<String> nodeActiveMetrics(String nsId, String clusterId, String nodeName) {
+        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+        List<String> active = new ArrayList<>();
+        for (String m : INPUTS.keySet()) {
+            try {
+                String q =
+                        "SELECT last(*) FROM "
+                                + m
+                                + " WHERE infra_id='"
+                                + clusterId
+                                + "' AND node_id='"
+                                + nodeName
+                                + "'";
+                if (influxHasSeries(influx, q)) {
+                    active.add(m);
+                }
+            } catch (Exception ignore) {
+                // skip
+            }
+        }
+        return active;
+    }
+
+    public List<NodeStatus> status(String nsId, String clusterId) {
+        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+        Map<String, String> lastSeen = queryLastSeen(influx, clusterId);
+        List<NodeStatus> out = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                String nodeName = node.getMetadata().getName();
+                String ts = lastSeen.get(nodeName);
+                boolean running = ts != null && isFresh(ts);
+                out.add(new NodeStatus(nodeName, running, running, ts));
+            }
+        }
+        return out;
+    }
+
+    // --- Job execution ---------------------------------------------------
+
+    private void runJob(KubernetesClient k8s, String prefix, String nodeName, String script) {
+        String b64 = Base64.getEncoder().encodeToString(script.getBytes(StandardCharsets.UTF_8));
+        String jobName = prefix + sanitize(nodeName);
+        // Clean any stale job with the same name first.
+        k8s.batch().v1().jobs().inNamespace(JOB_NS).withName(jobName).delete();
+
+        Job job =
+                new JobBuilder()
+                        .withNewMetadata()
+                        .withName(jobName)
+                        .withNamespace(JOB_NS)
+                        .endMetadata()
+                        .withNewSpec()
+                        .withBackoffLimit(0)
+                        .withTtlSecondsAfterFinished(300)
+                        .withNewTemplate()
+                        .withNewSpec()
+                        .withNodeName(nodeName)
+                        .withHostPID(true)
+                        .withHostNetwork(true)
+                        .withRestartPolicy("Never")
+                        .addNewToleration()
+                        .withOperator("Exists")
+                        .endToleration()
+                        .addNewContainer()
+                        .withName("agent")
+                        .withImage(NSENTER_IMAGE)
+                        .withNewSecurityContext()
+                        .withPrivileged(true)
+                        .endSecurityContext()
+                        .withCommand(
+                                "nsenter",
+                                "-t",
+                                "1",
+                                "-m",
+                                "-u",
+                                "-i",
+                                "-n",
+                                "-p",
+                                "--",
+                                "bash",
+                                "-c",
+                                "echo " + b64 + " | base64 -d | bash")
+                        .endContainer()
+                        .endSpec()
+                        .endTemplate()
+                        .endSpec()
+                        .build();
+
+        k8s.batch().v1().jobs().inNamespace(JOB_NS).resource(job).create();
+        // Best-effort wait for completion.
+        try {
+            k8s.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(JOB_NS)
+                    .withName(jobName)
+                    .waitUntilCondition(
+                            j ->
+                                    j != null
+                                            && j.getStatus() != null
+                                            && (numOrZero(j.getStatus().getSucceeded()) > 0
+                                                    || numOrZero(j.getStatus().getFailed()) > 0),
+                            180,
+                            java.util.concurrent.TimeUnit.SECONDS);
+            Job done = k8s.batch().v1().jobs().inNamespace(JOB_NS).withName(jobName).get();
+            if (done != null
+                    && done.getStatus() != null
+                    && numOrZero(done.getStatus().getSucceeded()) == 0) {
+                throw new IllegalStateException("job did not succeed: " + jobName);
+            }
+        } finally {
+            k8s.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(JOB_NS)
+                    .withName(jobName)
+                    .withPropagationPolicy(
+                            io.fabric8.kubernetes.api.model.DeletionPropagation.BACKGROUND)
+                    .delete();
+        }
+    }
+
+    private static int numOrZero(Integer i) {
+        return i == null ? 0 : i;
+    }
+
+    private static String sanitize(String s) {
+        String v = s.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+        return v.length() > 50 ? v.substring(0, 50) : v;
+    }
+
+    // --- Scripts ---------------------------------------------------------
+
+    private String installScript(
+            String nsId,
+            String clusterId,
+            String nodeName,
+            InfluxDTO influx,
+            List<String> metrics) {
+        return """
+                set -e
+                cd /tmp
+                curl -sL -o cmp-tg.tar.gz https://dl.influxdata.com/telegraf/releases/telegraf-%s_linux_amd64.tar.gz
+                tar xzf cmp-tg.tar.gz
+                install -m0755 telegraf-%s/usr/bin/telegraf /usr/local/bin/cmp-telegraf
+                mkdir -p /etc/cmp-telegraf
+                cat > /etc/cmp-telegraf/telegraf.conf <<'CONF'
+                [global_tags]
+                  ns_id = "%s"
+                  infra_id = "%s"
+                  node_id = "%s"
+                [agent]
+                  interval = "30s"
+                  flush_interval = "30s"
+                [[outputs.influxdb]]
+                  urls = ["%s"]
+                  database = "%s"
+                  username = "%s"
+                  password = "%s"
+                %s
+                CONF
+                cat > /etc/systemd/system/cmp-telegraf.service <<'SVC'
+                [Unit]
+                Description=CMP Telegraf (k8s node host agent)
+                After=network.target
+                [Service]
+                ExecStart=/usr/local/bin/cmp-telegraf --config /etc/cmp-telegraf/telegraf.conf
+                Restart=always
+                [Install]
+                WantedBy=multi-user.target
+                SVC
+                systemctl daemon-reload
+                systemctl enable --now cmp-telegraf
+                """
+                .formatted(
+                        TELEGRAF_VERSION,
+                        TELEGRAF_VERSION,
+                        nsId,
+                        clusterId,
+                        nodeName,
+                        influx.getUrl(),
+                        influx.getDatabase(),
+                        influx.getUsername() == null ? "" : influx.getUsername(),
+                        influx.getPassword() == null ? "" : influx.getPassword(),
+                        metricsToToml(metrics));
+    }
+
+    private String metricsToToml(List<String> metrics) {
+        List<String> use = (metrics == null || metrics.isEmpty()) ? DEFAULT_METRICS : metrics;
+        StringBuilder sb = new StringBuilder();
+        for (String m : use) {
+            String toml = INPUTS.get(m);
+            if (toml != null) {
+                if (sb.length() > 0) {
+                    sb.append("\n");
+                }
+                sb.append(toml);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String uninstallScript() {
+        return """
+                systemctl disable --now cmp-telegraf 2>/dev/null || true
+                rm -f /etc/systemd/system/cmp-telegraf.service /usr/local/bin/cmp-telegraf
+                rm -rf /etc/cmp-telegraf
+                systemctl daemon-reload 2>/dev/null || true
+                echo UNINSTALLED
+                """;
+    }
+
+    // --- InfluxDB status query ------------------------------------------
+
+    /** Returns node_id -> last cpu point ISO time for the cluster. */
+    private Map<String, String> queryLastSeen(InfluxDTO influx, String clusterId) {
+        Map<String, String> map = new java.util.HashMap<>();
+        try {
+            String q =
+                    "SELECT last(\"usage_idle\") FROM cpu WHERE infra_id='"
+                            + clusterId
+                            + "' GROUP BY node_id";
+            com.fasterxml.jackson.databind.JsonNode root =
+                    new com.fasterxml.jackson.databind.ObjectMapper()
+                            .readTree(influxGet(influx, q));
+            for (var stmt : root.path("results")) {
+                for (var series : stmt.path("series")) {
+                    String node = series.path("tags").path("node_id").asText(null);
+                    var values = series.path("values");
+                    if (node != null && values.isArray() && values.size() > 0) {
+                        map.put(node, values.get(values.size() - 1).get(0).asText(null));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("k8s agent status influx query failed for cluster={}", clusterId, e);
+        }
+        return map;
+    }
+
+    private String influxGet(InfluxDTO influx, String q) throws Exception {
+        String url = influx.getUrl() + "/query?db=" + enc(influx.getDatabase()) + "&q=" + enc(q);
+        HttpRequest.Builder rb =
+                HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(10)).GET();
+        if (influx.getUsername() != null && !influx.getUsername().isBlank()) {
+            String basic =
+                    Base64.getEncoder()
+                            .encodeToString(
+                                    (influx.getUsername() + ":" + influx.getPassword())
+                                            .getBytes(StandardCharsets.UTF_8));
+            rb.header("Authorization", "Basic " + basic);
+        }
+        return http.send(rb.build(), HttpResponse.BodyHandlers.ofString()).body();
+    }
+
+    private boolean influxHasSeries(InfluxDTO influx, String q) {
+        try {
+            com.fasterxml.jackson.databind.JsonNode root =
+                    new com.fasterxml.jackson.databind.ObjectMapper()
+                            .readTree(influxGet(influx, q));
+            for (var stmt : root.path("results")) {
+                for (var series : stmt.path("series")) {
+                    var values = series.path("values");
+                    if (values.isArray() && values.size() > 0) {
+                        var first = values.get(0);
+                        for (int i = 1; i < first.size(); i++) {
+                            if (!first.get(i).isNull()) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("influx hasSeries failed q={}", q, e);
+        }
+        return false;
+    }
+
+    private boolean isFresh(String iso) {
+        try {
+            java.time.Instant t = java.time.Instant.parse(iso);
+            return java.time.Instant.now().minusSeconds(FRESH_SECONDS).isBefore(t);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String enc(String s) {
+        return java.net.URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -64,6 +64,11 @@ public class K8sAgentService {
 
     private static final List<String> DEFAULT_METRICS = new ArrayList<>(INPUTS.keySet());
 
+    /** Log agent (fluent-bit) runs as a podman container on the node host, shipping to Loki. */
+    private static final String FLUENT_BIT_IMAGE = "docker.io/fluent/fluent-bit:3.2.4";
+
+    private static final int LOKI_PORT = 3100;
+
     private final HttpClient http =
             HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
 
@@ -192,6 +197,198 @@ public class K8sAgentService {
             }
         }
         return active;
+    }
+
+    // --- Log agent (fluent-bit via podman) -------------------------------
+
+    public List<NodeResult> installLog(String nsId, String clusterId) {
+        String lokiHost = lokiHost(nsId, clusterId);
+        List<NodeResult> results = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                results.add(
+                        installLogOne(
+                                k8s, nsId, clusterId, node.getMetadata().getName(), lokiHost));
+            }
+        }
+        return results;
+    }
+
+    public NodeResult installLogNode(String nsId, String clusterId, String nodeName) {
+        String lokiHost = lokiHost(nsId, clusterId);
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            return installLogOne(k8s, nsId, clusterId, nodeName, lokiHost);
+        }
+    }
+
+    public List<NodeResult> uninstallLog(String nsId, String clusterId) {
+        List<NodeResult> results = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                results.add(uninstallLogOne(k8s, node.getMetadata().getName()));
+            }
+        }
+        return results;
+    }
+
+    public NodeResult uninstallLogNode(String nsId, String clusterId, String nodeName) {
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            return uninstallLogOne(k8s, nodeName);
+        }
+    }
+
+    /** Per-node log agent status (running = node logs present in Loki recently). */
+    public List<NodeStatus> logStatus(String nsId, String clusterId) {
+        String lokiHost = lokiHost(nsId, clusterId);
+        List<NodeStatus> out = new ArrayList<>();
+        try (KubernetesClient k8s = client(nsId, clusterId)) {
+            for (Node node : k8s.nodes().list().getItems()) {
+                String nodeName = node.getMetadata().getName();
+                boolean running = lokiHasRecent(lokiHost, nsId, clusterId, nodeName);
+                out.add(new NodeStatus(nodeName, running, running, null));
+            }
+        }
+        return out;
+    }
+
+    private NodeResult installLogOne(
+            KubernetesClient k8s, String nsId, String clusterId, String nodeName, String lokiHost) {
+        try {
+            runJob(
+                    k8s,
+                    "cmp-fluentbit-install-",
+                    nodeName,
+                    logInstallScript(nsId, clusterId, nodeName, lokiHost));
+            return new NodeResult(nodeName, true, "installed");
+        } catch (Exception e) {
+            log.error("k8s log agent install failed node={}", nodeName, e);
+            return new NodeResult(nodeName, false, e.getMessage());
+        }
+    }
+
+    private NodeResult uninstallLogOne(KubernetesClient k8s, String nodeName) {
+        try {
+            runJob(k8s, "cmp-fluentbit-uninstall-", nodeName, logUninstallScript());
+            return new NodeResult(nodeName, true, "uninstalled");
+        } catch (Exception e) {
+            log.error("k8s log agent uninstall failed node={}", nodeName, e);
+            return new NodeResult(nodeName, false, e.getMessage());
+        }
+    }
+
+    /** Loki host = same host as the (VM-reachable) InfluxDB endpoint. */
+    private String lokiHost(String nsId, String clusterId) {
+        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+        try {
+            return URI.create(influx.getUrl()).getHost();
+        } catch (Exception e) {
+            return influx.getUrl();
+        }
+    }
+
+    private boolean lokiHasRecent(String lokiHost, String nsId, String clusterId, String nodeName) {
+        try {
+            long endNs = System.currentTimeMillis() * 1_000_000L;
+            long startNs = endNs - 180L * 1_000_000_000L;
+            String q =
+                    "{NS_ID=\""
+                            + nsId
+                            + "\",INFRA_ID=\""
+                            + clusterId
+                            + "\",NODE_ID=\""
+                            + nodeName
+                            + "\"}";
+            String url =
+                    "http://"
+                            + lokiHost
+                            + ":"
+                            + LOKI_PORT
+                            + "/loki/api/v1/query_range?limit=1&start="
+                            + startNs
+                            + "&end="
+                            + endNs
+                            + "&query="
+                            + enc(q);
+            HttpResponse<String> resp =
+                    http.send(
+                            HttpRequest.newBuilder(URI.create(url))
+                                    .timeout(Duration.ofSeconds(10))
+                                    .GET()
+                                    .build(),
+                            HttpResponse.BodyHandlers.ofString());
+            com.fasterxml.jackson.databind.JsonNode root =
+                    new com.fasterxml.jackson.databind.ObjectMapper().readTree(resp.body());
+            return root.path("data").path("result").isArray()
+                    && root.path("data").path("result").size() > 0;
+        } catch (Exception e) {
+            log.warn("loki recent check failed node={}", nodeName, e);
+            return false;
+        }
+    }
+
+    private String logInstallScript(
+            String nsId, String clusterId, String nodeName, String lokiHost) {
+        return """
+                set -e
+                export DEBIAN_FRONTEND=noninteractive
+                if ! command -v podman >/dev/null 2>&1; then apt-get update -qq && apt-get install -y -qq podman; fi
+                PODMAN=$(command -v podman)
+                "$PODMAN" pull %s
+                mkdir -p /etc/cmp-fluent-bit
+                cat > /etc/cmp-fluent-bit/fluent-bit.conf <<'CONF'
+                [SERVICE]
+                    flush 5
+                    log_level info
+                [INPUT]
+                    name tail
+                    tag k8slog
+                    path /var/log/syslog,/var/log/containers/*.log
+                    Read_from_Head false
+                [OUTPUT]
+                    name loki
+                    match *
+                    host %s
+                    port %d
+                    labels NS_ID=%s, INFRA_ID=%s, NODE_ID=%s
+                CONF
+                "$PODMAN" rm -f cmp-fluent-bit >/dev/null 2>&1 || true
+                cat > /etc/systemd/system/cmp-fluent-bit.service <<SVC
+                [Unit]
+                Description=CMP Fluent Bit (k8s node host log agent)
+                After=network-online.target
+                Wants=network-online.target
+                [Service]
+                ExecStartPre=-$PODMAN rm -f cmp-fluent-bit
+                ExecStart=$PODMAN run --rm --name cmp-fluent-bit --network=host -v /var/log:/var/log:ro -v /etc/cmp-fluent-bit:/etc/cmp-fluent-bit:ro %s -c /etc/cmp-fluent-bit/fluent-bit.conf
+                ExecStop=$PODMAN stop -t 10 cmp-fluent-bit
+                Restart=always
+                RestartSec=5
+                [Install]
+                WantedBy=multi-user.target
+                SVC
+                systemctl daemon-reload
+                systemctl enable --now cmp-fluent-bit
+                """
+                .formatted(
+                        FLUENT_BIT_IMAGE,
+                        lokiHost,
+                        LOKI_PORT,
+                        nsId,
+                        clusterId,
+                        nodeName,
+                        FLUENT_BIT_IMAGE);
+    }
+
+    private String logUninstallScript() {
+        return """
+                systemctl disable --now cmp-fluent-bit 2>/dev/null || true
+                PODMAN=$(command -v podman)
+                [ -n "$PODMAN" ] && "$PODMAN" rm -f cmp-fluent-bit 2>/dev/null || true
+                rm -f /etc/systemd/system/cmp-fluent-bit.service
+                rm -rf /etc/cmp-fluent-bit
+                systemctl daemon-reload 2>/dev/null || true
+                echo UNINSTALLED
+                """;
     }
 
     public List<NodeStatus> status(String nsId, String clusterId) {


### PR DESCRIPTION
## 변경 사항

kubeconfig 기반으로 K8s 클러스터 노드 호스트에 에이전트를 설치/관리하는 기능. SSH/노드 IP 없이, 권한 Job(nsenter)으로 노드 host에 설치합니다.

### 백엔드 (manager)
- **모니터링 에이전트(telegraf)**: kubeconfig로 노드별 권한 Job 실행 → 노드 host에 telegraf systemd 설치, InfluxDB로 전송(태그 `ns_id`/`infra_id`=clusterId/`node_id`=노드명, VM 에이전트와 동일 스키마). 클러스터/노드 단위 install·uninstall·status, 노드별 메트릭 입력 선택.
- **로그 에이전트(fluent-bit)**: 노드 host에 fluent-bit(podman) 설치 → Loki 전송(`NS_ID`/`INFRA_ID`/`NODE_ID` 라벨). install·uninstall·status.

### 프론트
- **Config**: K8s 클러스터를 그룹으로, 노드를 행으로 표시(CSP 로고, Monitoring/Log Agent 상태, 노드별 설치/삭제, 클릭 시 메트릭 선택 패널). VM 메트릭 설정도 체크박스+Apply 방식으로 통일.
- **Monitoring**: K8s 탭의 Agent 소스에 telegraf 메트릭 그래프 표시. 클러스터 디스커버리를 네임스페이스 기준으로 변경(VM 없어도 동작).
- 노드 상태 인지형 안내 메시지(미설치/정지/불명 구분).
