### PR TITLE
fix: CSP 'not supported' label, persistent infra selector, and Config refresh feedback

### DIFF
--- a/front/src/api/csp.js
+++ b/front/src/api/csp.js
@@ -38,6 +38,7 @@ export async function getAllCspMetrics(connectionName, cspResourceName, timeBefo
         ...m,
         metricName,
         metricUnit,
+        unsupported: data.unsupported === true,
         series: [{ name: metricName, data: points }],
       };
     })

--- a/front/src/api/k8s.js
+++ b/front/src/api/k8s.js
@@ -43,6 +43,7 @@ export async function getAllClusterNodeMetrics(connectionName, clusterName, node
         ...m,
         metricName,
         metricUnit,
+        unsupported: data.unsupported === true,
         series: [{ name: metricName, data: points }],
       };
     })

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -97,11 +97,14 @@ export default function Layout() {
         )}
 
         <div className="ml-auto flex items-center gap-1">
-          {/* Infra selector — shown only when an infra is NOT yet in the path */}
-          {nsId && !infraId && infraList.length > 0 && (
-            <select className="border border-gray-200 rounded px-2 py-1 text-xs" value=""
-              onChange={(e) => { if (e.target.value) navigate(`${base}/${currentSection}/${nsId}/${e.target.value}`); }}>
-              <option value="">Infra</option>
+          {/* Infra selector — kept visible even after an infra is selected so the user can switch
+              to another infra (selecting the blank option returns to the namespace level). */}
+          {nsId && infraList.length > 0 && (
+            <select className="border border-gray-200 rounded px-2 py-1 text-xs" value={infraId || ''}
+              onChange={(e) => navigate(e.target.value
+                ? `${base}/${currentSection}/${nsId}/${e.target.value}`
+                : `${base}/${currentSection}/${nsId}`)}>
+              <option value="">All Infra</option>
               {infraList.map((i) => <option key={i.id} value={i.id}>{i.name || i.id}</option>)}
             </select>
           )}

--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -516,7 +516,9 @@ function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart,
         <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
           {metricsLoading ? (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading CSP API data...</div>
-          ) : activeData?.series ? (
+          ) : activeData?.unsupported ? (
+            <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm">Not supported for this resource</div>
+          ) : activeData?.series?.[0]?.data?.length ? (
             <MetricChart title={`${activeData.metricName} (${activeData.metricUnit})`} series={activeData.series} height={220} />
           ) : (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm">No data</div>
@@ -634,7 +636,9 @@ function CspNodeCard({ node, metrics, metricsLoading, selectedChart, onSelectCha
         <div className="flex-1 px-2 py-1 min-w-0 cursor-pointer" onClick={onClickChart}>
           {metricsLoading ? (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm animate-pulse">Loading CSP API data...</div>
-          ) : activeData?.series ? (
+          ) : activeData?.unsupported ? (
+            <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm">Not supported for this resource</div>
+          ) : activeData?.series?.[0]?.data?.length ? (
             <MetricChart title={`${activeData.metricName} (${activeData.metricUnit})`} series={activeData.series} height={220} />
           ) : (
             <div className="flex items-center justify-center h-[220px] text-gray-400 text-sm">No data</div>

--- a/front/src/pages/K8sNodeDashboard.jsx
+++ b/front/src/pages/K8sNodeDashboard.jsx
@@ -157,7 +157,9 @@ export default function K8sNodeDashboard() {
               <div className="mb-2 text-sm font-medium">{activeData?.metricName || selectedMetric}</div>
               {(loading || !allMetrics) ? (
                 <div className="flex items-center justify-center h-[300px] text-gray-400 animate-pulse">Loading CSP API data...</div>
-              ) : activeData?.series ? (
+              ) : activeData?.unsupported ? (
+                <div className="flex items-center justify-center h-[300px] text-gray-400">Not supported for this resource</div>
+              ) : activeData?.series?.[0]?.data?.length ? (
                 <div className="bg-white rounded border p-3">
                   <MetricChart title={`${activeData.metricName} (${activeData.metricUnit})`} series={activeData.series} height={300} />
                 </div>

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -221,7 +221,7 @@ export default function MonitoringConfig() {
         <div className="p-4 flex items-center gap-4">
           <span className="text-sm text-gray-600">{infraId ? 'Workload:' : 'Namespace:'}</span>
           <span className="font-medium">{infraId || nsId}</span>
-          <button onClick={loadNodes} className="ml-auto text-sm text-gray-500 hover:text-gray-700">Refresh</button>
+          <button onClick={() => loadNodes()} className="ml-auto text-sm text-gray-500 hover:text-gray-700">Refresh</button>
         </div>
       </div>
 

--- a/front/src/pages/MonitoringDashboard.jsx
+++ b/front/src/pages/MonitoringDashboard.jsx
@@ -438,7 +438,9 @@ export default function MonitoringDashboard() {
             </div>
             {(cspLoading || !cspMetrics) ? (
               <div className="flex items-center justify-center h-[300px] text-gray-400 animate-pulse">Loading CSP API data...</div>
-            ) : cspMetrics[selectedCspMetric]?.series ? (
+            ) : cspMetrics[selectedCspMetric]?.unsupported ? (
+              <div className="flex items-center justify-center h-[300px] text-gray-400">Not supported for this resource</div>
+            ) : cspMetrics[selectedCspMetric]?.series?.[0]?.data?.length ? (
               <div className="bg-white rounded border p-3">
                 <MetricChart
                   title={`${cspMetrics[selectedCspMetric].metricName} (${cspMetrics[selectedCspMetric].metricUnit})`}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
@@ -141,11 +141,14 @@ public class CspMonitoringController {
                 });
     }
 
-    /** An empty monitoring series, used when cb-spider has no data for the resource/metric. */
+    /**
+     * An empty series flagged unsupported, used when cb-spider can't monitor the resource/metric.
+     */
     private static SpiderMonitoringInfo.Data emptyData(String measurement) {
         SpiderMonitoringInfo.Data d = new SpiderMonitoringInfo.Data();
         d.setMetricName(measurement);
         d.setTimestampValues(java.util.List.of());
+        d.setUnsupported(true);
         return d;
     }
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/SpiderMonitoringInfo.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/dto/SpiderMonitoringInfo.java
@@ -18,6 +18,13 @@ public class SpiderMonitoringInfo {
         private String metricUnit;
         private List<TimestampValue> timestampValues;
 
+        /**
+         * True when cb-spider cannot provide this metric for the resource (unsupported metric, or a
+         * resource — e.g. a K8s node — that has no CSP monitoring). Lets the UI show "not
+         * supported" rather than a misleading "no data". Null/false on a normal response.
+         */
+        private Boolean unsupported;
+
         @Getter
         @Setter
         @NoArgsConstructor


### PR DESCRIPTION
## Summary
세 가지 모니터링/Config UX 수정:

1. **CSP 메트릭 "지원 안됨" 표시**: cb-spider가 해당 리소스에 모니터링을 못 줄 때(예:
   k8s 노드를 VM으로 조회, 미지원 메트릭) 그냥 "No data"가 아니라 **"Not supported for
   this resource"** 로 표시. 매니저가 `unsupported` 플래그를 실어주고 프론트가 구분 표시.
2. **상단 Infra 셀렉터 유지**: infra를 선택하면 우측 상단 Infra 드롭다운이 사라져 다른
   infra로 못 넘어가던 것을 → 선택 후에도 드롭다운 유지(현재 infra 표시 + 전환 가능,
   빈 선택 시 네임스페이스 레벨로).
3. **Config Refresh 버튼 피드백**: 버튼이 클릭 이벤트를 silent 인자로 넘겨 로딩 표시
   없이 조용히 새로고침되던 것을 → `loadNodes()` 호출로 로딩 상태가 보이게.

## Changes
- `SpiderMonitoringInfo.Data.unsupported` + `CspMonitoringController` emptyData 플래그
- `api/csp.js`, `api/k8s.js`: unsupported 전파
- `InfraOverview`, `K8sNodeDashboard`, `MonitoringDashboard`: unsupported→"Not supported"
- `Layout`: infra 셀렉터 항상 표시
- `MonitoringConfig`: refresh 버튼

## Note
Config 로그 에이전트 설치가 "Install로 되돌아가던" 문제는 별개로, 기존 DB의 ENUM 컬럼
(`*_agent_status`)에 `NOT_INSTALLED` 값이 없어 상태 저장이 truncate되던 것이 원인 —
해당 환경 DB에 ALTER로 값 추가하여 해결(코드 변경 아님, 기존 마이그레이션 누락분).
