### PR TITLE
feat: remember the last selected namespace

### DIFF
--- a/front/src/hooks/useFollowParentNamespace.js
+++ b/front/src/hooks/useFollowParentNamespace.js
@@ -3,8 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import useParentNamespace from './useParentNamespace';
 import useBasePath from './useBasePath';
 import { getNsList } from '../api/tumblebug';
-
-const SECTIONS = ['monitoring', 'logs', 'config', 'insight', 'alerts', 'trace'];
+import { getLastSection, setLastSection, SECTIONS } from '../lib/lastSection';
 
 // Pull the section (if any) and the namespace out of the current path, ignoring the
 // optional /embed base. Paths look like `/{ns}`, `/{ns}/{infra}[/{node}]`, or
@@ -29,6 +28,13 @@ export default function useFollowParentNamespace() {
   const base = useBasePath();
   const { pathname } = useLocation();
 
+  // Remember the section the user is on so a parent namespace switch (which reloads this
+  // iframe) can return to the same menu instead of snapping back to Monitoring.
+  useEffect(() => {
+    const { section } = parsePath(pathname, base);
+    if (section) setLastSection(section);
+  }, [pathname, base]);
+
   useEffect(() => {
     if (!parentNs) return;
     let alive = true;
@@ -40,8 +46,10 @@ export default function useFollowParentNamespace() {
         const match = (list || []).find((n) => n.id === parentNs || n.name === parentNs);
         const targetNs = match ? match.id : parentNs;
         if (targetNs && targetNs !== currentNs) {
-          // Preserve the current section; at the namespace root (no section) land on Monitoring.
-          navigate(`${base}/${section || 'monitoring'}/${targetNs}`, { replace: true });
+          // Preserve the current section; at the namespace root (no section) fall back to the
+          // last remembered section (then Monitoring) so the chosen menu survives a switch.
+          const sec = section || getLastSection() || 'monitoring';
+          navigate(`${base}/${sec}/${targetNs}`, { replace: true });
         }
       })
       .catch(() => {});

--- a/front/src/lib/lastSection.js
+++ b/front/src/lib/lastSection.js
@@ -1,0 +1,23 @@
+// Remembers the last section (Monitoring/Logs/Config/…) the user was on, so that when the
+// embedding console switches namespace — which reloads this iframe from scratch — we can land
+// on the same section under the new namespace instead of always snapping back to Monitoring.
+// Persisted in localStorage (same :18081 origin across reloads).
+const KEY = 'o11y:lastSection';
+export const SECTIONS = ['monitoring', 'logs', 'config', 'insight', 'alerts', 'trace'];
+
+export function setLastSection(section) {
+  try {
+    if (SECTIONS.includes(section)) localStorage.setItem(KEY, section);
+  } catch {
+    /* private mode / storage disabled — ignore */
+  }
+}
+
+export function getLastSection() {
+  try {
+    const s = localStorage.getItem(KEY);
+    return SECTIONS.includes(s) ? s : '';
+  } catch {
+    return '';
+  }
+}

--- a/front/src/pages/NamespaceHome.jsx
+++ b/front/src/pages/NamespaceHome.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { getNsList, getInfraList } from '../api/tumblebug';
 import { getK8sClusters } from '../api/k8sAgent';
 import useParentNamespace from '../hooks/useParentNamespace';
+import { getLastSection } from '../lib/lastSection';
 
 /**
  * Landing shown at `/` when no namespace is passed in the path.
@@ -28,7 +29,10 @@ export default function NamespaceHome() {
   useEffect(() => {
     if (!parentNs || loading) return;
     const match = nsList.find((n) => n.id === parentNs || (n.name && n.name === parentNs));
-    navigate(`/monitoring/${match ? match.id : parentNs}`, { replace: true });
+    // Land on the last section the user was on (survives the iframe reload a parent namespace
+    // switch triggers); default to Monitoring on the very first visit.
+    const sec = getLastSection() || 'monitoring';
+    navigate(`/${sec}/${match ? match.id : parentNs}`, { replace: true });
   }, [parentNs, loading, nsList, navigate]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
임베딩 콘솔에서 네임스페이스를 바꾸면 iframe이 통째로 reload되어 항상 Monitoring으로
돌아가던 것을, **마지막에 보던 메뉴(섹션)를 기억했다가 그 메뉴로 복원**하도록 개선.

reload를 넘어 유지돼야 하므로 섹션을 localStorage(같은 :18081 origin)에 저장하고,
새로 뜰 때 그 섹션으로 이동한다.

## Changes
- `lib/lastSection.js` (신규): 섹션 get/set (localStorage)
- `useFollowParentNamespace`: 현재 섹션을 기억; ns 변경 시 현재/마지막 섹션으로 이동
- `NamespaceHome`: 부모 ns 감지 시 마지막 섹션(없으면 monitoring)으로 진입

## Verification
실제 콘솔 흐름: default→Logs 클릭(`/logs/default`)→프로젝트 전환 시
`/logs/{새 ns}`로 이동(메뉴 유지)을 확인.
