### PR TITLE
fix: land k8s UX commits that missed main after #329 merged mid-development

### DIFF
--- a/front/src/api/logs.js
+++ b/front/src/api/logs.js
@@ -3,6 +3,25 @@ import client from './client';
 // NOTE: Loki labels renamed to NS_ID / INFRA_ID / NODE_ID (fluent-bit label rename
 // applied). JS identifiers reflect Tumblebug Infra/Node naming.
 
+// Best-effort level from a log line: bracketed tags, klog (I/W/E/F0623…), or a bare keyword.
+function deriveLevel(msg) {
+  if (!msg) return '';
+  const b = msg.match(/^\s*\[(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|FATAL|CRIT|CRITICAL)\]/i);
+  if (b) return b[1].toUpperCase();
+  const k = msg.match(/^([IWEF])\d{4}\s/);
+  if (k) return { I: 'INFO', W: 'WARN', E: 'ERROR', F: 'FATAL' }[k[1]];
+  const w = msg.match(/\b(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|CRITICAL)\b/);
+  if (w) return w[1].toUpperCase();
+  return '';
+}
+
+// Best-effort service from a syslog-style line: "Mon DD HH:MM:SS host <proc>[pid]: …".
+function deriveService(msg) {
+  if (!msg) return '';
+  const m = msg.match(/^[A-Z][a-z]{2}\s+\d+\s+[\d:]+\s+\S+\s+([\w.-]+?)(?:\[\d+\])?:\s/);
+  return m ? m[1] : '';
+}
+
 export async function queryLogs({ nsId, infraId, nodeId, keyword, limit = 50, rangeHours = 24 }) {
   let logql = `{NS_ID="${nsId}", INFRA_ID="${infraId}"`;
   if (nodeId) logql += `, NODE_ID="${nodeId}"`;
@@ -47,10 +66,10 @@ export async function queryLogs({ nsId, infraId, nodeId, keyword, limit = 50, ra
     return {
       timestamp: parsed.time || (e.timestamp ? new Date(e.timestamp / 1e6).toISOString() : ''),
       message,
-      level: e.labels?.level || parsed.level || '',
+      level: e.labels?.level || parsed.level || deriveLevel(message),
       node_id: e.labels?.NODE_ID || '',
       host: e.labels?.host || parsed.host || '',
-      service: parsed.service || e.labels?.service || '',
+      service: parsed.service || e.labels?.service || deriveService(message),
       source: parsed.source || e.labels?.source || '',
       labels: e.labels || {},
       raw: parsed,

--- a/front/src/api/logs.js
+++ b/front/src/api/logs.js
@@ -8,7 +8,9 @@ function deriveLevel(msg) {
   if (!msg) return '';
   const b = msg.match(/^\s*\[(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|FATAL|CRIT|CRITICAL)\]/i);
   if (b) return b[1].toUpperCase();
-  const k = msg.match(/^([IWEF])\d{4}\s/);
+  // klog severity token "<I|W|E|F>MMDD HH:MM:SS" — at the start (container logs) or embedded
+  // after a syslog prefix (e.g. "kubelet[4168]: E0623 05:15:04 …").
+  const k = msg.match(/(?:^|\s)([IWEF])\d{4}\s+\d{2}:\d{2}:\d{2}/);
   if (k) return { I: 'INFO', W: 'WARN', E: 'ERROR', F: 'FATAL' }[k[1]];
   const w = msg.match(/\b(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|CRITICAL)\b/);
   if (w) return w[1].toUpperCase();
@@ -66,7 +68,7 @@ export async function queryLogs({ nsId, infraId, nodeId, keyword, limit = 50, ra
     return {
       timestamp: parsed.time || (e.timestamp ? new Date(e.timestamp / 1e6).toISOString() : ''),
       message,
-      level: e.labels?.level || parsed.level || deriveLevel(message),
+      level: e.labels?.level || parsed.level || deriveLevel(message) || 'UNKNOWN',
       node_id: e.labels?.NODE_ID || '',
       host: e.labels?.host || parsed.host || '',
       service: parsed.service || e.labels?.service || deriveService(message),

--- a/front/src/api/logs.js
+++ b/front/src/api/logs.js
@@ -26,10 +26,27 @@ export async function queryLogs({ nsId, infraId, nodeId, keyword, limit = 50, ra
   if (!Array.isArray(entries)) return [];
   return entries.map((e) => {
     let parsed = {};
-    try { parsed = typeof e.value === 'string' ? JSON.parse(e.value) : (e.value || {}); } catch {}
+    let isJson = false;
+    try {
+      if (typeof e.value === 'string') { parsed = JSON.parse(e.value); isJson = true; }
+      else if (e.value) parsed = e.value;
+    } catch { parsed = {}; }
+    // VM agent ships structured JSON with a `message` key. The K8s agent (fluent-bit tailing
+    // container/syslog files) ships the raw line under `log`; container logs are CRI-formatted
+    // ("<ts> stdout|stderr F <msg>") so strip that prefix to show the real message.
+    let message = parsed.message;
+    if (!message) {
+      if (typeof parsed.log === 'string') {
+        const m = parsed.log.match(/^\S+\s+std(?:out|err)\s+[FP]\s+([\s\S]*)$/);
+        message = m ? m[1] : parsed.log;
+      } else if (!isJson && typeof e.value === 'string') {
+        message = e.value; // plain (non-JSON) log line
+      }
+    }
+    message = (message || '').replace(/\s+$/, '');
     return {
       timestamp: parsed.time || (e.timestamp ? new Date(e.timestamp / 1e6).toISOString() : ''),
-      message: parsed.message || '',
+      message,
       level: e.labels?.level || parsed.level || '',
       node_id: e.labels?.NODE_ID || '',
       host: e.labels?.host || parsed.host || '',

--- a/front/src/api/node.js
+++ b/front/src/api/node.js
@@ -23,6 +23,20 @@ export async function uninstallAgent(nsId, infraId, nodeId) {
   return res.data;
 }
 
+// Per-agent install/uninstall (monitoring = telegraf, log = fluent-bit) — managed independently.
+export async function installMonitoringAgent(nsId, infraId, nodeId) {
+  return (await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/monitoring-agent`)).data;
+}
+export async function uninstallMonitoringAgent(nsId, infraId, nodeId) {
+  return (await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/monitoring-agent`)).data;
+}
+export async function installLogAgent(nsId, infraId, nodeId) {
+  return (await client.post(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/log-agent`)).data;
+}
+export async function uninstallLogAgent(nsId, infraId, nodeId) {
+  return (await client.delete(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/log-agent`)).data;
+}
+
 export async function getNodeItems(nsId, infraId, nodeId) {
   const res = await client.get(`/api/o11y/monitoring/${nsId}/${infraId}/node/${nodeId}/item`);
   return res.data?.data || [];

--- a/front/src/components/EmbedLayout.jsx
+++ b/front/src/components/EmbedLayout.jsx
@@ -1,6 +1,8 @@
 import { Outlet } from 'react-router-dom';
+import useFollowParentNamespace from '../hooks/useFollowParentNamespace';
 
 export default function EmbedLayout() {
+  useFollowParentNamespace(); // follow parent-page namespace changes for the whole session
   return (
     <div className="h-screen overflow-auto p-4">
       <Outlet />

--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -23,6 +23,7 @@ export default function K8sAgentPanel({ nsId }) {
   const [metricLoading, setMetricLoading] = useState(false);
   const [busy, setBusy] = useState('');
   const [busyMsg, setBusyMsg] = useState('');
+  const [applied, setApplied] = useState(''); // `${clusterId}/${node}` after a successful Apply
 
   const load = useCallback(() => {
     if (!nsId) { setClusters([]); setLoading(false); return; }
@@ -65,6 +66,7 @@ export default function K8sAgentPanel({ nsId }) {
 
   async function selectNode(clusterId, node) {
     setSel({ clusterId, node });
+    setApplied('');
     setMetricLoading(true);
     setMetrics({ available: [], active: [] });
     try {
@@ -169,12 +171,22 @@ export default function K8sAgentPanel({ nsId }) {
                         );
                       })}
                     </div>
-                    <button onClick={() => run(`${c.id}/${sel.node}/mon`, `Applying metrics on ${sel.node}…`, async () => { await installK8sNode(nsId, c.id, sel.node, [...picked]); setTimeout(() => selectNode(c.id, sel.node), 1200); }, c.id)}
+                    <button onClick={() => run(`${c.id}/${sel.node}/mon`, `Applying metrics on ${sel.node}…`, async () => {
+                        await installK8sNode(nsId, c.id, sel.node, [...picked]);
+                        // Keep the user's selection visible. Refresh the available list but do NOT
+                        // reset `picked` from InfluxDB-derived "active" — metrics take ~1 min to
+                        // start flowing after install, so active would be empty and wrongly clear
+                        // every checkbox.
+                        try { const m = await getK8sNodeMetrics(nsId, c.id, sel.node); setMetrics((prev) => ({ ...prev, available: m.available || prev.available, active: m.active || [] })); } catch { /* keep current */ }
+                        setApplied(`${c.id}/${sel.node}`);
+                      }, c.id)}
                       disabled={!!busy || picked.size === 0}
                       className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50">
                       Apply (install selected)
                     </button>
-                    <span className="ml-3 text-xs text-gray-400">Re-installs the monitoring agent with the selected inputs.</span>
+                    {applied === `${c.id}/${sel.node}`
+                      ? <span className="ml-3 text-xs text-green-600">Applied — the agent is installing; metrics &amp; Running status appear within ~1 min.</span>
+                      : <span className="ml-3 text-xs text-gray-400">Re-installs the monitoring agent with the selected inputs.</span>}
                   </>
                 )}
               </div>

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
+import useFollowParentNamespace from '../hooks/useFollowParentNamespace';
 import { setApiToken } from '../api/client';
 import { getInfraList, getInfra } from '../api/tumblebug';
 
@@ -21,6 +22,7 @@ export default function Layout() {
   const navigate = useNavigate();
   const base = useBasePath();
   const location = useLocation();
+  useFollowParentNamespace(); // follow parent-page namespace changes for the whole session
 
   const currentSection = navItems.find((n) => location.pathname.includes(`/${n.path}/`))?.path || 'monitoring';
 

--- a/front/src/hooks/useFollowParentNamespace.js
+++ b/front/src/hooks/useFollowParentNamespace.js
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import useParentNamespace from './useParentNamespace';
+import useBasePath from './useBasePath';
+import { getNsList } from '../api/tumblebug';
+
+const SECTIONS = ['monitoring', 'logs', 'config', 'insight', 'alerts', 'trace'];
+
+// Pull the section (if any) and the namespace out of the current path, ignoring the
+// optional /embed base. Paths look like `/{ns}`, `/{ns}/{infra}[/{node}]`, or
+// `/{section}/{ns}/...`.
+function parsePath(pathname, base) {
+  let p = pathname;
+  if (base && p.startsWith(base)) p = p.slice(base.length);
+  const segs = p.split('/').filter(Boolean);
+  if (segs.length && SECTIONS.includes(segs[0])) return { section: segs[0], ns: segs[1] || '' };
+  return { section: '', ns: segs[0] || '' };
+}
+
+/**
+ * Keeps the embedded app's namespace in sync with the parent page's project selector for the
+ * WHOLE session — not just on first load. When the parent switches namespace, navigate the
+ * iframe to the same section under the new namespace (infra/node context is dropped since it's
+ * namespace-specific). Mount once in each top-level shell.
+ */
+export default function useFollowParentNamespace() {
+  const parentNs = useParentNamespace();
+  const navigate = useNavigate();
+  const base = useBasePath();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (!parentNs) return;
+    let alive = true;
+    const { section, ns: currentNs } = parsePath(pathname, base);
+    // Resolve the parent's displayed text (could be an id or a name) to a namespace id.
+    getNsList()
+      .then((list) => {
+        if (!alive) return;
+        const match = (list || []).find((n) => n.id === parentNs || n.name === parentNs);
+        const targetNs = match ? match.id : parentNs;
+        if (targetNs && targetNs !== currentNs) {
+          navigate(`${base}/${section ? section + '/' : ''}${targetNs}`, { replace: true });
+        }
+      })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [parentNs, pathname, base, navigate]);
+}

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -104,7 +104,9 @@ function PoliciesTab({ nsId, infraId }) {
         let node = [];
         try {
           const st = await getK8sAgentStatus(nsId, c.id);
-          node = (Array.isArray(st) ? st : []).filter((n) => n.running).map((n) => ({ id: n.node, name: n.node }));
+          // List every cluster node (not only ones currently "running") so a target can be set
+          // even right after install, before the agent's InfluxDB data has started flowing.
+          node = (Array.isArray(st) ? st : []).map((n) => ({ id: n.node, name: n.node }));
         } catch { node = []; }
         return { id: c.id, name: `[K8s] ${c.name || c.id}`, node, isK8s: true };
       }));

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -558,24 +558,22 @@ function ChannelPicker({ channels, value, onChange }) {
   );
 }
 
-// Pick an infra, then its VMs. Infra level = multi-select VMs; Node level = a single VM.
-// Both are added as `node` targets. Works at namespace-level (route has no infraId) by
-// letting the user choose the infra from the dropdown.
+// Pick an Infra/Cluster, then check one or more of its nodes. All selections are added as
+// `node` targets. Works at namespace-level (route has no infraId) by letting the user choose
+// the infra/cluster from the dropdown.
 function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
   const matchInfra = (i) => i.id === defaultInfraId || i.name === defaultInfraId;
   const [selInfra, setSelInfra] = useState(() => {
     const m = (infras || []).find(matchInfra);
     return m ? (m.id ?? m.name) : (infras?.[0]?.id ?? infras?.[0]?.name ?? '');
   });
-  const [level, setLevel] = useState('infra');
-  const [checked, setChecked] = useState({}); // nodeId -> bool (infra level)
-  const [single, setSingle] = useState('');   // node level
+  const [checked, setChecked] = useState({}); // nodeId -> bool
 
   if (!nsId) {
-    return <p className="text-xs text-gray-400">Select a namespace to choose target VMs.</p>;
+    return <p className="text-xs text-gray-400">Select a namespace to choose target nodes.</p>;
   }
   if (!infras || infras.length === 0) {
-    return <p className="text-xs text-gray-400">No infras found in this namespace.</p>;
+    return <p className="text-xs text-gray-400">No infras / clusters found in this namespace.</p>;
   }
 
   const infra = infras.find(i => String(i.id ?? i.name) === String(selInfra)) || infras[0];
@@ -584,25 +582,21 @@ function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
   const toggle = (id) => setChecked(prev => ({ ...prev, [id]: !prev[id] }));
 
   const commit = () => {
-    let targets = [];
-    if (level === 'infra') {
-      targets = nodes.filter(n => checked[nodeIdOf(n)]).map(n => ({ targetScope: 'node', targetId: nodeIdOf(n), label: nodeLabelOf(n) }));
-    } else if (single) {
-      const n = nodes.find(x => String(nodeIdOf(x)) === String(single));
-      if (n) targets = [{ targetScope: 'node', targetId: nodeIdOf(n), label: nodeLabelOf(n) }];
-    }
-    if (!targets.length) { alert('Select at least one VM.'); return; }
+    const targets = nodes
+      .filter(n => checked[nodeIdOf(n)])
+      .map(n => ({ targetScope: 'node', targetId: nodeIdOf(n), label: nodeLabelOf(n) }));
+    if (!targets.length) { alert('Select at least one node.'); return; }
     onAdd(targets);
-    setChecked({}); setSingle('');
+    setChecked({});
   };
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 text-xs">
-        <span className="text-gray-500">Infra</span>
+        <span className="text-gray-500">Infra / Cluster</span>
         <select
           value={selInfra}
-          onChange={e => { setSelInfra(e.target.value); setChecked({}); setSingle(''); }}
+          onChange={e => { setSelInfra(e.target.value); setChecked({}); }}
           className="border rounded px-2 py-1 text-xs">
           {infras.map(i => {
             const id = i.id ?? i.name;
@@ -611,18 +605,9 @@ function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
         </select>
       </div>
 
-      <div className="flex items-center gap-4 text-xs">
-        <label className="flex items-center gap-1 cursor-pointer">
-          <input type="radio" name={`level-${selInfra}`} checked={level === 'infra'} onChange={() => setLevel('infra')} /> Infra (select VMs)
-        </label>
-        <label className="flex items-center gap-1 cursor-pointer">
-          <input type="radio" name={`level-${selInfra}`} checked={level === 'node'} onChange={() => setLevel('node')} /> Node (single VM)
-        </label>
-      </div>
-
       {nodes.length === 0 ? (
-        <p className="text-xs text-gray-400">No VMs found in this infra.</p>
-      ) : level === 'infra' ? (
+        <p className="text-xs text-gray-400">No nodes found in this infra / cluster.</p>
+      ) : (
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           {nodes.map(n => {
             const id = nodeIdOf(n);
@@ -634,14 +619,6 @@ function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
             );
           })}
         </div>
-      ) : (
-        <select value={single} onChange={e => setSingle(e.target.value)} className="border rounded px-2 py-1 text-xs">
-          <option value="">Select VM...</option>
-          {nodes.map(n => {
-            const id = nodeIdOf(n);
-            return <option key={id} value={id}>{nodeLabelOf(n)} ({id})</option>;
-          })}
-        </select>
       )}
 
       <button type="button" disabled={busy || nodes.length === 0} onClick={commit} className="bg-blue-600 text-white px-3 py-1 rounded text-xs hover:bg-blue-700 disabled:opacity-50">

--- a/front/src/pages/AlertManager.jsx
+++ b/front/src/pages/AlertManager.jsx
@@ -76,6 +76,7 @@ function PoliciesTab({ nsId, infraId }) {
   const [showCreate, setShowCreate] = useState(false);
   const [channels, setChannels] = useState([]); // available noti channels
   const [infras, setInfras] = useState([]);     // infras (each with embedded `node` list)
+  const [infrasLoading, setInfrasLoading] = useState(true);
   const [expanded, setExpanded] = useState(null);
 
   const load = () => {
@@ -91,8 +92,9 @@ function PoliciesTab({ nsId, infraId }) {
   }, []);
 
   useEffect(() => {
-    if (!nsId) { setInfras([]); return; }
+    if (!nsId) { setInfras([]); setInfrasLoading(false); return; }
     let alive = true;
+    setInfrasLoading(true);
     // getInfraList returns each VM infra with its embedded `node` list. K8s clusters are
     // appended as pseudo-infras (node list = installed agent nodes) so alerts can target
     // them too — k8s metrics share the same (infra_id, node_id) InfluxDB schema.
@@ -110,7 +112,7 @@ function PoliciesTab({ nsId, infraId }) {
         } catch { node = []; }
         return { id: c.id, name: `[K8s] ${c.name || c.id}`, node, isK8s: true };
       }));
-      if (alive) setInfras([...vms, ...k8sInfras]);
+      if (alive) { setInfras([...vms, ...k8sInfras]); setInfrasLoading(false); }
     })();
     return () => { alive = false; };
   }, [nsId]);
@@ -132,7 +134,7 @@ function PoliciesTab({ nsId, infraId }) {
         </div>
         {showCreate && (
           <CreatePolicyForm
-            nsId={nsId} infraId={infraId} channels={channels} infras={infras}
+            nsId={nsId} infraId={infraId} channels={channels} infras={infras} infrasLoading={infrasLoading}
             onCreated={() => { setShowCreate(false); load(); }}
           />
         )}
@@ -153,7 +155,7 @@ function PoliciesTab({ nsId, infraId }) {
               <tbody>
                 {policies.map(p => (
                   <PolicyRow
-                    key={p.id} p={p} nsId={nsId} infraId={infraId} channels={channels} infras={infras}
+                    key={p.id} p={p} nsId={nsId} infraId={infraId} channels={channels} infras={infras} infrasLoading={infrasLoading}
                     expanded={expanded === p.id} onToggle={() => setExpanded(expanded === p.id ? null : p.id)}
                     onChanged={load} onDelete={() => handleDelete(p.id)}
                   />
@@ -167,7 +169,7 @@ function PoliciesTab({ nsId, infraId }) {
   );
 }
 
-function PolicyRow({ p, nsId, infraId, channels, infras, expanded, onToggle, onChanged, onDelete }) {
+function PolicyRow({ p, nsId, infraId, channels, infras, infrasLoading, expanded, onToggle, onChanged, onDelete }) {
   const vms = p.vms || [];
   const chans = p.notiChannels || [];
   return (
@@ -191,7 +193,7 @@ function PolicyRow({ p, nsId, infraId, channels, infras, expanded, onToggle, onC
       {expanded && (
         <tr>
           <td colSpan={7} className="border-b bg-gray-50 px-4 py-3">
-            <ManagePanel p={p} nsId={nsId} infraId={infraId} channels={channels} infras={infras} onChanged={onChanged} />
+            <ManagePanel p={p} nsId={nsId} infraId={infraId} channels={channels} infras={infras} infrasLoading={infrasLoading} onChanged={onChanged} />
           </td>
         </tr>
       )}
@@ -199,7 +201,7 @@ function PolicyRow({ p, nsId, infraId, channels, infras, expanded, onToggle, onC
   );
 }
 
-function ManagePanel({ p, nsId, infraId, channels, infras, onChanged }) {
+function ManagePanel({ p, nsId, infraId, channels, infras, infrasLoading, onChanged }) {
   const vms = p.vms || [];
   const [busy, setBusy] = useState(false);
 
@@ -259,7 +261,8 @@ function ManagePanel({ p, nsId, infraId, channels, infras, onChanged }) {
             ))}
           </div>
         )}
-        <TargetPicker nsId={nsId} defaultInfraId={infraId} infras={infras} busy={busy} onAdd={addTargets} addLabel="Add targets" />
+        <TargetPicker nsId={nsId} defaultInfraId={infraId} infras={infras} infrasLoading={infrasLoading} busy={busy} onAdd={addTargets} addLabel="Add targets"
+          excludeIds={new Set((p.vms || []).map((v) => v.targetId))} />
       </div>
 
       <div>
@@ -355,7 +358,7 @@ function PolicySettingsEditor({ p, onChanged }) {
   );
 }
 
-function CreatePolicyForm({ nsId, infraId, channels, infras, onCreated }) {
+function CreatePolicyForm({ nsId, infraId, channels, infras, infrasLoading, onCreated }) {
   const [title, setTitle] = useState('');
   const [desc, setDesc] = useState('');
   const [resource, setResource] = useState('CPU');
@@ -458,7 +461,8 @@ function CreatePolicyForm({ nsId, infraId, channels, infras, onCreated }) {
             ))}
           </div>
         )}
-        <TargetPicker nsId={nsId} defaultInfraId={infraId} infras={infras} onAdd={addPending} addLabel="Add" />
+        <TargetPicker nsId={nsId} defaultInfraId={infraId} infras={infras} infrasLoading={infrasLoading} onAdd={addPending} addLabel="Add"
+          excludeIds={new Set(pendingTargets.map((t) => t.targetId))} />
       </div>
 
       {/* Notification channels */}
@@ -561,7 +565,7 @@ function ChannelPicker({ channels, value, onChange }) {
 // Pick an Infra/Cluster, then check one or more of its nodes. All selections are added as
 // `node` targets. Works at namespace-level (route has no infraId) by letting the user choose
 // the infra/cluster from the dropdown.
-function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
+function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel, infrasLoading, excludeIds }) {
   const matchInfra = (i) => i.id === defaultInfraId || i.name === defaultInfraId;
   const [selInfra, setSelInfra] = useState(() => {
     const m = (infras || []).find(matchInfra);
@@ -572,12 +576,18 @@ function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
   if (!nsId) {
     return <p className="text-xs text-gray-400">Select a namespace to choose target nodes.</p>;
   }
+  if (infrasLoading) {
+    return <p className="text-xs text-gray-400 animate-pulse">Loading infras / clusters…</p>;
+  }
   if (!infras || infras.length === 0) {
     return <p className="text-xs text-gray-400">No infras / clusters found in this namespace.</p>;
   }
 
   const infra = infras.find(i => String(i.id ?? i.name) === String(selInfra)) || infras[0];
-  const nodes = infra?.node || [];
+  // Hide nodes already added as targets (e.g. when editing an existing policy).
+  const exclude = excludeIds || new Set();
+  const allNodes = infra?.node || [];
+  const nodes = allNodes.filter((n) => !exclude.has(nodeIdOf(n)));
 
   const toggle = (id) => setChecked(prev => ({ ...prev, [id]: !prev[id] }));
 
@@ -606,7 +616,7 @@ function TargetPicker({ nsId, defaultInfraId, infras, busy, onAdd, addLabel }) {
       </div>
 
       {nodes.length === 0 ? (
-        <p className="text-xs text-gray-400">No nodes found in this infra / cluster.</p>
+        <p className="text-xs text-gray-400">{allNodes.length > 0 ? 'All nodes already added.' : 'No nodes found in this infra / cluster.'}</p>
       ) : (
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           {nodes.map(n => {

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -486,7 +486,7 @@ function AgentNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectC
     <div className="bg-white rounded-lg shadow">
       <NodeHeader node={node} showCspBadge={false} cspAvailable={cspSupported} />
       <div className="flex">
-        <div className="flex flex-col justify-center gap-2 px-4 py-3 w-52 shrink-0 border-r max-h-[380px] overflow-auto">
+        <div className="flex flex-col justify-start gap-2 px-4 py-3 w-52 shrink-0 border-r max-h-[380px] overflow-auto">
           {gauges.map((g) => (
             <GaugeItem key={g.key} g={g} active={selectedChart === g.key} onClick={() => onSelectChart(g.key)} noBar={g.unit !== '%'} />
           ))}

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -27,7 +27,6 @@ const AGENT_METRICS = [
   { key: 'net_recv', measurement: 'net', field: 'bytes_recv', label: 'Net Recv', unit: 'bytes' },
   { key: 'net_sent', measurement: 'net', field: 'bytes_sent', label: 'Net Sent', unit: 'bytes' },
   { key: 'load1', measurement: 'system', field: 'load1', label: 'Load (1m)', unit: '' },
-  { key: 'procs', measurement: 'processes', field: 'total', label: 'Processes', unit: '' },
 ];
 
 function fmtAgentValue(v, unit) {

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -141,7 +141,7 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
   // Scope: pick Infra/Cluster, then optionally a Node (empty = all nodes).
   const [infra, setInfra] = useState(infraId || '');
   const [node, setNode] = useState(nodeId || '');
-  const { infras, clusters } = useScopeTargets(nsId);
+  const { infras, clusters, loading: scopeLoading } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
   const [nodesLoading, setNodesLoading] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -191,7 +191,8 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
           <div>
             <label className="block text-xs text-gray-600 mb-1">Scope — Infra / Cluster</label>
             <select value={infra} onChange={(e) => { setInfra(e.target.value); setNode(''); }} className="w-full border rounded px-3 py-1.5 text-sm">
-              <option value="">Select Infra / Cluster</option>
+              <option value="">{scopeLoading ? 'Loading…' : 'Select Infra / Cluster'}</option>
+              {scopeLoading && <option disabled>Loading infras / clusters…</option>}
               {infras.length > 0 && (
                 <optgroup label="VM Infra">
                   {infras.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
@@ -259,7 +260,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   // Scope: pick Infra/Cluster, then optionally a Node (empty = all nodes).
   const [pInfra, setPInfra] = useState(infraId || '');
   const [pNode, setPNode] = useState(nodeId || '');
-  const { infras, clusters } = useScopeTargets(nsId);
+  const { infras, clusters, loading: scopeLoading } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
   const [nodesLoading, setNodesLoading] = useState(false);
   const isK8s = clusters.some((c) => c.id === pInfra);
@@ -333,7 +334,8 @@ function PredictionTab({ nsId, infraId, nodeId }) {
             <div>
               <label className="block text-xs text-gray-600 mb-1">Scope — Infra / Cluster</label>
               <select className="border border-gray-300 rounded px-3 py-1.5 text-sm" value={pInfra} onChange={(e) => { setPInfra(e.target.value); setPNode(''); }}>
-                <option value="">Select Infra / Cluster</option>
+                <option value="">{scopeLoading ? 'Loading…' : 'Select Infra / Cluster'}</option>
+                {scopeLoading && <option disabled>Loading infras / clusters…</option>}
                 {infras.length > 0 && (
                   <optgroup label="VM Infra">
                     {infras.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}

--- a/front/src/pages/InsightDashboard.jsx
+++ b/front/src/pages/InsightDashboard.jsx
@@ -143,6 +143,7 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
   const [node, setNode] = useState(nodeId || '');
   const { infras, clusters } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
+  const [nodesLoading, setNodesLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
 
@@ -152,7 +153,13 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
 
   useEffect(() => {
     if (!nsId || !infra) { setNodeList([]); return; }
-    loadScopeNodes(nsId, infra, isK8s).then((ns) => setNodeList(ns)).catch(() => setNodeList([]));
+    let alive = true;
+    setNodesLoading(true);
+    loadScopeNodes(nsId, infra, isK8s)
+      .then((ns) => { if (alive) setNodeList(ns); })
+      .catch(() => { if (alive) setNodeList([]); })
+      .finally(() => { if (alive) setNodesLoading(false); });
+    return () => { alive = false; };
   }, [nsId, infra, isK8s]);
 
   async function submit(e) {
@@ -201,8 +208,8 @@ function CreateAnomalyForm({ nsId, infraId, nodeId, options, onCreated }) {
         <div>
           <label className="block text-xs text-gray-600 mb-1">Scope — Node</label>
           <select value={node} onChange={(e) => setNode(e.target.value)} disabled={!infra} className="w-full border rounded px-3 py-1.5 text-sm disabled:bg-gray-100">
-            <option value="">All nodes</option>
-            {nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
+            <option value="">{nodesLoading ? 'Loading nodes…' : 'All nodes'}</option>
+            {nodesLoading ? <option disabled>Loading nodes…</option> : nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
           </select>
         </div>
         <div>
@@ -254,6 +261,7 @@ function PredictionTab({ nsId, infraId, nodeId }) {
   const [pNode, setPNode] = useState(nodeId || '');
   const { infras, clusters } = useScopeTargets(nsId);
   const [nodeList, setNodeList] = useState([]);
+  const [nodesLoading, setNodesLoading] = useState(false);
   const isK8s = clusters.some((c) => c.id === pInfra);
 
   useEffect(() => {
@@ -262,7 +270,13 @@ function PredictionTab({ nsId, infraId, nodeId }) {
 
   useEffect(() => {
     if (!nsId || !pInfra) { setNodeList([]); return; }
-    loadScopeNodes(nsId, pInfra, isK8s).then((ns) => setNodeList(ns)).catch(() => setNodeList([]));
+    let alive = true;
+    setNodesLoading(true);
+    loadScopeNodes(nsId, pInfra, isK8s)
+      .then((ns) => { if (alive) setNodeList(ns); })
+      .catch(() => { if (alive) setNodeList([]); })
+      .finally(() => { if (alive) setNodesLoading(false); });
+    return () => { alive = false; };
   }, [nsId, pInfra, isK8s]);
 
   async function loadHistory() {
@@ -336,8 +350,8 @@ function PredictionTab({ nsId, infraId, nodeId }) {
           <div>
             <label className="block text-xs text-gray-600 mb-1">Scope — Node</label>
             <select className="border border-gray-300 rounded px-3 py-1.5 text-sm disabled:bg-gray-100" value={pNode} onChange={(e) => setPNode(e.target.value)} disabled={!pInfra}>
-              <option value="">All nodes</option>
-              {nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
+              <option value="">{nodesLoading ? 'Loading nodes…' : 'All nodes'}</option>
+              {nodesLoading ? <option disabled>Loading nodes…</option> : nodeList.map((n) => <option key={n.id} value={n.id}>{n.name || n.id}</option>)}
             </select>
           </div>
           <div>

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -10,6 +10,7 @@ export default function LogViewer() {
 
   const [infraList, setInfraList] = useState([]);   // VM infras
   const [clusters, setClusters] = useState([]);     // K8s clusters
+  const [listLoading, setListLoading] = useState(false); // VM infra + k8s cluster list loading
   const [selectedInfraId, setSelectedInfraId] = useState(infraId || '');
   const [nodes, setNodes] = useState([]);
   const [nodesLoading, setNodesLoading] = useState(false);
@@ -26,8 +27,16 @@ export default function LogViewer() {
   // know which kind the selected target is (for node loading + Loki labels are shared).
   useEffect(() => {
     if (!nsId) { setInfraList([]); setClusters([]); return; }
-    getInfraList(nsId).then((l) => setInfraList(Array.isArray(l) ? l : [])).catch(() => setInfraList([]));
-    getK8sClusters(nsId).then((l) => setClusters(Array.isArray(l) ? l : [])).catch(() => setClusters([]));
+    let alive = true;
+    setListLoading(true);
+    Promise.allSettled([getInfraList(nsId), getK8sClusters(nsId)])
+      .then(([inf, cl]) => {
+        if (!alive) return;
+        setInfraList(inf.status === 'fulfilled' && Array.isArray(inf.value) ? inf.value : []);
+        setClusters(cl.status === 'fulfilled' && Array.isArray(cl.value) ? cl.value : []);
+      })
+      .finally(() => { if (alive) setListLoading(false); });
+    return () => { alive = false; };
   }, [nsId]);
 
   useEffect(() => { if (infraId) setSelectedInfraId(infraId); }, [infraId]);
@@ -96,7 +105,8 @@ export default function LogViewer() {
                 </select>
               ) : (
                 <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedInfraId} onChange={(e) => { setSelectedInfraId(e.target.value); setSelectedNodeId(''); }}>
-                  <option value="">Select Infra / Cluster</option>
+                  <option value="">{listLoading ? 'Loading…' : 'Select Infra / Cluster'}</option>
+                  {listLoading && <option disabled>Loading infras / clusters…</option>}
                   {infraList.length > 0 && (
                     <optgroup label="VM Infra">
                       {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}

--- a/front/src/pages/LogViewer.jsx
+++ b/front/src/pages/LogViewer.jsx
@@ -12,6 +12,7 @@ export default function LogViewer() {
   const [clusters, setClusters] = useState([]);     // K8s clusters
   const [selectedInfraId, setSelectedInfraId] = useState(infraId || '');
   const [nodes, setNodes] = useState([]);
+  const [nodesLoading, setNodesLoading] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState(routeNodeId || '');
   const [keyword, setKeyword] = useState('');
   const [logs, setLogs] = useState(null);
@@ -36,14 +37,18 @@ export default function LogViewer() {
   useEffect(() => {
     if (!nsId || !selectedInfraId) { setNodes([]); return; }
     let alive = true;
+    setNodesLoading(true);
+    const done = () => { if (alive) setNodesLoading(false); };
     if (isK8s) {
       getK8sLogStatus(nsId, selectedInfraId)
         .then((st) => { if (alive) setNodes((Array.isArray(st) ? st : []).filter((n) => n.running).map((n) => ({ id: n.node, name: n.node }))); })
-        .catch(() => { if (alive) setNodes([]); });
+        .catch(() => { if (alive) setNodes([]); })
+        .finally(done);
     } else {
       getInfra(nsId, selectedInfraId)
         .then((data) => { if (alive) setNodes(data.node || []); })
-        .catch(() => { if (alive) setNodes([]); });
+        .catch(() => { if (alive) setNodes([]); })
+        .finally(done);
     }
     return () => { alive = false; };
   }, [nsId, selectedInfraId, isK8s]);
@@ -109,8 +114,8 @@ export default function LogViewer() {
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Server</label>
               <select className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm" value={selectedNodeId} onChange={(e) => setSelectedNodeId(e.target.value)}>
-                <option value="">All</option>
-                {nodes.map((node) => <option key={node.id} value={node.id}>{node.name || node.id}</option>)}
+                <option value="">{nodesLoading ? 'Loading nodes…' : 'All'}</option>
+                {nodesLoading ? <option disabled>Loading nodes…</option> : nodes.map((node) => <option key={node.id} value={node.id}>{node.name || node.id}</option>)}
               </select>
             </div>
             {/* Keyword */}

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { getNodeList, getNode, getNodeItems, installAgent, uninstallAgent, createNodeItem, deleteNodeItem } from '../api/node';
+import {
+  getNodeList, getNode, getNodeItems, createNodeItem, deleteNodeItem,
+  installMonitoringAgent, uninstallMonitoringAgent, installLogAgent, uninstallLogAgent,
+} from '../api/node';
 import { getPlugins } from '../api/monitoring';
 import { getInfra, getInfraList } from '../api/tumblebug';
 import ProviderBadge from '../components/ProviderBadge';
@@ -83,7 +86,8 @@ export default function MonitoringConfig() {
     setSelectedNode(node);
     setSelectedNodeInfraId(node.infraId || infraId);
     setItems([]);
-    if (!node.registered) return;
+    // Metric config is for the monitoring (telegraf) agent — only load when it's installed.
+    if (!isAgentInstalled(node.monitoring_agent_status)) return;
     setItemLoading(true);
     try { setItems(await getNodeItems(nsId, node.infraId || infraId, node.id)); } catch { setItems([]); }
     setItemLoading(false);
@@ -112,58 +116,54 @@ export default function MonitoringConfig() {
     setBusy(false); setBusyMsg('');
   }
 
-  // --- Install / Uninstall with polling ---
-  async function handleInstall(e, node) {
+  // --- Per-agent install / uninstall with polling (monitoring = telegraf, log = fluent-bit) ---
+  const AGENT_API = {
+    monitoring: { install: installMonitoringAgent, uninstall: uninstallMonitoringAgent, field: 'monitoring_agent_status', label: 'monitoring agent' },
+    log: { install: installLogAgent, uninstall: uninstallLogAgent, field: 'log_agent_status', label: 'log agent' },
+  };
+
+  async function handleAgent(e, node, kind, op) {
     e.stopPropagation();
-    if (!confirm(`Install monitoring agent on "${node.name || node.id}"?`)) return;
+    const a = AGENT_API[kind];
+    const verb = op === 'install' ? 'Install' : 'Uninstall';
+    if (!confirm(`${verb} ${a.label} on "${node.name || node.id}"?`)) return;
+    const infra = node.infraId || infraId;
     setGlobalBusy(true);
-    setBusyMsg(`Installing agent on ${node.name || node.id}...`);
+    setBusyMsg(`${verb}ing ${a.label} on ${node.name || node.id}...`);
     try {
-      await installAgent(nsId, node.infraId || infraId, node.id);
-      startPolling(node.id);
+      await a[op](nsId, infra, node.id);
+      startPolling(node.id, infra, a.field, `${verb}ing ${a.label}`, kind, op);
     } catch (err) {
-      alert('Install failed: ' + (err.response?.data?.error_message || err.message));
+      alert(`${verb} failed: ` + (err.response?.data?.error_message || err.message));
       setGlobalBusy(false);
       setBusyMsg('');
     }
   }
 
-  async function handleUninstall(e, node) {
-    e.stopPropagation();
-    if (!confirm(`Uninstall monitoring agent from "${node.name || node.id}"?`)) return;
-    setGlobalBusy(true);
-    setBusyMsg(`Uninstalling agent from ${node.name || node.id}...`);
-    try {
-      await uninstallAgent(nsId, node.infraId || infraId, node.id);
-      await loadNodes();
-      if (selectedNode?.id === node.id) { setSelectedNode(null); setItems([]); }
-    } catch (err) {
-      alert('Uninstall failed: ' + (err.response?.data?.error_message || err.message));
-    }
-    setGlobalBusy(false);
-    setBusyMsg('');
-  }
-
-  function startPolling(nodeId) {
+  function startPolling(nodeId, infra, statusField, msgPrefix, kind, op) {
     if (pollRef.current) clearInterval(pollRef.current);
     let count = 0;
     pollRef.current = setInterval(async () => {
       count++;
       try {
-        const nodeData = await getNode(nsId, selectedNodeInfraId || infraId, nodeId);
-        const status = nodeData?.monitoring_agent_status || nodeData?.monitoringAgentStatus;
-        setBusyMsg(`Installing agent... (${status || 'checking'}) [${count * 5}s]`);
-        if (status === 'SUCCESS' || status === 'FAILED' || count > 60) {
+        const nodeData = await getNode(nsId, infra, nodeId);
+        const status = nodeData?.[statusField];
+        setBusyMsg(`${msgPrefix}... (${status || 'checking'}) [${count * 5}s]`);
+        // INSTALLING/UNINSTALLING are in-progress; any other resolved state ends the poll.
+        const done = status && !['INSTALLING', 'UNINSTALLING', 'PREPARING', 'IDLE'].includes(status);
+        if (done || count > 60) {
           clearInterval(pollRef.current);
           pollRef.current = null;
           setGlobalBusy(false);
           setBusyMsg('');
           await loadNodes();
-          if (status === 'SUCCESS') {
-            // Auto-select the Node to show items
-            const refreshedNodes = await getNodeList(nsId, infraId);
-            const found = refreshedNodes.find(n => (n.node_id || n.id) === nodeId);
-            if (found) selectNode({ ...found, id: nodeId, registered: true });
+          // After a successful monitoring install, auto-select the node to show its metrics.
+          if (kind === 'monitoring' && op === 'install' && (status === 'SUCCESS' || status === 'SERVICE_INACTIVE')) {
+            try {
+              const refreshed = await getNodeList(nsId, infra);
+              const found = refreshed.find((n) => (n.node_id || n.id) === nodeId);
+              if (found) selectNode({ ...found, infraId: infra, id: nodeId, registered: true });
+            } catch { /* ignore */ }
           }
         }
       } catch {
@@ -171,6 +171,9 @@ export default function MonitoringConfig() {
       }
     }, 5000);
   }
+
+  // An agent column shows Install when its status is missing/NOT_INSTALLED, Uninstall otherwise.
+  const isAgentInstalled = (status) => !!status && status !== 'NOT_INSTALLED';
 
   // --- Metric toggle with confirmation + overlay ---
   async function handleToggle(plugin, isActive) {
@@ -250,15 +253,15 @@ export default function MonitoringConfig() {
                 {infraNodes.length === 0 ? <tr><td colSpan={5} className="px-4 py-6 text-center text-gray-400">No servers</td></tr>
                 : infraNodes.map((node) => {
                   const run = nodeRunState(node.status);
-                  // VM agents (telegraf + fluent-bit) install/uninstall together, so the same
-                  // control is shown in BOTH the Monitoring Agent and Log Agent columns.
-                  const renderAction = () => (run !== 'running' && !node.registered)
-                    ? <span className="text-xs text-gray-400" title="Node is not running; agent state unknown">—</span>
-                    : !node.registered
-                    ? <button onClick={(e) => handleInstall(e, node)} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
-                    : node.monitoring_agent_status === 'INSTALLING'
-                    ? <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>
-                    : <button onClick={(e) => handleUninstall(e, node)} disabled={busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
+                  // Monitoring (telegraf) and Log (fluent-bit) agents are installed independently.
+                  const agentControl = (kind, status) => {
+                    const installed = isAgentInstalled(status);
+                    if (status === 'INSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>;
+                    if (status === 'UNINSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Uninstalling…</span>;
+                    if (installed) return <button onClick={(e) => handleAgent(e, node, kind, 'uninstall')} disabled={busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
+                    if (run !== 'running') return <span className="text-xs text-gray-400" title="Node is not running">—</span>;
+                    return <button onClick={(e) => handleAgent(e, node, kind, 'install')} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>;
+                  };
                   return (
                   <tr key={node.id} onClick={() => selectNode(node)}
                     className={`cursor-pointer hover:bg-blue-50 ${selectedNode?.id === node.id ? 'bg-blue-100' : ''}`}>
@@ -266,10 +269,10 @@ export default function MonitoringConfig() {
                     <td className="px-4 py-2.5 border-b text-gray-500">{node.id}</td>
                     <td className="px-4 py-2.5 border-b"><Badge status={node.status} /></td>
                     <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
-                      <div className="flex items-center gap-2"><AgentBadge status={node.monitoring_agent_status} run={run} />{renderAction()}</div>
+                      <div className="flex items-center gap-2"><AgentBadge status={node.monitoring_agent_status} run={run} />{agentControl('monitoring', node.monitoring_agent_status)}</div>
                     </td>
                     <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
-                      <div className="flex items-center gap-2"><AgentBadge status={node.log_agent_status} run={run} />{renderAction()}</div>
+                      <div className="flex items-center gap-2"><AgentBadge status={node.log_agent_status} run={run} />{agentControl('log', node.log_agent_status)}</div>
                     </td>
                   </tr>
                   );
@@ -300,11 +303,11 @@ export default function MonitoringConfig() {
                 </div>
               </div>
             )}
-            {!selectedNode.registered ? (
+            {!isAgentInstalled(selectedNode.monitoring_agent_status) ? (
               nodeRunState(selectedNode.status) === 'running' ? (
                 <div className="text-center py-6">
-                  <p className="text-sm text-gray-500 mb-3">Agent not installed.</p>
-                  <button onClick={(e) => handleInstall(e, selectedNode)} disabled={busy} className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50">Install Agent</button>
+                  <p className="text-sm text-gray-500 mb-3">Monitoring agent not installed.</p>
+                  <button onClick={(e) => handleAgent(e, selectedNode, 'monitoring', 'install')} disabled={busy} className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50">Install Monitoring Agent</button>
                 </div>
               ) : (
                 <div className="text-center py-6 text-sm text-gray-500">
@@ -351,13 +354,12 @@ function Badge({ status }) {
 }
 
 function AgentBadge({ status, run }) {
-  if (!status) {
-    // No agent status: only call it "Not installed" when the node is actually running.
-    // For stopped/terminated/undefined nodes we don't know the agent state.
-    return <span className="text-xs text-gray-400">{run === 'running' ? 'Not installed' : 'Unknown'}</span>;
+  if (!status || status === 'NOT_INSTALLED') {
+    // Not installed (or, for stopped/undefined nodes, state unknown).
+    return <span className="text-xs text-gray-400">{status === 'NOT_INSTALLED' || run === 'running' ? 'Not installed' : 'Unknown'}</span>;
   }
   const s = status.toUpperCase();
-  const c = s === 'SUCCESS' ? 'bg-green-100 text-green-700' : s === 'INSTALLING' ? 'bg-yellow-100 text-yellow-700' :
+  const c = s === 'SUCCESS' ? 'bg-green-100 text-green-700' : (s === 'INSTALLING' || s === 'UNINSTALLING') ? 'bg-yellow-100 text-yellow-700' :
     s === 'SERVICE_INACTIVE' ? 'bg-orange-100 text-orange-700' : s === 'FAILED' ? 'bg-red-100 text-red-700' : 'bg-gray-100 text-gray-500';
   return <span className={`text-xs px-2 py-0.5 rounded-full ${c}`}>{status}</span>;
 }

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -250,9 +250,9 @@ export default function MonitoringConfig() {
                 {infraNodes.length === 0 ? <tr><td colSpan={5} className="px-4 py-6 text-center text-gray-400">No servers</td></tr>
                 : infraNodes.map((node) => {
                   const run = nodeRunState(node.status);
-                  // VM agents (telegraf + fluent-bit) install together — the install/uninstall
-                  // control lives in the Monitoring Agent column (same layout as K8s nodes).
-                  const action = (run !== 'running' && !node.registered)
+                  // VM agents (telegraf + fluent-bit) install/uninstall together, so the same
+                  // control is shown in BOTH the Monitoring Agent and Log Agent columns.
+                  const renderAction = () => (run !== 'running' && !node.registered)
                     ? <span className="text-xs text-gray-400" title="Node is not running; agent state unknown">—</span>
                     : !node.registered
                     ? <button onClick={(e) => handleInstall(e, node)} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
@@ -266,9 +266,11 @@ export default function MonitoringConfig() {
                     <td className="px-4 py-2.5 border-b text-gray-500">{node.id}</td>
                     <td className="px-4 py-2.5 border-b"><Badge status={node.status} /></td>
                     <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
-                      <div className="flex items-center gap-2"><AgentBadge status={node.monitoring_agent_status} run={run} />{action}</div>
+                      <div className="flex items-center gap-2"><AgentBadge status={node.monitoring_agent_status} run={run} />{renderAction()}</div>
                     </td>
-                    <td className="px-4 py-2.5 border-b"><AgentBadge status={node.log_agent_status} run={run} /></td>
+                    <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex items-center gap-2"><AgentBadge status={node.log_agent_status} run={run} />{renderAction()}</div>
+                    </td>
                   </tr>
                   );
                 })}

--- a/front/src/pages/NsScopedApp.jsx
+++ b/front/src/pages/NsScopedApp.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import useBasePath from '../hooks/useBasePath';
+import useFollowParentNamespace from '../hooks/useFollowParentNamespace';
 import InfraOverview from './InfraOverview';
 import MonitoringDashboard from './MonitoringDashboard';
 
@@ -31,6 +32,7 @@ export default function NsScopedApp() {
   const { nsId, infraId, nodeId } = useParams();
   const navigate = useNavigate();
   const base = useBasePath();
+  useFollowParentNamespace(); // follow parent-page namespace changes for the whole session
 
   return (
     <div className="flex flex-col h-screen">

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/VMController.java
@@ -1,5 +1,6 @@
 package com.mcmp.o11ymanager.manager.controller;
 
+import com.mcmp.o11ymanager.manager.dto.vm.ResultDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.VMDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.VMRequestDTO;
 import com.mcmp.o11ymanager.manager.facade.VMFacadeService;
@@ -53,6 +54,42 @@ public class VMController {
             @RequestBody @Valid VMRequestDTO dto) {
         vmFacadeService.postVM(nsId, infraId, nodeId, dto);
         return new ResBody<>();
+    }
+
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/monitoring-agent")
+    @Operation(
+            summary = "InstallMonitoringAgent",
+            description = "Install only the monitoring agent (telegraf) on the node")
+    public ResBody<List<ResultDTO>> installMonitoringAgent(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId) {
+        return new ResBody<>(vmFacadeService.installMonitoringAgent(nsId, infraId, nodeId));
+    }
+
+    @DeleteMapping("/{nsId}/{infraId}/node/{nodeId}/monitoring-agent")
+    @Operation(
+            summary = "UninstallMonitoringAgent",
+            description = "Uninstall only the monitoring agent (telegraf) from the node")
+    public ResBody<List<ResultDTO>> uninstallMonitoringAgent(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId) {
+        return new ResBody<>(vmFacadeService.uninstallMonitoringAgent(nsId, infraId, nodeId));
+    }
+
+    @PostMapping("/{nsId}/{infraId}/node/{nodeId}/log-agent")
+    @Operation(
+            summary = "InstallLogAgent",
+            description = "Install only the log agent (fluent-bit) on the node")
+    public ResBody<List<ResultDTO>> installLogAgent(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId) {
+        return new ResBody<>(vmFacadeService.installLogAgent(nsId, infraId, nodeId));
+    }
+
+    @DeleteMapping("/{nsId}/{infraId}/node/{nodeId}/log-agent")
+    @Operation(
+            summary = "UninstallLogAgent",
+            description = "Uninstall only the log agent (fluent-bit) from the node")
+    public ResBody<List<ResultDTO>> uninstallLogAgent(
+            @PathVariable String nsId, @PathVariable String infraId, @PathVariable String nodeId) {
+        return new ResBody<>(vmFacadeService.uninstallLogAgent(nsId, infraId, nodeId));
     }
 
     @PutMapping("/{nsId}/{infraId}/node/{nodeId}")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/enums/AgentStatus.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/enums/AgentStatus.java
@@ -5,4 +5,5 @@ public enum AgentStatus {
     SERVICE_INACTIVE,
     SUCCESS,
     FAILED,
+    NOT_INSTALLED,
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
@@ -211,6 +211,12 @@ public class AgentFacadeService {
         if (taskStatus == VMAgentTaskStatus.FAILED) {
             return AgentStatus.FAILED;
         }
+        // This agent was never installed (or was uninstalled) on a node that still has the
+        // other agent — don't probe the (absent) service; report NOT_INSTALLED so the UI shows
+        // an Install button for it.
+        if (taskStatus == VMAgentTaskStatus.NOT_INSTALLED || taskStatus == null) {
+            return AgentStatus.NOT_INSTALLED;
+        }
 
         AgentServiceStatus serviceStatus = getAgentServiceStatus(nsId, infraId, nodeId, agent);
 
@@ -263,6 +269,90 @@ public class AgentFacadeService {
                             .build());
         }
 
+        return results;
+    }
+
+    // --- Per-agent install / uninstall (monitoring = telegraf, log = fluent-bit) ---------------
+    // VM monitoring and log agents can be installed/removed independently (same as K8s nodes).
+
+    @Transactional
+    public List<ResultDTO> installMonitoringAgent(String nsId, String infraId, String nodeId) {
+        return runAgentTask(
+                nsId,
+                infraId,
+                nodeId,
+                (accessInfo, templateCount) ->
+                        telegrafFacadeService.install(
+                                nsId, infraId, nodeId, accessInfo, templateCount));
+    }
+
+    @Transactional
+    public List<ResultDTO> uninstallMonitoringAgent(String nsId, String infraId, String nodeId) {
+        return runAgentTask(
+                nsId,
+                infraId,
+                nodeId,
+                (accessInfo, templateCount) ->
+                        telegrafFacadeService.uninstall(
+                                nsId, infraId, nodeId, accessInfo, templateCount));
+    }
+
+    @Transactional
+    public List<ResultDTO> installLogAgent(String nsId, String infraId, String nodeId) {
+        return runAgentTask(
+                nsId,
+                infraId,
+                nodeId,
+                (accessInfo, templateCount) ->
+                        fluentBitFacadeService.install(
+                                nsId, infraId, nodeId, accessInfo, templateCount));
+    }
+
+    @Transactional
+    public List<ResultDTO> uninstallLogAgent(String nsId, String infraId, String nodeId) {
+        return runAgentTask(
+                nsId,
+                infraId,
+                nodeId,
+                (accessInfo, templateCount) ->
+                        fluentBitFacadeService.uninstall(
+                                nsId, infraId, nodeId, accessInfo, templateCount));
+    }
+
+    private interface AgentTask {
+        void run(AccessInfoDTO accessInfo, int templateCount) throws Exception;
+    }
+
+    private List<ResultDTO> runAgentTask(
+            String nsId, String infraId, String nodeId, AgentTask task) {
+        List<ResultDTO> results = new ArrayList<>();
+        try {
+            AccessInfoDTO accessInfo = getAccessInfo(nsId, infraId, nodeId);
+            int templateCount;
+            try {
+                semaphoreInstallTemplateCurrentCountLock.lock();
+                templateCount = getSemaphoreInstallTemplateCurrentCount();
+            } finally {
+                semaphoreInstallTemplateCurrentCountLock.unlock();
+            }
+            task.run(accessInfo, templateCount);
+            results.add(
+                    ResultDTO.builder()
+                            .nsId(nsId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
+                            .status(ResponseStatus.SUCCESS)
+                            .build());
+        } catch (Exception e) {
+            results.add(
+                    ResultDTO.builder()
+                            .nsId(nsId)
+                            .infraId(infraId)
+                            .nodeId(nodeId)
+                            .status(ResponseStatus.ERROR)
+                            .errorMessage(e.getMessage())
+                            .build());
+        }
         return results;
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/AgentFacadeService.java
@@ -213,8 +213,9 @@ public class AgentFacadeService {
         }
         // This agent was never installed (or was uninstalled) on a node that still has the
         // other agent — don't probe the (absent) service; report NOT_INSTALLED so the UI shows
-        // an Install button for it.
-        if (taskStatus == VMAgentTaskStatus.NOT_INSTALLED || taskStatus == null) {
+        // an Install button for it. (Only the explicit marker — a null status means "unknown",
+        // so fall through to the live service probe as before.)
+        if (taskStatus == VMAgentTaskStatus.NOT_INSTALLED) {
             return AgentStatus.NOT_INSTALLED;
         }
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/SchedulerFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/SchedulerFacadeService.java
@@ -143,19 +143,25 @@ public class SchedulerFacadeService {
                                 }
 
                                 // success case
-                                // 에이전트 별, FINISHED 상태로 DB 업데이트
+                                // 설치/업데이트 성공 → FINISHED, 제거 성공 → NOT_INSTALLED 로 DB 업데이트.
+                                // (NOT_INSTALLED 로 남겨야 노드 등록은 유지하면서 해당 에이전트만
+                                // "미설치"로 표시되어 Install 버튼이 다시 노출된다.)
                                 if ("success".equals(status)) {
                                     log.debug("Task successful for agent {}", agent);
+                                    VMAgentTaskStatus doneStatus =
+                                            method == SemaphoreInstallMethod.UNINSTALL
+                                                    ? VMAgentTaskStatus.NOT_INSTALLED
+                                                    : VMAgentTaskStatus.FINISHED;
                                     if (agent == Agent.TELEGRAF) {
                                         vmService.updateMonitoringAgentTaskStatus(
-                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, doneStatus);
                                     } else if (agent == Agent.FLUENT_BIT) {
                                         vmService.updateLogAgentTaskStatus(
-                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, doneStatus);
                                     } else if (agent == Agent.BEYLA
                                             || agent == Agent.OTEL_JAVA_AGENT) {
                                         vmService.updateTraceAgentTaskStatus(
-                                                nsId, infraId, nodeId, VMAgentTaskStatus.FINISHED);
+                                                nsId, infraId, nodeId, doneStatus);
                                     }
 
                                     ScheduledFuture<?> scheduledFuture = futureRef.get();

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -1,6 +1,7 @@
 package com.mcmp.o11ymanager.manager.facade;
 
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
+import com.mcmp.o11ymanager.manager.dto.vm.ResultDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.VMDTO;
 import com.mcmp.o11ymanager.manager.dto.vm.VMRequestDTO;
 import com.mcmp.o11ymanager.manager.enums.Agent;
@@ -84,6 +85,86 @@ public class VMFacadeService {
         } finally {
             hostLock.unlock();
         }
+    }
+
+    // --- Per-agent install / uninstall (monitoring = telegraf, log = fluent-bit) --------------
+    // VM monitoring and log agents can be managed independently, like K8s nodes. The first
+    // install registers the node; the node record stays even when both agents are uninstalled
+    // (both then show NOT_INSTALLED -> Install button).
+
+    public List<ResultDTO> installMonitoringAgent(String nsId, String infraId, String nodeId) {
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
+        try {
+            hostLock.lock();
+            ensureRegistered(nsId, infraId, nodeId, Agent.TELEGRAF);
+            return agentFacadeService.installMonitoringAgent(nsId, infraId, nodeId);
+        } finally {
+            hostLock.unlock();
+        }
+    }
+
+    public List<ResultDTO> uninstallMonitoringAgent(String nsId, String infraId, String nodeId) {
+        return agentFacadeService.uninstallMonitoringAgent(nsId, infraId, nodeId);
+    }
+
+    public List<ResultDTO> installLogAgent(String nsId, String infraId, String nodeId) {
+        ReentrantLock hostLock = vmService.getHostLock(nsId, infraId, nodeId);
+        try {
+            hostLock.lock();
+            ensureRegistered(nsId, infraId, nodeId, Agent.FLUENT_BIT);
+            return agentFacadeService.installLogAgent(nsId, infraId, nodeId);
+        } finally {
+            hostLock.unlock();
+        }
+    }
+
+    public List<ResultDTO> uninstallLogAgent(String nsId, String infraId, String nodeId) {
+        return agentFacadeService.uninstallLogAgent(nsId, infraId, nodeId);
+    }
+
+    private void ensureRegistered(String nsId, String infraId, String nodeId, Agent installing) {
+        boolean exists;
+        try {
+            vmService.getByNsVm(nsId, nodeId);
+            exists = true;
+        } catch (Exception e) {
+            exists = false;
+        }
+        if (exists) {
+            return;
+        }
+
+        VMStatus status =
+                tumblebugService.isConnectedVM(nsId, infraId, nodeId)
+                        ? VMStatus.RUNNING
+                        : VMStatus.FAILED;
+        if (status != VMStatus.RUNNING) {
+            throw new RuntimeException("FAILED TO CONNECT VM");
+        }
+        Long influxSeq = influxDbService.resolveInfluxDb(nsId, infraId);
+        VMRequestDTO dto = VMRequestDTO.builder().name(nodeId).build();
+        vmService.post(nsId, infraId, nodeId, status, dto, influxSeq);
+
+        // Agent being installed -> IDLE (the install flow moves it to INSTALLING); the others
+        // start NOT_INSTALLED so the UI shows them as installable.
+        vmService.updateMonitoringAgentTaskStatusAndTaskId(
+                nsId,
+                infraId,
+                nodeId,
+                installing == Agent.TELEGRAF
+                        ? VMAgentTaskStatus.IDLE
+                        : VMAgentTaskStatus.NOT_INSTALLED,
+                "");
+        vmService.updateLogAgentTaskStatusAndTaskId(
+                nsId,
+                infraId,
+                nodeId,
+                installing == Agent.FLUENT_BIT
+                        ? VMAgentTaskStatus.IDLE
+                        : VMAgentTaskStatus.NOT_INSTALLED,
+                "");
+        vmService.updateTraceAgentTaskStatusAndTaskId(
+                nsId, infraId, nodeId, VMAgentTaskStatus.NOT_INSTALLED, "");
     }
 
     public VMDTO getVM(String nsId, String infraId, String nodeId) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/aspect/request/RequestIdAspect.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/aspect/request/RequestIdAspect.java
@@ -14,8 +14,15 @@ public class RequestIdAspect {
 
     private final RequestInfo requestInfo;
 
+    // The leading within(...) restricts class-level matching to the controller package so Spring's
+    // ClassFilter rejects every other bean cheaply. Without it, the trailing !within(...) negation
+    // makes the class filter permissive and AspectJ falls back to resolving the generic signature
+    // of
+    // every method on every bean during auto-proxy creation — that added ~5 minutes to startup.
     @Around(
-            "execution(* com.mcmp.o11ymanager.manager.controller.*.*(..)) && !within(com.mcmp.o11ymanager.manager.controller.VMWebSocketController)")
+            "within(com.mcmp.o11ymanager.manager.controller..*)"
+                    + " && execution(* com.mcmp.o11ymanager.manager.controller.*.*(..))"
+                    + " && !within(com.mcmp.o11ymanager.manager.controller.VMWebSocketController)")
     public Object aroundControllerMethods(ProceedingJoinPoint joinPoint) throws Throwable {
         String requestId = UUID.randomUUID().toString();
         requestInfo.setRequestId(requestId);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/runner/PreparationRunner.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/global/runner/PreparationRunner.java
@@ -5,27 +5,37 @@ import com.mcmp.o11ymanager.manager.service.SemaphoreService;
 import com.mcmp.o11ymanager.manager.service.interfaces.VMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.lang.Nullable;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+/**
+ * One-time startup preparation (agent plugin definitions, Semaphore project/templates, agent task
+ * status reset).
+ *
+ * <p>Runs on a background daemon thread so it does NOT block application startup. Semaphore
+ * initialization in particular calls the Semaphore REST API and used to take several minutes,
+ * during which the manager (running this in {@code setApplicationContext}, before the web server
+ * started) didn't accept any requests. The app now starts immediately and these resources become
+ * ready shortly after — only agent install / metric-config depends on them.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Order(Ordered.HIGHEST_PRECEDENCE)
-public class PreparationRunner implements ApplicationContextAware {
+public class PreparationRunner implements ApplicationRunner {
 
     private final SemaphoreService semaphoreService;
     private final AgentPluginDefServiceImpl agentPluginDefServiceImpl;
     private final VMService vmService;
 
     @Override
-    public void setApplicationContext(@Nullable ApplicationContext applicationContext)
-            throws BeansException {
+    public void run(ApplicationArguments args) {
+        Thread t = new Thread(this::prepare, "manager-preparation");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private void prepare() {
         try {
             agentPluginDefServiceImpl.initializePluginDefinitions();
         } catch (Exception e) {
@@ -33,7 +43,7 @@ public class PreparationRunner implements ApplicationContextAware {
         }
 
         try {
-            log.info("Starting semaphore initialization.");
+            log.info("Starting semaphore initialization (background).");
             semaphoreService.initSemaphore();
             log.info("Semaphore initialization completed successfully.");
         } catch (Exception e) {

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/model/host/VMAgentTaskStatus.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/model/host/VMAgentTaskStatus.java
@@ -12,6 +12,7 @@ public enum VMAgentTaskStatus {
     RESTARTING("Agent restart is in progress."),
     FAILED("There are no agent-related tasks currently in progress."),
     FINISHED("There are no agent-related tasks currently in progress."),
+    NOT_INSTALLED("The agent is not installed on this node."),
     IDLE("There are no agent-related tasks currently in progress.");
 
     private final String message;

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/TumblebugServiceImpl.java
@@ -129,9 +129,12 @@ public class TumblebugServiceImpl implements TumblebugService {
                     agent);
         }
 
+        // Must run with sudo: the SSH user (e.g. cb-user) cannot restart a systemd unit
+        // otherwise ("Interactive authentication required"), which left the agent inactive
+        // after a VM suspend/resume and surfaced as a 500 when toggling a metric.
         String command =
                 String.format(
-                        "systemctl restart cmp-%s-%s.service",
+                        "sudo systemctl restart cmp-%s-%s.service",
                         agent.name().toLowerCase().replace("_", "-"), sitecode.toLowerCase());
 
         String result = executeCommand(nsId, infraId, nodeId, command).trim();

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
@@ -414,6 +414,7 @@ public class VMServiceImpl implements VMService {
         return status != null
                 && status != VMAgentTaskStatus.IDLE
                 && status != VMAgentTaskStatus.FINISHED
-                && status != VMAgentTaskStatus.FAILED;
+                && status != VMAgentTaskStatus.FAILED
+                && status != VMAgentTaskStatus.NOT_INSTALLED;
     }
 }

--- a/java/mc-o11y-manager/src/main/resources/application.yaml
+++ b/java/mc-o11y-manager/src/main/resources/application.yaml
@@ -259,14 +259,17 @@ logging:
   level:
     org.apache.sshd.client: ERROR
     org.apache.sshd.common: ERROR
-    feign: DEBUG
-    feign.Logger: DEBUG
+    feign: ${LOG_FEIGN:INFO}
+    feign.Logger: ${LOG_FEIGN:INFO}
     feign.template: WARN
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-    org.hibernate.type: TRACE
-    org.hibernate.engine.transaction.internal.TransactionImpl: TRACE
-    org.hibernate.type.descriptor.sql: TRACE
+    # Hibernate SQL/type loggers default to WARN so startup isn't spent logging every type
+    # registration (org.hibernate.type at TRACE alone added minutes of boot time and floods every
+    # request). Override via the env vars below to re-enable SQL/bind tracing when debugging.
+    org.hibernate.SQL: ${LOG_HIBERNATE_SQL:WARN}
+    org.hibernate.type.descriptor.sql.BasicBinder: ${LOG_HIBERNATE_BIND:WARN}
+    org.hibernate.type: ${LOG_HIBERNATE_TYPE:WARN}
+    org.hibernate.engine.transaction.internal.TransactionImpl: ${LOG_HIBERNATE_TX:WARN}
+    org.hibernate.type.descriptor.sql: ${LOG_HIBERNATE_TYPE_SQL:WARN}
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
#329 가 개발 도중(커밋 `745c319a7` 시점)에 머지되어, 그 이후에 같은 브랜치로 푸시된 커밋들이 main에 반영되지 않았습니다. 이 PR은 그 누락분 + 후속 수정을 main에 반영합니다.

## What's included (main에 빠져있던 것들)
- feat: follow parent-page namespace changes for the whole session (iframe ns 지속 동기화)
- feat: loading state in node dropdowns (insight/logs) + insight infra/cluster dropdowns
- fix: render k8s (fluent-bit) log messages by parsing the CRI log field
- feat: derive log level/service from message; detect klog severity mid-line; UNKNOWN fallback
- fix: keep selected metrics after k8s Apply (don't clear from empty InfluxDB-derived active)
- fix: alert — list all k8s cluster nodes as targets (first-try save right after install)
- feat: simplify alert target picker (single multi-select), loading state, hide already-added nodes
- feat: log workload dropdown loading state
- feat: drop Processes from the VM agent monitoring tab
- fix: top-align the agent gauge column (top metrics no longer clipped)
- fix: show install/uninstall control in the Log Agent column too (VM agents install together)

(브랜치 끝의 sudo restart 커밋은 #330 으로 이미 main 에 있으므로 diff 에 안 나타납니다.)
