### PR TITLE
fix: resolve exec-plugin K8s kubeconfigs (EKS/GKE) and stop 400ing metrics for unreported nodes

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugK8sToken.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/tumblebug/TumblebugK8sToken.java
@@ -1,0 +1,46 @@
+package com.mcmp.o11ymanager.manager.dto.tumblebug;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * cb-tumblebug {@code /k8sCluster/{id}/token} response. cb-tumblebug wraps a Kubernetes client-go
+ * {@code ExecCredential} under an {@code execCredential} key; we only need the bearer token from
+ * its status to authenticate fabric8 against exec-plugin clusters (AWS EKS, etc.).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TumblebugK8sToken {
+
+    @JsonProperty("execCredential")
+    private ExecCredential execCredential;
+
+    /** Convenience accessor for the bearer token, or {@code null} when absent. */
+    public String getToken() {
+        if (execCredential == null || execCredential.getStatus() == null) {
+            return null;
+        }
+        return execCredential.getStatus().getToken();
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ExecCredential {
+        private Status status;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Status {
+        private String token;
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugClient.java
@@ -4,6 +4,7 @@ import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugCmd;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfraList;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sToken;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugSshKey;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -44,4 +45,8 @@ public interface TumblebugClient {
 
     @GetMapping("/tumblebug/ns/{nsId}/k8sCluster/{k8sClusterId}")
     TumblebugK8sCluster getK8sCluster(@PathVariable String nsId, @PathVariable String k8sClusterId);
+
+    @GetMapping("/tumblebug/ns/{nsId}/k8sCluster/{k8sClusterId}/token")
+    TumblebugK8sToken getK8sClusterToken(
+            @PathVariable String nsId, @PathVariable String k8sClusterId);
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/InfluxDbServiceImpl.java
@@ -372,10 +372,14 @@ public class InfluxDbServiceImpl implements InfluxDbService {
         String q = InfluxQl.buildQuery(req, rp);
 
         if (!existsVmInInflux(s, nsId, infraId, nodeId)) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Invalid nodeId='%s': does not exist for nsId='%s', infraId='%s'",
-                            nodeId, nsId, infraId));
+            // No series for this node yet — the agent isn't installed or hasn't reported. Return
+            // empty (not a 400) so the UI renders a graceful "no data" state instead of an error.
+            log.debug(
+                    "No InfluxDB series for ns='{}', infra='{}', node='{}'; returning empty metrics",
+                    nsId,
+                    infraId,
+                    nodeId);
+            return List.of();
         }
 
         List<MetricDTO> metrics = exec(s, q).map(QueryMapper::toMetricDTOs).orElse(List.of());

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -3,6 +3,7 @@ package com.mcmp.o11ymanager.manager.service;
 import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
 import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sToken;
 import com.mcmp.o11ymanager.manager.facade.InfluxDbFacadeService;
 import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
 import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
@@ -10,6 +11,7 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import java.net.URI;
@@ -129,8 +131,63 @@ public class K8sAgentService {
             throw new IllegalStateException(
                     "kubeconfig not available for cluster " + nsId + "/" + clusterId);
         }
-        Config cfg = Config.fromKubeconfig(cluster.getAccessInfo().getKubeconfig());
+        String kubeconfig = cluster.getAccessInfo().getKubeconfig();
+
+        // cb-spider hands out exec-plugin kubeconfigs for AWS EKS / GCP GKE / NCP NKS that shell
+        // out to a cloud CLI (or cb-spider's local credential via 0.0.0.0:1024) to mint a token.
+        // Neither the CLI nor that credential exists in this container, and fabric8 cannot even
+        // parse the exec stanza (YAML "mapping values are not allowed here"). Mirror
+        // cm-grasshopper:
+        // pull a short-lived bearer token from cb-tumblebug's /token endpoint and build the client
+        // from the API server + CA + token, dropping the exec stanza entirely. Self-contained
+        // kubeconfigs (e.g. Azure AKS) carry their own credentials and are used as-is.
+        if (kubeconfig.contains("exec:")) {
+            String server = extractKubeconfigField(kubeconfig, "server");
+            if (server == null) {
+                throw new IllegalStateException(
+                        "could not extract API server from kubeconfig for "
+                                + nsId
+                                + "/"
+                                + clusterId);
+            }
+            String caData = extractKubeconfigField(kubeconfig, "certificate-authority-data");
+            String token = resolveClusterToken(nsId, clusterId);
+            ConfigBuilder b = new ConfigBuilder().withMasterUrl(server).withOauthToken(token);
+            if (caData != null && !caData.isBlank()) {
+                b.withCaCertData(caData);
+            } else {
+                b.withTrustCerts(true);
+            }
+            return new KubernetesClientBuilder().withConfig(b.build()).build();
+        }
+
+        Config cfg = Config.fromKubeconfig(kubeconfig);
         return new KubernetesClientBuilder().withConfig(cfg).build();
+    }
+
+    /** Resolves a short-lived bearer token for an exec-plugin cluster via cb-tumblebug. */
+    private String resolveClusterToken(String nsId, String clusterId) {
+        TumblebugK8sToken t = tumblebugClient.getK8sClusterToken(nsId, clusterId);
+        String token = t == null ? null : t.getToken();
+        if (token == null || token.isBlank()) {
+            throw new IllegalStateException(
+                    "cb-tumblebug returned no token for cluster " + nsId + "/" + clusterId);
+        }
+        return token;
+    }
+
+    /**
+     * Pulls a single scalar field (e.g. {@code server}, {@code certificate-authority-data}) out of
+     * a kubeconfig by line, without YAML-parsing the exec-plugin user section that fabric8 rejects.
+     */
+    private static String extractKubeconfigField(String kubeconfig, String key) {
+        java.util.regex.Matcher m =
+                java.util.regex.Pattern.compile(
+                                "(?m)^\\s*"
+                                        + java.util.regex.Pattern.quote(key)
+                                        + ":\\s*(\\S+)\\s*$")
+                        .matcher(kubeconfig);
+        return m.find() ? m.group(1) : null;
     }
 
     public List<NodeResult> install(String nsId, String clusterId) {


### PR DESCRIPTION
## Summary
- **K8s 노드 에이전트 설치 500 수정**: cb-spider가 주는 exec-plugin kubeconfig
  (AWS EKS / GCP GKE / NCP NKS)는 cloud CLI·cb-spider 로컬 자격증명에 의존해
  매니저 컨테이너에서 쓸 수 없고, fabric8가 exec 스탠자 YAML 파싱조차 실패
  (`mapping values are not allowed here`). cm-grasshopper의 token-broker 방식을
  미러링 — exec 기반이면 cb-tumblebug `/k8sCluster/{id}/token`에서 bearer 토큰을
  받아 API server + CA + token으로 fabric8 Config를 직접 구성. self-contained
  kubeconfig(Azure AKS)는 기존대로 사용.
- **메트릭 400 수정**: InfluxDB에 시리즈가 없는 노드(에이전트 미설치/미보고)에서
  `existsVmInInflux`가 400을 던지던 것을 빈 결과(200) 반환으로 변경 — UI가 에러
  대신 "no data"로 표시.

## Changes
- `TumblebugClient`: `getK8sClusterToken(ns, id)` 추가 + `TumblebugK8sToken` DTO
- `K8sAgentService.client()`: exec 기반 kubeconfig 감지 -> token-broker 경로
- `InfluxDbServiceImpl.loadMetricsByVM`: 시리즈 없으면 빈 결과 반환

## Reference
cm-grasshopper `lib/k8s/tumblebug/resolve.go` (`rewriteExecToBroker`)
