### PR TITLE
fix: schedule k8s agent jobs onto the real node and graceful-empty CSP metrics

### DIFF
--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -171,15 +171,17 @@ export default function MonitoringDashboard() {
     if (routeNodeId) setSelectedNodeId(routeNodeId);
   }, [routeNodeId]);
 
-  // Track CSP info for selected Node
+  // Track CSP info for selected Node. K8s nodes are NOT cb-spider VMs — their CSP metrics live
+  // behind the cluster-node endpoint (see K8sNodeDashboard / the Infra overview K8s tab), so don't
+  // offer the VM-based API source here for a k8s node (it would 404/empty on cb-spider).
   useEffect(() => {
     const node = nodes.find((n) => n.id === selectedNodeId);
-    if (node && node.connectionName && node.cspResourceName) {
+    if (!isK8s && node && node.connectionName && node.cspResourceName) {
       setCspNodeInfo({ connectionName: node.connectionName, cspResourceName: node.cspResourceName });
     } else {
       setCspNodeInfo(null);
     }
-  }, [selectedNodeId, nodes]);
+  }, [selectedNodeId, nodes, isK8s]);
 
   // Load CSP metrics when dataSource=csp (wait for nodes to load first)
   const [cspLoading, setCspLoading] = useState(false);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>Returns the raw cb-spider payload (no {@code ResBody} wrapping) so existing clients that
  * talked directly to {@code /spider/monitoring/**} only need to repoint the base path.
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/o11y/monitoring/csp")
@@ -67,9 +69,23 @@ public class CspMonitoringController {
         CspCacheKey key = CspCacheKey.forVm(nodeName, measurement, connectionName, tbh, ivm);
         return cspCacheService.getOrLoad(
                 key,
-                () ->
-                        spiderClient.getVMMonitoring(
-                                nodeName, measurement, connectionName, tbh, ivm));
+                () -> {
+                    try {
+                        return spiderClient.getVMMonitoring(
+                                nodeName, measurement, connectionName, tbh, ivm);
+                    } catch (Exception e) {
+                        // cb-spider has no CloudWatch monitoring for this resource (e.g. a k8s node
+                        // queried as a VM, or an unsupported metric). Return empty so the UI shows
+                        // "no data" instead of a 500.
+                        log.debug(
+                                "cb-spider VM monitoring unavailable conn={} node={} metric={}: {}",
+                                connectionName,
+                                nodeName,
+                                measurement,
+                                e.toString());
+                        return emptyData(measurement);
+                    }
+                });
     }
 
     @GetMapping("/cluster/{clusterName}/{nodeGroupName}/{nodeNumber}/{measurement}")
@@ -101,15 +117,36 @@ public class CspMonitoringController {
                         ivm);
         return cspCacheService.getOrLoad(
                 key,
-                () ->
-                        spiderClient.getClusterNodeMonitoring(
+                () -> {
+                    try {
+                        return spiderClient.getClusterNodeMonitoring(
                                 clusterName,
                                 nodeGroupName,
                                 nodeNumber,
                                 measurement,
                                 connectionName,
                                 tbh,
-                                ivm));
+                                ivm);
+                    } catch (Exception e) {
+                        log.debug(
+                                "cb-spider cluster-node monitoring unavailable conn={} cluster={}"
+                                        + " node={} metric={}: {}",
+                                connectionName,
+                                clusterName,
+                                nodeNumber,
+                                measurement,
+                                e.toString());
+                        return emptyData(measurement);
+                    }
+                });
+    }
+
+    /** An empty monitoring series, used when cb-spider has no data for the resource/metric. */
+    private static SpiderMonitoringInfo.Data emptyData(String measurement) {
+        SpiderMonitoringInfo.Data d = new SpiderMonitoringInfo.Data();
+        d.setMetricName(measurement);
+        d.setTimestampValues(java.util.List.of());
+        return d;
     }
 
     @GetMapping("/cache/stats")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -605,6 +605,33 @@ public class K8sAgentService {
 
     // --- Job execution ---------------------------------------------------
 
+    /**
+     * Maps a cb-spider node identifier to the actual Kubernetes node name so a Job can be scheduled
+     * onto it. On AWS EKS, cb-spider reports the EC2 instance id (e.g. {@code i-0abc...}) while the
+     * k8s node name is the private DNS name; the node's {@code spec.providerID} ({@code
+     * aws:///<az>/<instance-id>}) links the two. Returns {@code nodeName} unchanged when it already
+     * matches a k8s node (e.g. Azure AKS) or no mapping is found.
+     */
+    private String resolveK8sNodeName(KubernetesClient k8s, String nodeName) {
+        try {
+            List<Node> nodes = k8s.nodes().list().getItems();
+            for (Node n : nodes) {
+                if (nodeName.equals(n.getMetadata().getName())) {
+                    return nodeName;
+                }
+            }
+            for (Node n : nodes) {
+                String pid = n.getSpec() == null ? null : n.getSpec().getProviderID();
+                if (pid != null && (pid.endsWith("/" + nodeName) || pid.endsWith(":" + nodeName))) {
+                    return n.getMetadata().getName();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("resolveK8sNodeName failed for node={}: {}", nodeName, e.toString());
+        }
+        return nodeName;
+    }
+
     private void runJob(KubernetesClient k8s, String prefix, String nodeName, String script) {
         String b64 = Base64.getEncoder().encodeToString(script.getBytes(StandardCharsets.UTF_8));
         String jobName = prefix + sanitize(nodeName);
@@ -622,7 +649,7 @@ public class K8sAgentService {
                         .withTtlSecondsAfterFinished(300)
                         .withNewTemplate()
                         .withNewSpec()
-                        .withNodeName(nodeName)
+                        .withNodeName(resolveK8sNodeName(k8s, nodeName))
                         .withHostPID(true)
                         .withHostNetwork(true)
                         .withRestartPolicy("Never")


### PR DESCRIPTION
## Summary
- **K8s 노드 에이전트 설치 실패 수정**: AWS EKS에서 cb-spider가 노드 식별자로 EC2
  인스턴스 ID(`i-0...`)를 주는데, 매니저가 그걸 그대로 Job의 `nodeName`으로 써서
  스케줄 불가(그런 k8s 노드 없음) → Job 실패. 노드의 `spec.providerID`
  (`aws:///<az>/<instance-id>`)로 실제 k8s 노드 이름을 찾아 스케줄. (node_id 태그/
  job 이름은 인스턴스 ID 유지 — InfluxDB/UI 일관성)
- **CSP(API) 모니터링 graceful**: cb-spider가 해당 리소스 모니터링을 못 줄 때(특히
  k8s 노드를 VM 엔드포인트로 조회 시) 500 대신 빈 시리즈(200) 반환 → UI가 "no data".
- **프론트**: k8s 노드 상세에서 VM 기반 CSP(API) 소스를 끔(올바른 cluster 엔드포인트는
  K8sNodeDashboard / Infra K8s 탭이 사용).

## Changes
- `K8sAgentService.runJob`: `resolveK8sNodeName()`로 노드 스케줄 타겟 매핑
- `CspMonitoringController`: VM/cluster 모니터링 프록시를 try/catch로 감싸 빈 결과 반환
- `MonitoringDashboard`: `isK8s`일 때 cspNodeInfo 비활성화

## Verification (실제 AWS EKS 로 테스트)
배포 후 노드 에이전트 설치/CSP 호출 검증 진행.
