### PR TITLE
fix: recover parent namespace from window.__parentNs

### DIFF
--- a/front/src/hooks/useParentNamespace.js
+++ b/front/src/hooks/useParentNamespace.js
@@ -70,10 +70,13 @@ export default function useParentNamespace() {
     };
     window.addEventListener('message', onMessage);
 
-    // 2. same-origin DOM read + change listener + polling (dev fallback).
+    // 2. window.__parentNs (captured by the early listener in main.jsx) + same-origin DOM read,
+    //    polled. This recovers the parent's one-shot on-load postMessage even if it landed in the
+    //    gap between this component's first render and this effect attaching its own listener —
+    //    main.jsx's module-level listener still caught it into window.__parentNs.
     let sel = null;
     const update = () => {
-      const v = readParentNamespaceFromDom();
+      const v = (typeof window !== 'undefined' && window.__parentNs) || readParentNamespaceFromDom();
       if (v) setNs(v);
     };
     try {


### PR DESCRIPTION
## Summary
임베딩 콘솔에서 네임스페이스 선택 시, observability iframe이 해당 네임스페이스의
Monitoring 화면으로 전환되지 않는 문제 수정.

부모 콘솔은 `iframe.onload` 시점에 `postMessage`로 네임스페이스를 **한 번** 보낸다.
이 메시지가 `useParentNamespace` 훅의 리스너가 부착되기 직전(첫 렌더와 effect 사이)에
도착하면 훅이 놓쳤고, 폴링 폴백은 `window.__parentNs`(main.jsx의 모듈 레벨 리스너가
이미 캡처해 둔 값)는 보지 않고 cross-origin DOM만 읽어 영영 회수하지 못했음.

## Changes
- `useParentNamespace`: 폴링이 `window.__parentNs`를 우선 확인하도록 변경 →
  one-shot on-load postMessage를 놓쳐도 1.5초 내 회수되어 `/monitoring/{ns}`로 이동

## Verification
프로젝트 선택 시 iframe이 `/monitoring/{선택ns}`로 전환, 프로젝트 변경도 따라감을 확인.
