### PR TITLE
fix: detect embedding console namespace via postMessage for cross-origin iframes

### DIFF
--- a/front/src/hooks/useParentNamespace.js
+++ b/front/src/hooks/useParentNamespace.js
@@ -1,48 +1,93 @@
 import { useState, useEffect } from 'react';
 
-// The embedding (parent) page is expected to have a project selector with this id.
-// We read the *displayed text* of the selected option (not its value) and use it
-// as the namespace. If the parent DOM cannot be read (cross-origin, not embedded,
-// element missing), we silently return '' — no error — so the app falls back to
-// the manual namespace picker.
+// The embedding (parent) console tells us which namespace is selected in two ways:
+//
+//  1. postMessage — the parent posts a payload to the iframe on load / project change
+//     (mc-web-console's iframe.js does `iframe.contentWindow.postMessage(data, src)`).
+//     This is the ONLY reliable channel when the parent is a different origin — e.g. the
+//     console and this app on :18081 are cross-origin (different port at least), so the
+//     same-origin policy blocks reading `window.parent.document` entirely.
+//
+//  2. a `#select-current-project` <select> in the parent DOM, whose selected <option>
+//     carries the namespace in `data-nsid` (falling back to the displayed text). Only
+//     readable when the parent is same-origin (e.g. local dev), so it's just a fallback.
+//
+// We prefer the postMessage value and fall back to the DOM read.
 const SELECT_ID = 'select-current-project';
 
-function readParentNamespace() {
+function readParentNamespaceFromDom() {
   try {
     if (typeof window === 'undefined' || window.parent === window) return '';
     const doc = window.parent.document; // throws on cross-origin → caught below
     const sel = doc.getElementById(SELECT_ID);
     if (!sel) return '';
     const opt = sel.options && sel.selectedIndex >= 0 ? sel.options[sel.selectedIndex] : null;
-    const text = opt ? (opt.text ?? opt.label ?? opt.textContent ?? '') : '';
-    return String(text).trim();
+    if (!opt) return '';
+    // The namespace id lives in data-nsid; the visible text is only a label.
+    const nsid = opt.getAttribute ? opt.getAttribute('data-nsid') : '';
+    const text = opt.text ?? opt.label ?? opt.textContent ?? '';
+    return String(nsid || text).trim();
   } catch {
     return ''; // cross-origin or any access issue → just skip, not an error
   }
 }
 
+// Extract a namespace id from a parent postMessage payload. The console sends
+// `{ projectInfo: { id, ns_id, name }, ... }`; accept a few spellings/locations.
+function nsFromMessage(data) {
+  if (!data || typeof data !== 'object') return '';
+  const p = data.projectInfo || data.project || {};
+  const candidates = [
+    p.ns_id, p.nsId, p.NsId, p.nsid,
+    data.ns_id, data.nsId, data.NsId,
+  ];
+  for (const c of candidates) {
+    if (c) return String(c).trim();
+  }
+  return '';
+}
+
+// Seed from an already-captured parent message (see main.jsx) before falling back to
+// the same-origin DOM read — avoids missing the parent's one-shot on-load postMessage.
+function initialNs() {
+  if (typeof window !== 'undefined' && window.__parentNs) return window.__parentNs;
+  return readParentNamespaceFromDom();
+}
+
 /**
- * Watches the parent page's `#select-current-project` selected option text and
- * returns it as the namespace. Returns '' when it cannot be read.
+ * Returns the namespace selected in the embedding console. Listens for the parent's
+ * postMessage (cross-origin friendly) and, as a same-origin fallback, watches the
+ * parent's `#select-current-project`. Returns '' when nothing can be determined.
  */
 export default function useParentNamespace() {
-  const [ns, setNs] = useState(readParentNamespace);
+  const [ns, setNs] = useState(initialNs);
 
   useEffect(() => {
+    // 1. postMessage — works across origins (the real integration path).
+    const onMessage = (e) => {
+      const v = nsFromMessage(e.data);
+      if (v) setNs(v);
+    };
+    window.addEventListener('message', onMessage);
+
+    // 2. same-origin DOM read + change listener + polling (dev fallback).
     let sel = null;
-    const update = () => setNs(readParentNamespace());
+    const update = () => {
+      const v = readParentNamespaceFromDom();
+      if (v) setNs(v);
+    };
     try {
       if (window.parent !== window) {
         sel = window.parent.document.getElementById(SELECT_ID);
         if (sel) sel.addEventListener('change', update);
       }
     } catch {
-      sel = null; // cross-origin: cannot attach listener, fall back to polling only
+      sel = null; // cross-origin: cannot attach listener, postMessage covers it
     }
-    // Poll as a fallback in case the parent updates the selection without a
-    // reachable change event. Cheap DOM read; stops on unmount.
     const timer = setInterval(update, 1500);
+
     return () => {
+      window.removeEventListener('message', onMessage);
       if (sel) { try { sel.removeEventListener('change', update); } catch { /* ignore */ } }
       clearInterval(timer);
     };

--- a/front/src/main.jsx
+++ b/front/src/main.jsx
@@ -5,6 +5,19 @@ import App from './App';
 import { AppProvider } from './context/AppContext';
 import './index.css';
 
+// Capture the embedding console's selected namespace as early as possible. The parent
+// posts it via postMessage on iframe load, which can arrive before React mounts the
+// listener in useParentNamespace — stash it on window so the hook can seed from it.
+if (typeof window !== 'undefined') {
+  window.addEventListener('message', (e) => {
+    const d = e && e.data;
+    if (!d || typeof d !== 'object') return;
+    const p = d.projectInfo || d.project || {};
+    const ns = p.ns_id || p.nsId || p.NsId || d.ns_id || d.nsId || d.NsId;
+    if (ns) window.__parentNs = String(ns).trim();
+  });
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>


### PR DESCRIPTION
## Summary
임베딩 콘솔(mc-web-console)과 o11y iframe은 포트가 달라(콘솔 vs `:18081`) **cross-origin**이라,
부모 DOM의 `#select-current-project`를 직접 읽는 기존 방식이 동일출처 정책에 막혀 namespace를
감지하지 못함. 그 결과 부모에서 프로젝트를 골라도 iframe이 해당 namespace로 전환되지 않음.

mc-web-console의 `iframe.js`는 이미 iframe `onload` 시 `postMessage(data)`로
`data.projectInfo.ns_id`를 보내므로, 이를 수신해 namespace로 사용하도록 변경.

## Changes
- `useParentNamespace`: 부모 `postMessage`(cross-origin 가능) 수신을 1순위로,
  동일출처 DOM 읽기(+`data-nsid`)는 폴백으로 유지
- `main.jsx`: 부모가 onload에 한 번 보내는 메시지를 React 마운트 전에 놓치지 않도록
  진입점에서 조기 캡처(`window.__parentNs`)
