### PR TITLE
feat: extend insight/alert/log to k8s and polish config UX

### DIFF
--- a/front/src/api/cache.js
+++ b/front/src/api/cache.js
@@ -1,0 +1,45 @@
+// Tiny client-side cache for hot, semi-static list lookups (VM/infra lists, k8s clusters).
+//
+// Two jobs:
+//  1. TTL cache  — repeated reads within `ttlMs` reuse the result instead of re-hitting
+//     cb-tumblebug, so tab switches / multiple panels don't each pay a network round-trip.
+//  2. In-flight dedup — concurrent identical requests share one promise, so a burst (e.g. the
+//     landing page counting several namespaces, or many cards mounting at once) collapses to a
+//     single call. This is what keeps us under cb-tumblebug's rate limiter (HTTP 429).
+//
+// Roughly an LRU of the most-recently-used entries (cap below), so the recently-viewed
+// VMs/clusters stay warm.
+
+const MAX_ENTRIES = 60;
+const store = new Map(); // key -> { ts, value }
+const inflight = new Map(); // key -> Promise
+
+function trim() {
+  if (store.size <= MAX_ENTRIES) return;
+  const oldest = [...store.entries()].sort((a, b) => a[1].ts - b[1].ts);
+  for (let i = 0; i < oldest.length - MAX_ENTRIES; i++) store.delete(oldest[i][0]);
+}
+
+export function cached(key, ttlMs, loader) {
+  const hit = store.get(key);
+  if (hit && Date.now() - hit.ts < ttlMs) return Promise.resolve(hit.value);
+  if (inflight.has(key)) return inflight.get(key);
+  const p = loader()
+    .then((value) => {
+      store.set(key, { ts: Date.now(), value });
+      inflight.delete(key);
+      trim();
+      return value;
+    })
+    .catch((e) => {
+      inflight.delete(key);
+      throw e;
+    });
+  inflight.set(key, p);
+  return p;
+}
+
+/** Drop cached entries whose key starts with `prefix` (e.g. after an install/uninstall). */
+export function invalidate(prefix = '') {
+  for (const k of [...store.keys()]) if (k.startsWith(prefix)) store.delete(k);
+}

--- a/front/src/api/client.js
+++ b/front/src/api/client.js
@@ -18,4 +18,21 @@ client.interceptors.request.use((config) => {
   return config;
 });
 
+// cb-tumblebug rate-limits bursts (HTTP 429); retry a few times with backoff so list/status
+// lookups don't fail just because several panels loaded at once.
+client.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const cfg = error.config;
+    if (error.response?.status === 429 && cfg) {
+      cfg._retry429 = (cfg._retry429 || 0) + 1;
+      if (cfg._retry429 <= 4) {
+        await new Promise((r) => setTimeout(r, 400 * cfg._retry429));
+        return client(cfg);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default client;

--- a/front/src/api/k8sAgent.js
+++ b/front/src/api/k8sAgent.js
@@ -1,9 +1,13 @@
 import client from './client';
+import { cached } from './cache';
 
-// K8s clusters in a namespace (from cb-tumblebug, proxied by nginx).
+// K8s clusters in a namespace (from cb-tumblebug, proxied by nginx). Cached ~30s with
+// in-flight dedup since several panels list clusters and the lookup is heavy.
 export async function getK8sClusters(nsId) {
-  const res = await client.get(`/tumblebug/ns/${nsId}/k8sCluster`);
-  return res.data?.K8sClusterInfo || res.data?.k8sClusterInfo || [];
+  return cached(`k8sClusters:${nsId}`, 30000, async () => {
+    const res = await client.get(`/tumblebug/ns/${nsId}/k8sCluster`);
+    return res.data?.K8sClusterInfo || res.data?.k8sClusterInfo || [];
+  });
 }
 
 // Host Telegraf agent on K8s cluster nodes (mc-observability manager).

--- a/front/src/api/tumblebug.js
+++ b/front/src/api/tumblebug.js
@@ -1,20 +1,27 @@
 import client from './client';
+import { cached } from './cache';
 
 const TB_BASE = '/tumblebug';
 
 export async function getNsList() {
-  const res = await client.get(`${TB_BASE}/ns`);
-  return res.data?.ns || [];
+  return cached('ns', 30000, async () => {
+    const res = await client.get(`${TB_BASE}/ns`);
+    return res.data?.ns || [];
+  });
 }
 
 export async function getInfraList(nsId) {
-  const res = await client.get(`${TB_BASE}/ns/${nsId}/infra`);
-  return res.data?.infra || [];
+  return cached(`infraList:${nsId}`, 10000, async () => {
+    const res = await client.get(`${TB_BASE}/ns/${nsId}/infra`);
+    return res.data?.infra || [];
+  });
 }
 
 export async function getInfra(nsId, infraId) {
-  const res = await client.get(`${TB_BASE}/ns/${nsId}/infra/${infraId}`);
-  return res.data || {};
+  return cached(`infra:${nsId}/${infraId}`, 5000, async () => {
+    const res = await client.get(`${TB_BASE}/ns/${nsId}/infra/${infraId}`);
+    return res.data || {};
+  });
 }
 
 /** Get all Infra list with Node details for a namespace */

--- a/front/src/components/K8sAgentMonitor.jsx
+++ b/front/src/components/K8sAgentMonitor.jsx
@@ -1,27 +1,22 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getK8sClusters, getK8sAgentStatus } from '../api/k8sAgent';
 import { getMetricsByNode } from '../api/monitoring';
+import useBasePath from '../hooks/useBasePath';
 import MetricChart from './MetricChart';
 import ProviderBadge from './ProviderBadge';
 
 // Host-agent (telegraf) metrics for K8s nodes, queried from InfluxDB by
 // (ns_id, infra_id=clusterId, node_id=k8s node name) — same schema as VM agents.
-// Mirrors the full set of telegraf inputs the agent collects (cpu/mem/disk/diskio/
-// net/system/processes/swap) so the Agent tab shows varied graphs like the API tab.
+// Compact overview set (cpu/mem/disk/diskio/net) — click a chart to open the
+// node's full monitoring detail (same as VM nodes).
 const METRICS = [
   { key: 'cpu', measurement: 'cpu', field: 'usage_idle', label: 'CPU Used', unit: '%', invert: true },
-  { key: 'cpu_user', measurement: 'cpu', field: 'usage_user', label: 'CPU User', unit: '%' },
-  { key: 'cpu_system', measurement: 'cpu', field: 'usage_system', label: 'CPU System', unit: '%' },
-  { key: 'cpu_iowait', measurement: 'cpu', field: 'usage_iowait', label: 'CPU IOWait', unit: '%' },
   { key: 'mem', measurement: 'mem', field: 'used_percent', label: 'Memory Used', unit: '%' },
-  { key: 'swap', measurement: 'swap', field: 'used_percent', label: 'Swap Used', unit: '%' },
   { key: 'disk', measurement: 'disk', field: 'used_percent', label: 'Disk Used', unit: '%' },
-  { key: 'diskio_read', measurement: 'diskio', field: 'read_bytes', label: 'Disk Read', unit: 'B' },
-  { key: 'diskio_write', measurement: 'diskio', field: 'write_bytes', label: 'Disk Write', unit: 'B' },
+  { key: 'diskio', measurement: 'diskio', field: 'read_bytes', label: 'Disk IO', unit: 'B' },
   { key: 'net_recv', measurement: 'net', field: 'bytes_recv', label: 'Net Recv', unit: 'B' },
   { key: 'net_sent', measurement: 'net', field: 'bytes_sent', label: 'Net Sent', unit: 'B' },
-  { key: 'load1', measurement: 'system', field: 'load1', label: 'Load (1m)', unit: '' },
-  { key: 'procs', measurement: 'processes', field: 'total', label: 'Processes', unit: '' },
 ];
 
 function fmtValue(val, unit) {
@@ -69,8 +64,11 @@ function toSeries(res, name, invert) {
 }
 
 export default function K8sAgentMonitor({ nsId }) {
+  const navigate = useNavigate();
+  const base = useBasePath();
   const [clusters, setClusters] = useState([]);
-  const [nodesMap, setNodesMap] = useState({}); // clusterId -> [nodeName]
+  const [nodesMap, setNodesMap] = useState({}); // clusterId -> [{node, running}]
+  const [statusLoaded, setStatusLoaded] = useState({}); // clusterId -> bool (agent status fetched)
   const [data, setData] = useState({}); // `${clusterId}/${node}` -> { cpu:{res}, ... }
   const [selectedChart, setSelectedChart] = useState('cpu');
   const [loading, setLoading] = useState(true);
@@ -79,21 +77,24 @@ export default function K8sAgentMonitor({ nsId }) {
     if (!nsId) { setClusters([]); setLoading(false); return; }
     let alive = true;
     setLoading(true);
-    setData({}); setNodesMap({});
+    setData({}); setNodesMap({}); setStatusLoaded({});
     getK8sClusters(nsId)
       .then(async (cs) => {
         const arr = Array.isArray(cs) ? cs : [];
         if (!alive) return;
         setClusters(arr);
         for (const c of arr) {
-          let nodes = [];
+          let statuses = [];
           try {
             const st = await getK8sAgentStatus(nsId, c.id);
-            nodes = (Array.isArray(st) ? st : []).map((n) => n.node);
-          } catch { nodes = []; }
+            statuses = Array.isArray(st) ? st : [];
+          } catch { statuses = []; }
           if (!alive) return;
-          setNodesMap((m) => ({ ...m, [c.id]: nodes }));
-          for (const node of nodes) {
+          setNodesMap((m) => ({ ...m, [c.id]: statuses }));
+          setStatusLoaded((m) => ({ ...m, [c.id]: true }));
+          // Only nodes with the agent actually running have metrics to load.
+          for (const s of statuses.filter((n) => n.running)) {
+            const node = s.node;
             METRICS.forEach(async (mt) => {
               try {
                 const res = await getMetricsByNode(nsId, c.id, node, {
@@ -112,13 +113,19 @@ export default function K8sAgentMonitor({ nsId }) {
     return () => { alive = false; };
   }, [nsId]);
 
+  function openNode(clusterId, node) {
+    navigate(`${base}/monitoring/${nsId}/${clusterId}/${node}?source=agent&k8s=1`);
+  }
+
   if (loading) return <div className="text-sm text-gray-400 animate-pulse p-4">Loading K8s agent metrics…</div>;
   if (clusters.length === 0) return <div className="bg-white rounded-lg shadow p-8 text-center text-sm text-gray-400">No K8s clusters in this namespace</div>;
 
   return (
     <>
       {clusters.map((c) => {
-        const nodes = nodesMap[c.id] || [];
+        const statuses = nodesMap[c.id] || [];
+        const installed = statuses.filter((n) => n.running);
+        const loaded = statusLoaded[c.id];
         return (
           <div key={c.id} className="bg-white rounded-lg shadow">
             <div className="px-4 py-3 border-b flex items-center gap-3">
@@ -126,14 +133,19 @@ export default function K8sAgentMonitor({ nsId }) {
               <span className="text-[10px] uppercase tracking-wide text-gray-400 font-medium">Cluster</span>
               <span className="font-semibold text-sm truncate">{c.name || c.id}</span>
               <span className={`text-xs px-2 py-0.5 rounded-full ${(c.status || '').includes('Active') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{c.status || '-'}</span>
-              <span className="text-xs text-gray-400 ml-auto">{nodes.length} agent node(s)</span>
+              <span className="text-xs text-gray-400 ml-auto">
+                {!loaded ? 'checking agents…' : `${installed.length} agent node(s)`}
+              </span>
             </div>
             <div className="p-3 space-y-3">
-              {nodes.length === 0
+              {!loaded
+                ? <div className="p-6 text-center text-xs text-gray-400 animate-pulse">Checking agent status…</div>
+                : installed.length === 0
                 ? <div className="p-6 text-center text-xs text-gray-400">No host agent installed — install from the Config menu.</div>
-                : nodes.map((node) => (
-                  <NodeCard key={node} node={node} metrics={data[`${c.id}/${node}`] || {}}
-                    selectedChart={selectedChart} onSelectChart={setSelectedChart} />
+                : installed.map((s) => (
+                  <NodeCard key={s.node} node={s.node} metrics={data[`${c.id}/${s.node}`] || {}}
+                    selectedChart={selectedChart} onSelectChart={setSelectedChart}
+                    onOpen={() => openNode(c.id, s.node)} />
                 ))}
             </div>
           </div>
@@ -143,7 +155,7 @@ export default function K8sAgentMonitor({ nsId }) {
   );
 }
 
-function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
+function NodeCard({ node, metrics, selectedChart, onSelectChart, onOpen }) {
   const gauges = METRICS.map((m) => {
     const d = metrics[m.key];
     const last = d?.res ? getLastValue(d.res) : null;
@@ -155,11 +167,12 @@ function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
   const series = cd?.res ? toSeries(cd.res, active.label, active.invert) : [];
   return (
     <div className="bg-white rounded-lg border">
-      <div className="px-4 py-2 border-b">
+      <div className="px-4 py-2 border-b flex items-center justify-between">
         <span className="font-mono text-sm text-gray-700">{node}</span>
+        <button onClick={onOpen} className="text-xs text-blue-600 hover:underline">Detail →</button>
       </div>
       <div className="flex">
-        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r max-h-[360px] overflow-auto">
+        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r">
           {gauges.map((g) => (
             <button key={g.key} onClick={() => onSelectChart(g.key)}
               className={`text-left px-2 py-1.5 rounded ${selectedChart === g.key ? 'bg-blue-50 ring-1 ring-blue-200' : 'hover:bg-gray-50'}`}>
@@ -168,7 +181,7 @@ function NodeCard({ node, metrics, selectedChart, onSelectChart }) {
             </button>
           ))}
         </div>
-        <div className="flex-1 px-2 py-1 min-w-0">
+        <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onOpen} title="Open node detail">
           {cd?.res ? (
             <MetricChart title={`${active.label}${active.unit ? ` (${active.unit})` : ''}`} series={series} height={200} measurement={active.measurement} metric={active.field} />
           ) : (

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -36,15 +36,19 @@ export default function K8sAgentPanel({ nsId }) {
   useEffect(() => { load(); }, [load]);
 
   const loadStatus = useCallback(async (clusterId) => {
+    let ok = false;
     try {
       const s = await getK8sAgentStatus(nsId, clusterId);
       setStatusMap((m) => ({ ...m, [clusterId]: Array.isArray(s) ? s : [] }));
-    } catch { setStatusMap((m) => ({ ...m, [clusterId]: [] })); }
+      ok = true;
+    } catch { /* keep previous data + "Checking…" state; the periodic refresh retries */ }
     try {
       const l = await getK8sLogStatus(nsId, clusterId);
       setLogMap((m) => ({ ...m, [clusterId]: Array.isArray(l) ? l : [] }));
-    } catch { setLogMap((m) => ({ ...m, [clusterId]: [] })); }
-    setStatusLoaded((m) => ({ ...m, [clusterId]: true }));
+    } catch { /* log status is best-effort */ }
+    // Only mark "loaded" once the agent status actually came back, so a transient failure
+    // (e.g. rate limit) shows "Checking agent status…" instead of "No nodes".
+    if (ok) setStatusLoaded((m) => ({ ...m, [clusterId]: true }));
   }, [nsId]);
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -16,6 +16,7 @@ export default function K8sAgentPanel({ nsId }) {
   const [loading, setLoading] = useState(true);
   const [statusMap, setStatusMap] = useState({}); // clusterId -> [{node,running}]
   const [logMap, setLogMap] = useState({}); // clusterId -> [{node,running}]
+  const [statusLoaded, setStatusLoaded] = useState({}); // clusterId -> bool (agent status checked)
   const [sel, setSel] = useState(null); // { clusterId, node }
   const [metrics, setMetrics] = useState({ available: [], active: [] });
   const [picked, setPicked] = useState(new Set());
@@ -43,6 +44,7 @@ export default function K8sAgentPanel({ nsId }) {
       const l = await getK8sLogStatus(nsId, clusterId);
       setLogMap((m) => ({ ...m, [clusterId]: Array.isArray(l) ? l : [] }));
     } catch { setLogMap((m) => ({ ...m, [clusterId]: [] })); }
+    setStatusLoaded((m) => ({ ...m, [clusterId]: true }));
   }, [nsId]);
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);
@@ -72,7 +74,7 @@ export default function K8sAgentPanel({ nsId }) {
 
   const logRunning = (cid, node) => (logMap[cid] || []).find((n) => n.node === node)?.running;
 
-  if (loading) return null;
+  if (loading) return <div className="bg-white rounded-lg shadow p-4 text-sm text-gray-400 animate-pulse">Loading K8s clusters…</div>;
   if (clusters.length === 0) return null;
 
   return (
@@ -93,7 +95,7 @@ export default function K8sAgentPanel({ nsId }) {
               <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 font-medium">K8s</span>
               <span className="font-semibold text-sm">{c.name || c.id}</span>
               <span className={`text-xs px-2 py-0.5 rounded-full ${(c.status || '').includes('Active') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{c.status || '-'}</span>
-              <span className="text-xs text-gray-400">{nodes.length} Nodes</span>
+              <span className="text-xs text-gray-400">{statusLoaded[c.id] ? `${nodes.length} Nodes` : 'checking agents…'}</span>
             </div>
             <div className="overflow-auto">
               <table className="w-full text-sm">
@@ -103,7 +105,8 @@ export default function K8sAgentPanel({ nsId }) {
                   <th className="px-4 py-2.5 border-b text-gray-500">Log Agent</th>
                 </tr></thead>
                 <tbody>
-                  {nodes.length === 0 ? <tr><td colSpan={3} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
+                  {!statusLoaded[c.id] ? <tr><td colSpan={3} className="px-4 py-6 text-center text-gray-400 animate-pulse">Checking agent status…</td></tr>
+                  : nodes.length === 0 ? <tr><td colSpan={3} className="px-4 py-6 text-center text-gray-400">No nodes / status unavailable</td></tr>
                   : nodes.map((n) => {
                     const monOn = n.running;
                     const logOn = logRunning(c.id, n.node);

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   getK8sClusters, getK8sAgentStatus, getK8sLogStatus,
   installK8sNode, uninstallK8sNode, getK8sNodeMetrics,
@@ -48,6 +48,16 @@ export default function K8sAgentPanel({ nsId }) {
   }, [nsId]);
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);
+
+  // Periodically re-check agent status so transient states settle on their own (e.g. after a
+  // node restart). Skipped while an install/uninstall is running on a cluster.
+  const busyRef = useRef('');
+  useEffect(() => { busyRef.current = busy; }, [busy]);
+  useEffect(() => {
+    if (clusters.length === 0) return;
+    const id = setInterval(() => { if (!busyRef.current) clusters.forEach((c) => loadStatus(c.id)); }, 20000);
+    return () => clearInterval(id);
+  }, [clusters, loadStatus]);
 
   async function selectNode(clusterId, node) {
     setSel({ clusterId, node });

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -55,7 +55,7 @@ export default function K8sAgentPanel({ nsId }) {
   useEffect(() => { busyRef.current = busy; }, [busy]);
   useEffect(() => {
     if (clusters.length === 0) return;
-    const id = setInterval(() => { if (!busyRef.current) clusters.forEach((c) => loadStatus(c.id)); }, 20000);
+    const id = setInterval(() => { if (!busyRef.current) clusters.forEach((c) => loadStatus(c.id)); }, 10000);
     return () => clearInterval(id);
   }, [clusters, loadStatus]);
 

--- a/front/src/hooks/useScopeTargets.js
+++ b/front/src/hooks/useScopeTargets.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { getInfraList, getInfra } from '../api/tumblebug';
+import { getK8sClusters, getK8sAgentStatus } from '../api/k8sAgent';
+
+/**
+ * Combined scope targets for pickers that select an (infra/cluster, node) pair.
+ *
+ * VM infras and K8s clusters share the same InfluxDB tag schema
+ * (infra_id = infraId|clusterId, node_id = nodeName), so both plug into the same
+ * downstream (infra, node) monitoring/insight/alert APIs. This hook returns both
+ * lists plus a loading flag so callers can render a grouped picker.
+ */
+export default function useScopeTargets(nsId) {
+  const [infras, setInfras] = useState([]); // [{id,name}]
+  const [clusters, setClusters] = useState([]); // [{id,name}]
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!nsId) { setInfras([]); setClusters([]); return; }
+    let alive = true;
+    setLoading(true);
+    Promise.allSettled([getInfraList(nsId), getK8sClusters(nsId)])
+      .then(([a, b]) => {
+        if (!alive) return;
+        setInfras(a.status === 'fulfilled' && Array.isArray(a.value) ? a.value : []);
+        setClusters(b.status === 'fulfilled' && Array.isArray(b.value) ? b.value : []);
+      })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [nsId]);
+
+  return { infras, clusters, loading };
+}
+
+/** Load nodes for a selected target. K8s clusters resolve to their installed agent nodes. */
+export async function loadScopeNodes(nsId, targetId, isK8s) {
+  if (!nsId || !targetId) return [];
+  if (isK8s) {
+    const st = await getK8sAgentStatus(nsId, targetId);
+    return (Array.isArray(st) ? st : []).filter((n) => n.running).map((n) => ({ id: n.node, name: n.node }));
+  }
+  const d = await getInfra(nsId, targetId);
+  return d.node || [];
+}

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -5,6 +5,7 @@ import {
   getNotiChannels, getNotiHistory, sendTestNotification,
 } from '../api/trigger';
 import { getInfraList } from '../api/tumblebug';
+import { getK8sClusters, getK8sAgentStatus } from '../api/k8sAgent';
 import { formatLocalTime } from '../utils/time';
 import { useParams } from 'react-router-dom';
 
@@ -91,9 +92,25 @@ function PoliciesTab({ nsId, infraId }) {
 
   useEffect(() => {
     if (!nsId) { setInfras([]); return; }
-    // getInfraList returns each infra with its embedded `node` list, so VM selection
-    // works even when the route has no infraId (namespace-level alert page).
-    getInfraList(nsId).then(list => setInfras(list || [])).catch(() => setInfras([]));
+    let alive = true;
+    // getInfraList returns each VM infra with its embedded `node` list. K8s clusters are
+    // appended as pseudo-infras (node list = installed agent nodes) so alerts can target
+    // them too — k8s metrics share the same (infra_id, node_id) InfluxDB schema.
+    (async () => {
+      const [vmRes, clRes] = await Promise.allSettled([getInfraList(nsId), getK8sClusters(nsId)]);
+      const vms = vmRes.status === 'fulfilled' && Array.isArray(vmRes.value) ? vmRes.value : [];
+      const clusters = clRes.status === 'fulfilled' && Array.isArray(clRes.value) ? clRes.value : [];
+      const k8sInfras = await Promise.all(clusters.map(async (c) => {
+        let node = [];
+        try {
+          const st = await getK8sAgentStatus(nsId, c.id);
+          node = (Array.isArray(st) ? st : []).filter((n) => n.running).map((n) => ({ id: n.node, name: n.node }));
+        } catch { node = []; }
+        return { id: c.id, name: `[K8s] ${c.name || c.id}`, node, isK8s: true };
+      }));
+      if (alive) setInfras([...vms, ...k8sInfras]);
+    })();
+    return () => { alive = false; };
   }, [nsId]);
 
   async function handleDelete(id) {

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -344,7 +344,12 @@ export default function InfraOverview() {
 
       {/* Node Tab — grouped by Infra. When a specific infraId is selected via the
           URL/dropdown, narrow to that one; otherwise show every Infra in the NS. */}
-      {viewTab === 'node' && (infraId ? allInfras.filter(i => i.id === infraId || i.name === infraId) : allInfras).map((infra) => (
+      {viewTab === 'node' && (() => {
+        const list = infraId ? allInfras.filter(i => i.id === infraId || i.name === infraId) : allInfras;
+        if (list.length === 0) {
+          return <div className="bg-white rounded-lg shadow p-8 text-center text-sm text-gray-400">No nodes in this namespace</div>;
+        }
+        return list.map((infra) => (
         <div key={infra.id} className="bg-white rounded-lg shadow">
           {/* Infra group header */}
           <div className="px-4 py-3 border-b flex items-center gap-3">
@@ -370,7 +375,8 @@ export default function InfraOverview() {
             ))}
           </div>
         </div>
-      ))}
+        ));
+      })()}
     </div>
   );
 }

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -6,7 +6,7 @@ import {
   getPredictionHistory, runPrediction, getPredictionOptions,
   getServerErrorRecords, getServerErrorRecord, detectServerError, rerunServerErrorAnalysis,
 } from '../api/insight';
-import { getInfraList, getInfra } from '../api/tumblebug';
+import useScopeTargets, { loadScopeNodes } from '../hooks/useScopeTargets';
 import MetricChart from '../components/MetricChart';
 
 const TABS = ['Anomaly Detection', 'Prediction', 'Server Error Analysis'];
@@ -138,26 +138,22 @@ function AnomalyTab({ nsId, infraId, nodeId }) {
 function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
   const [measurement, setMeasurement] = useState('');
   const [interval, setInterval] = useState('');
-  // Scope: pick Infra, then optionally a Node (empty = all nodes).
+  // Scope: pick Infra/Cluster, then optionally a Node (empty = all nodes).
   const [infra, setInfra] = useState(infraId || '');
   const [node, setNode] = useState(nodeId || '');
-  const [infraList, setInfraList] = useState([]);
+  const { infras, clusters } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
 
   const measurements = options.measurements || [];
   const intervals = options.execution_intervals || [];
-
-  useEffect(() => {
-    if (!nsId) { setInfraList([]); return; }
-    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
-  }, [nsId]);
+  const isK8s = clusters.some((c) => c.id === infra);
 
   useEffect(() => {
     if (!nsId || !infra) { setNodeList([]); return; }
-    getInfra(nsId, infra).then((d) => setNodeList(d.node || [])).catch(() => setNodeList([]));
-  }, [nsId, infra]);
+    loadScopeNodes(nsId, infra, isK8s).then((ns) => setNodeList(ns)).catch(() => setNodeList([]));
+  }, [nsId, infra, isK8s]);
 
   async function submit(e) {
     e.preventDefault();
@@ -186,10 +182,19 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
         {/* Infra selector only when not already fixed by the path */}
         {!infraId && (
           <div>
-            <label className="block text-xs text-gray-600 mb-1">Scope — Infra</label>
+            <label className="block text-xs text-gray-600 mb-1">Scope — Infra / Cluster</label>
             <select value={infra} onChange={(e) => { setInfra(e.target.value); setNode(''); }} className="w-full border rounded px-3 py-1.5 text-sm">
-              <option value="">Select Infra</option>
-              {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+              <option value="">Select Infra / Cluster</option>
+              {infras.length > 0 && (
+                <optgroup label="VM Infra">
+                  {infras.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+                </optgroup>
+              )}
+              {clusters.length > 0 && (
+                <optgroup label="K8s Cluster">
+                  {clusters.map((c) => <option key={c.id} value={c.id}>{c.name || c.id}</option>)}
+                </optgroup>
+              )}
             </select>
           </div>
         )}
@@ -244,25 +249,21 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   const [loadedMeasurement, setLoadedMeasurement] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
-  // Scope: pick Infra, then optionally a Node (empty = all nodes).
+  // Scope: pick Infra/Cluster, then optionally a Node (empty = all nodes).
   const [pInfra, setPInfra] = useState(infraId || '');
   const [pNode, setPNode] = useState(nodeId || '');
-  const [infraList, setInfraList] = useState([]);
+  const { infras, clusters } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
+  const isK8s = clusters.some((c) => c.id === pInfra);
 
   useEffect(() => {
     getPredictionOptions().then((o) => setOptions(o || {})).catch(() => {});
   }, []);
 
   useEffect(() => {
-    if (!nsId) { setInfraList([]); return; }
-    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
-  }, [nsId]);
-
-  useEffect(() => {
     if (!nsId || !pInfra) { setNodeList([]); return; }
-    getInfra(nsId, pInfra).then((d) => setNodeList(d.node || [])).catch(() => setNodeList([]));
-  }, [nsId, pInfra]);
+    loadScopeNodes(nsId, pInfra, isK8s).then((ns) => setNodeList(ns)).catch(() => setNodeList([]));
+  }, [nsId, pInfra, isK8s]);
 
   async function loadHistory() {
     if (!pInfra) { setMsg('Select an Infra first.'); return; }
@@ -316,10 +317,19 @@ function PredictionTab({ nsId, infraId, nodeId }) {
           {/* Infra selector only when not already fixed by the path */}
           {!infraId && (
             <div>
-              <label className="block text-xs text-gray-600 mb-1">Scope — Infra</label>
+              <label className="block text-xs text-gray-600 mb-1">Scope — Infra / Cluster</label>
               <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={pInfra} onChange={(e) => { setPInfra(e.target.value); setPNode(''); }}>
-                <option value="">Select Infra</option>
-                {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+                <option value="">Select Infra / Cluster</option>
+                {infras.length > 0 && (
+                  <optgroup label="VM Infra">
+                    {infras.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+                  </optgroup>
+                )}
+                {clusters.length > 0 && (
+                  <optgroup label="K8s Cluster">
+                    {clusters.map((c) => <option key={c.id} value={c.id}>{c.name || c.id}</option>)}
+                  </optgroup>
+                )}
               </select>
             </div>
           )}

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -2,12 +2,14 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { queryLogs } from '../api/logs';
 import { getInfra, getInfraList } from '../api/tumblebug';
+import { getK8sClusters, getK8sLogStatus } from '../api/k8sAgent';
 import LogTable from '../components/LogTable';
 
 export default function LogViewer() {
   const { nsId, infraId, nodeId: routeNodeId } = useParams();
 
-  const [infraList, setInfraList] = useState([]);
+  const [infraList, setInfraList] = useState([]);   // VM infras
+  const [clusters, setClusters] = useState([]);     // K8s clusters
   const [selectedInfraId, setSelectedInfraId] = useState(infraId || '');
   const [nodes, setNodes] = useState([]);
   const [selectedNodeId, setSelectedNodeId] = useState(routeNodeId || '');
@@ -15,23 +17,36 @@ export default function LogViewer() {
   const [logs, setLogs] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  // NS level: load Infra list
-  useEffect(() => {
-    if (!nsId) return;
-    if (!infraId) {
-      getInfraList(nsId).then(setInfraList).catch(() => setInfraList([]));
-    } else {
-      setSelectedInfraId(infraId);
-    }
-  }, [nsId, infraId]);
+  // The Workload is locked when the route carries an infraId; otherwise it's a dropdown.
+  const locked = !!infraId;
+  const isK8s = clusters.some((c) => c.id === selectedInfraId);
 
-  // Load Node list when an Infra is selected
+  // Always load both VM infras and K8s clusters so we can populate the dropdown and
+  // know which kind the selected target is (for node loading + Loki labels are shared).
+  useEffect(() => {
+    if (!nsId) { setInfraList([]); setClusters([]); return; }
+    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
+    getK8sClusters(nsId).then((l) => setClusters(Array.isArray(l) ? l : [])).catch(() => setClusters([]));
+  }, [nsId]);
+
+  useEffect(() => { if (infraId) setSelectedInfraId(infraId); }, [infraId]);
+
+  // Load Node list when a target is selected — VM nodes from Tumblebug, K8s nodes from
+  // the log-agent status (only nodes with a running fluent-bit agent).
   useEffect(() => {
     if (!nsId || !selectedInfraId) { setNodes([]); return; }
-    getInfra(nsId, selectedInfraId)
-      .then((data) => setNodes(data.node || []))
-      .catch(() => setNodes([]));
-  }, [nsId, selectedInfraId]);
+    let alive = true;
+    if (isK8s) {
+      getK8sLogStatus(nsId, selectedInfraId)
+        .then((st) => { if (alive) setNodes((Array.isArray(st) ? st : []).filter((n) => n.running).map((n) => ({ id: n.node, name: n.node }))); })
+        .catch(() => { if (alive) setNodes([]); });
+    } else {
+      getInfra(nsId, selectedInfraId)
+        .then((data) => { if (alive) setNodes(data.node || []); })
+        .catch(() => { if (alive) setNodes([]); });
+    }
+    return () => { alive = false; };
+  }, [nsId, selectedInfraId, isK8s]);
 
   useEffect(() => {
     if (routeNodeId) setSelectedNodeId(routeNodeId);
@@ -54,21 +69,39 @@ export default function LogViewer() {
     if (e.key === 'Enter') search();
   };
 
+  // When locked, make sure the selected infra still shows a readable label even if the
+  // lists haven't resolved it (e.g. it isn't in this user's VM/cluster lists).
+  const lockedLabel =
+    infraList.find((i) => i.id === selectedInfraId)?.name
+    || clusters.find((c) => c.id === selectedInfraId)?.name
+    || selectedInfraId;
+
   return (
     <div className="space-y-4">
       <div className="bg-white rounded-lg shadow">
         <div className="px-4 py-3 border-b font-semibold text-sm">Log Manage</div>
         <div className="p-4">
           <div className="grid grid-cols-4 gap-4 mb-4">
-            {/* Workload */}
+            {/* Workload — locked to the route infraId, or a dropdown of VM infras + K8s clusters */}
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Workload</label>
-              {infraId ? (
-                <input className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50" value={infraId} readOnly />
+              {locked ? (
+                <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-100 text-gray-600" value={selectedInfraId} disabled>
+                  <option value={selectedInfraId}>{lockedLabel}</option>
+                </select>
               ) : (
                 <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedInfraId} onChange={(e) => { setSelectedInfraId(e.target.value); setSelectedNodeId(''); }}>
-                  <option value="">Select Infra</option>
-                  {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+                  <option value="">Select Infra / Cluster</option>
+                  {infraList.length > 0 && (
+                    <optgroup label="VM Infra">
+                      {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
+                    </optgroup>
+                  )}
+                  {clusters.length > 0 && (
+                    <optgroup label="K8s Cluster">
+                      {clusters.map((c) => <option key={c.id} value={c.id}>{c.name || c.id}</option>)}
+                    </optgroup>
+                  )}
                 </select>
               )}
             </div>

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -73,7 +73,7 @@ export default function MonitoringConfig() {
   const mutatingRef = useRef(false);
   useEffect(() => { mutatingRef.current = busy || globalBusy; }, [busy, globalBusy]);
   useEffect(() => {
-    const id = setInterval(() => { if (!mutatingRef.current) loadNodesRef.current(true); }, 20000);
+    const id = setInterval(() => { if (!mutatingRef.current) loadNodesRef.current(true); }, 10000);
     return () => clearInterval(id);
   }, []);
   useEffect(() => { getPlugins().then(setPlugins).catch(() => setPlugins([])); }, []);

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -24,9 +24,9 @@ export default function MonitoringConfig() {
   const [globalBusy, setGlobalBusy] = useState(false);
   const pollRef = useRef(null);
 
-  const loadNodes = useCallback(async () => {
+  const loadNodes = useCallback(async (silent = false) => {
     if (!nsId) return;
-    setLoading(true);
+    if (!silent) setLoading(true);
     try {
       if (infraId) {
         // Single Infra mode
@@ -59,11 +59,23 @@ export default function MonitoringConfig() {
         setAllInfras(enriched);
         setNodes(enriched.flatMap(i => i.node || []));
       }
-    } catch { setNodes([]); setAllInfras([]); }
-    setLoading(false);
+    } catch { if (!silent) { setNodes([]); setAllInfras([]); } }
+    if (!silent) setLoading(false);
   }, [nsId, infraId]);
 
   useEffect(() => { loadNodes(); return () => { if (pollRef.current) clearInterval(pollRef.current); }; }, [loadNodes]);
+
+  // Silently re-poll agent status so transient states (e.g. SERVICE_INACTIVE right after a
+  // VM suspend/resume, before the agent finishes restarting) self-correct without a manual
+  // refresh. Skipped while an install/uninstall or metric op is running.
+  const loadNodesRef = useRef(loadNodes);
+  useEffect(() => { loadNodesRef.current = loadNodes; }, [loadNodes]);
+  const mutatingRef = useRef(false);
+  useEffect(() => { mutatingRef.current = busy || globalBusy; }, [busy, globalBusy]);
+  useEffect(() => {
+    const id = setInterval(() => { if (!mutatingRef.current) loadNodesRef.current(true); }, 20000);
+    return () => clearInterval(id);
+  }, []);
   useEffect(() => { getPlugins().then(setPlugins).catch(() => setPlugins([])); }, []);
 
   async function selectNode(node) {

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -214,7 +214,7 @@ export default function MonitoringConfig() {
       <K8sAgentPanel nsId={nsId} />
 
       {/* Server list — grouped by Infra */}
-      {loading ? <div className="text-sm text-gray-400 p-4 animate-pulse">Loading...</div>
+      {loading ? <div className="bg-white rounded-lg shadow p-4 text-sm text-gray-400 animate-pulse">Loading servers & agent status…</div>
       : allInfras.map((infra) => {
         const infraNodes = filter ? (infra.node || []).filter((node) => (node.name || node.id || '').toLowerCase().includes(filter.toLowerCase())) : (infra.node || []);
         return (
@@ -233,29 +233,33 @@ export default function MonitoringConfig() {
                 <th className="px-4 py-2.5 border-b text-gray-500">Status</th>
                 <th className="px-4 py-2.5 border-b text-gray-500">Monitoring Agent</th>
                 <th className="px-4 py-2.5 border-b text-gray-500">Log Agent</th>
-                <th className="px-4 py-2.5 border-b text-gray-500 text-right">Actions</th>
               </tr></thead>
               <tbody>
-                {infraNodes.length === 0 ? <tr><td colSpan={6} className="px-4 py-6 text-center text-gray-400">No servers</td></tr>
-                : infraNodes.map((node) => (
+                {infraNodes.length === 0 ? <tr><td colSpan={5} className="px-4 py-6 text-center text-gray-400">No servers</td></tr>
+                : infraNodes.map((node) => {
+                  const run = nodeRunState(node.status);
+                  // VM agents (telegraf + fluent-bit) install together — the install/uninstall
+                  // control lives in the Monitoring Agent column (same layout as K8s nodes).
+                  const action = (run !== 'running' && !node.registered)
+                    ? <span className="text-xs text-gray-400" title="Node is not running; agent state unknown">—</span>
+                    : !node.registered
+                    ? <button onClick={(e) => handleInstall(e, node)} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
+                    : node.monitoring_agent_status === 'INSTALLING'
+                    ? <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>
+                    : <button onClick={(e) => handleUninstall(e, node)} disabled={busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
+                  return (
                   <tr key={node.id} onClick={() => selectNode(node)}
                     className={`cursor-pointer hover:bg-blue-50 ${selectedNode?.id === node.id ? 'bg-blue-100' : ''}`}>
                     <td className="px-4 py-2.5 border-b font-medium"><span className="inline-flex items-center gap-1.5"><ProviderBadge connectionName={node.connectionName} showLabel={false} />{node.name || node.id}</span></td>
                     <td className="px-4 py-2.5 border-b text-gray-500">{node.id}</td>
                     <td className="px-4 py-2.5 border-b"><Badge status={node.status} /></td>
-                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.monitoring_agent_status} run={nodeRunState(node.status)} /></td>
-                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.log_agent_status} run={nodeRunState(node.status)} /></td>
-                    <td className="px-4 py-2.5 border-b text-right">
-                      {nodeRunState(node.status) !== 'running' && !node.registered
-                        ? <span className="text-xs text-gray-400" title="Node is not running; agent state unknown">—</span>
-                        : !node.registered
-                        ? <button onClick={(e) => handleInstall(e, node)} disabled={busy} className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install Agent</button>
-                        : node.monitoring_agent_status === 'INSTALLING'
-                        ? <span className="text-sm text-yellow-600 animate-pulse">Installing...</span>
-                        : <button onClick={(e) => handleUninstall(e, node)} disabled={busy} className="text-sm text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                    <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex items-center gap-2"><AgentBadge status={node.monitoring_agent_status} run={run} />{action}</div>
                     </td>
+                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.log_agent_status} run={run} /></td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
         </div>

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -40,6 +40,10 @@ export default function MonitoringDashboard() {
   const { nsId, infraId, nodeId: routeNodeId } = useParams();
   const [searchParams] = useSearchParams();
   const initialSource = searchParams.get('source') || 'agent';
+  // K8s agent node detail: infraId is the clusterId and routeNodeId is the k8s node name.
+  // Metrics live in InfluxDB under the same (ns_id, infra_id, node_id) schema, but the node
+  // is NOT a Tumblebug VM — so skip the VM infra/node-list lookups.
+  const isK8s = searchParams.get('k8s') === '1';
 
   // Cascade selectors
   const [nodes, setNodes] = useState([]);
@@ -85,10 +89,16 @@ export default function MonitoringDashboard() {
   useEffect(() => {
     if (!nsId || !infraId) return;
     setNodesLoaded(false);
+    // K8s agent node: not a Tumblebug VM infra — synthesize the single node from the route.
+    if (isK8s) {
+      setNodes(routeNodeId ? [{ id: routeNodeId, name: routeNodeId }] : []);
+      setNodesLoaded(true);
+      return;
+    }
     getInfra(nsId, infraId)
       .then((data) => { setNodes(data.node || []); setNodesLoaded(true); })
       .catch(() => { setNodes([]); setNodesLoaded(true); });
-  }, [nsId, infraId]);
+  }, [nsId, infraId, isK8s, routeNodeId]);
 
   // Load all measurement fields (for metric dropdown options)
   const [activeItemNames, setActiveItemNames] = useState(null); // null = not loaded, Set = loaded
@@ -101,6 +111,9 @@ export default function MonitoringDashboard() {
   const [agentInstalled, setAgentInstalled] = useState(null);
   useEffect(() => {
     if (!nsId || !infraId || !selectedNodeId) { setAgentInstalled(null); return; }
+    // K8s agent nodes are not in the VM node list; we arrived here because the agent
+    // is installed and reporting metrics, so don't show the "not installed" notice.
+    if (isK8s) { setAgentInstalled(true); return; }
     let alive = true;
     getNodeList(nsId, infraId)
       .then((list) => {
@@ -111,7 +124,7 @@ export default function MonitoringDashboard() {
       })
       .catch(() => { if (alive) setAgentInstalled(null); });
     return () => { alive = false; };
-  }, [nsId, infraId, selectedNodeId]);
+  }, [nsId, infraId, selectedNodeId, isK8s]);
 
   // Load active items for selected Node → filter measurements
   useEffect(() => {

--- a/front/src/pages/NamespaceHome.jsx
+++ b/front/src/pages/NamespaceHome.jsx
@@ -30,21 +30,42 @@ export default function NamespaceHome() {
   useEffect(() => {
     let alive = true;
     setLoading(true);
+    // Retry a call a couple of times on 429 — cb-tumblebug rate-limits bursts, and the
+    // k8sCluster lookup can be heavy.
+    const withRetry = async (fn) => {
+      for (let i = 0; i < 3; i++) {
+        try { return await fn(); }
+        catch (e) {
+          if (e?.response?.status === 429 && i < 2) {
+            await new Promise((r) => setTimeout(r, 500 * (i + 1)));
+            continue;
+          }
+          throw e;
+        }
+      }
+    };
     getNsList()
       .then(async (list) => {
         const arr = Array.isArray(list) ? list : [];
         if (alive) { setNsList(arr); setLoading(false); setCounting(true); }
-        // best-effort infra + k8s cluster counts per namespace
-        const entries = await Promise.all(
-          arr.map(async (ns) => {
-            const [inf, cl] = await Promise.allSettled([getInfraList(ns.id), getK8sClusters(ns.id)]);
-            return [ns.id, {
+        // Count infra + k8s per namespace SEQUENTIALLY (avoid bursting the rate limiter) and
+        // fill each card in as it resolves.
+        for (const ns of arr) {
+          if (!alive) return;
+          const [inf, cl] = await Promise.allSettled([
+            withRetry(() => getInfraList(ns.id)),
+            withRetry(() => getK8sClusters(ns.id)),
+          ]);
+          if (!alive) return;
+          setCounts((c) => ({
+            ...c,
+            [ns.id]: {
               infra: inf.status === 'fulfilled' && Array.isArray(inf.value) ? inf.value.length : null,
               k8s: cl.status === 'fulfilled' && Array.isArray(cl.value) ? cl.value.length : null,
-            }];
-          })
-        );
-        if (alive) { setCounts(Object.fromEntries(entries)); setCounting(false); }
+            },
+          }));
+        }
+        if (alive) setCounting(false);
       })
       .catch(() => { if (alive) { setNsList([]); setLoading(false); setCounting(false); } });
     return () => { alive = false; };

--- a/front/src/pages/NamespaceHome.jsx
+++ b/front/src/pages/NamespaceHome.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getNsList, getInfraList } from '../api/tumblebug';
+import { getK8sClusters } from '../api/k8sAgent';
 import useParentNamespace from '../hooks/useParentNamespace';
 
 /**
@@ -13,8 +14,9 @@ export default function NamespaceHome() {
   const navigate = useNavigate();
   const parentNs = useParentNamespace(); // namespace from the embedding page (if any)
   const [nsList, setNsList] = useState([]);
-  const [counts, setCounts] = useState({}); // ns -> infra count
+  const [counts, setCounts] = useState({}); // ns -> { infra, k8s }
   const [loading, setLoading] = useState(true);
+  const [counting, setCounting] = useState(false); // infra/cluster counts being aggregated
 
   // If the parent page exposes a selected project, reflect it automatically:
   // resolve the displayed text against the ns list (by id or name) and open it.
@@ -31,22 +33,20 @@ export default function NamespaceHome() {
     getNsList()
       .then(async (list) => {
         const arr = Array.isArray(list) ? list : [];
-        if (alive) setNsList(arr);
-        // best-effort infra counts per namespace
+        if (alive) { setNsList(arr); setLoading(false); setCounting(true); }
+        // best-effort infra + k8s cluster counts per namespace
         const entries = await Promise.all(
           arr.map(async (ns) => {
-            try {
-              const infras = await getInfraList(ns.id);
-              return [ns.id, Array.isArray(infras) ? infras.length : 0];
-            } catch {
-              return [ns.id, null];
-            }
+            const [inf, cl] = await Promise.allSettled([getInfraList(ns.id), getK8sClusters(ns.id)]);
+            return [ns.id, {
+              infra: inf.status === 'fulfilled' && Array.isArray(inf.value) ? inf.value.length : null,
+              k8s: cl.status === 'fulfilled' && Array.isArray(cl.value) ? cl.value.length : null,
+            }];
           })
         );
-        if (alive) setCounts(Object.fromEntries(entries));
+        if (alive) { setCounts(Object.fromEntries(entries)); setCounting(false); }
       })
-      .catch(() => alive && setNsList([]))
-      .finally(() => alive && setLoading(false));
+      .catch(() => { if (alive) { setNsList([]); setLoading(false); setCounting(false); } });
     return () => { alive = false; };
   }, []);
 
@@ -76,7 +76,11 @@ export default function NamespaceHome() {
                 <div className="text-xs text-gray-400 break-all">{ns.id}</div>
               )}
               <div className="mt-2 text-xs text-gray-500">
-                {counts[ns.id] == null ? '—' : `${counts[ns.id]} infra`}
+                {counts[ns.id] == null ? (
+                  counting ? <span className="text-gray-400 animate-pulse">counting…</span> : '—'
+                ) : (
+                  `${counts[ns.id].infra ?? '—'} infra · ${counts[ns.id].k8s ?? '—'} k8s`
+                )}
               </div>
             </button>
           ))}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/trigger/ManagerAdapter.java
@@ -38,16 +38,28 @@ public class ManagerAdapter implements ManagerPort {
 
         } else if ("node".equalsIgnoreCase(vmScope)) {
             // 3. Map infra id using ns and node
-            VMDTO t = vmService.getByNsVm(nsId, nodeId);
+            VMDTO t = null;
+            try {
+                t = vmService.getByNsVm(nsId, nodeId);
+            } catch (Exception ignore) {
+                // Not a Tumblebug VM (e.g. a K8s agent node) — fall through to InfluxDB resolve.
+            }
 
-            influxId = t.getInfluxSeq();
-            if (influxId == null) {
-                String infraId = t.getInfraId();
-                if (infraId == null || infraId.isBlank()) {
-                    throw new IllegalStateException(
-                            "infraId not found for vm: ns=" + nsId + ", nodeId=" + nodeId);
+            if (t != null) {
+                influxId = t.getInfluxSeq();
+                if (influxId == null) {
+                    String infraId = t.getInfraId();
+                    if (infraId == null || infraId.isBlank()) {
+                        throw new IllegalStateException(
+                                "infraId not found for vm: ns=" + nsId + ", nodeId=" + nodeId);
+                    }
+                    influxId = influxDbService.resolveInfluxDb(nsId, infraId);
                 }
-                influxId = influxDbService.resolveInfluxDb(nsId, infraId);
+            } else {
+                // K8s node: metrics live in the shared InfluxDB; resolve by namespace.
+                // resolveInfluxDb falls back to a reachable DB when the exact tag combo
+                // isn't matched, so a bare nodeId is sufficient here.
+                influxId = influxDbService.resolveInfluxDb(nsId, nodeId);
             }
 
         } else {


### PR DESCRIPTION
## Summary
K8s 노드를 VM과 동일하게 다루도록 메뉴들을 확장하고 Config/첫화면 UX를 다듬음.
K8s agent 메트릭은 VM과 같은 InfluxDB 스키마(infra_id=clusterId, node_id=nodeName)라
대부분 프론트만으로 연결됨.

## Changes
- **Monitoring (Agent 탭)**: 항목을 cpu/mem/disk/diskio/net 6개로 축소,
  그래프 클릭 시 해당 노드 상세 화면으로 이동(VM과 동일), 미설치 노드는 표시 안 함
  (로딩중으로 남던 문제 해결).
- **Insight**: anomaly/prediction 대상에 K8s 클러스터·노드 선택 가능
- **Alert**: K8s 클러스터·노드를 알림 대상으로 등록 가능.
- **Log**: URL 경로에 infra id가 있으면 그걸로 고정(드롭다운 비활성),
  없으면 드롭다운으로 VM infra + K8s 클러스터 목록 제공. K8s 노드 로그 조회 가능.
- **Config**: VM 행의 설치/제거 버튼을 Monitoring Agent 컬럼으로 옮겨 K8s 노드와
  레이아웃 통일(Actions 컬럼 제거). 목록·노드 조회중 / agent 상태 체크중 로딩 표시.
- **첫 화면(Namespace 선택)**: namespace별 K8s 클러스터 수 집계 추가,
  집계 중에는 "counting…" 표시.
