### PR TITLE
fix: restart agents with sudo

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
@@ -129,9 +129,12 @@ public class TumblebugServiceImpl implements TumblebugService {
                     agent);
         }
 
+        // Must run with sudo: the SSH user (e.g. cb-user) cannot restart a systemd unit
+        // otherwise ("Interactive authentication required"), which left the agent inactive
+        // after a VM suspend/resume and surfaced as a 500 when toggling a metric.
         String command =
                 String.format(
-                        "systemctl restart cmp-%s-%s.service",
+                        "sudo systemctl restart cmp-%s-%s.service",
                         agent.name().toLowerCase().replace("_", "-"), sitecode.toLowerCase());
 
         String result = executeCommand(nsId, infraId, nodeId, command).trim();


### PR DESCRIPTION
## Problem
모니터링 에이전트가 설치된 VM을 suspend → resume 하면 Monitoring/Log Agent가
SERVICE_INACTIVE로 표시되고, 메트릭을 활성화하면 500이 남.

## Cause
매니저가 에이전트를 재시작할 때 `systemctl restart`를 **sudo 없이** 실행함.
SSH 사용자(cb-user)는 권한이 없어 "Interactive authentication required"로 실패 →
서비스가 안 뜨고, 환경에 따라 그 에러 문자열이 응답에 실리면 `AgentStatusException` → 500.

## Fix
restart 명령을 `sudo systemctl restart`로 변경. 모든 에이전트(telegraf/fluent-bit/beyla)
재시작에 적용됨.

## Verification
AWS Ubuntu 노드에서 재현: sudo 없이는 EXIT=1 / inactive, sudo로는 EXIT=0 / active 확인.
