### PR TITLE
fix: read parent namespace immediately

### DIFF
--- a/front/src/hooks/useParentNamespace.js
+++ b/front/src/hooks/useParentNamespace.js
@@ -87,6 +87,10 @@ export default function useParentNamespace() {
     } catch {
       sel = null; // cross-origin: cannot attach listener, postMessage covers it
     }
+    // Read once immediately: the parent's on-load postMessage may have already landed in
+    // window.__parentNs (via main.jsx) before this effect attached its listener, so don't wait
+    // for the first poll tick — pick it up now for an instant switch.
+    update();
     const timer = setInterval(update, 1500);
 
     return () => {


### PR DESCRIPTION
## Summary
임베딩 시 네임스페이스 전환이 최대 ~1.5초(폴링 주기) 지연되던 것을 즉시 전환으로 개선.

부모의 on-load postMessage가 훅 리스너 부착 전에 도착하면 값이 `window.__parentNs`에만
들어가는데, 폴링이 1.5초 뒤에야 회수했음. effect 부착 시점에 `update()`를 한 번 즉시
호출해 그 값을 바로 반영하도록 변경.

## Verification
헤드리스 브라우저로 실제 콘솔 흐름 측정: 프로젝트 선택 후 iframe이 `/monitoring/{ns}`에
도달하기까지 ~200ms (기존 최대 1.5s).
