### PR TITLE
fix: k8s log agent installs on EKS (Fluent Bit host binary) and precise CSP 'unsupported'

### DIFF
--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -43,13 +43,13 @@ export default function K8sAgentPanel({ nsId }) {
       setStatusMap((m) => ({ ...m, [clusterId]: Array.isArray(s) ? s : [] }));
       ok = true;
     } catch { /* keep previous data + "Checking…" state; the periodic refresh retries */ }
+    // Mark "loaded" as soon as the agent status is in — don't let a slow/hanging log-status
+    // request (best-effort) keep the whole panel stuck on "Checking agent status…".
+    if (ok) setStatusLoaded((m) => ({ ...m, [clusterId]: true }));
     try {
       const l = await getK8sLogStatus(nsId, clusterId);
       setLogMap((m) => ({ ...m, [clusterId]: Array.isArray(l) ? l : [] }));
     } catch { /* log status is best-effort */ }
-    // Only mark "loaded" once the agent status actually came back, so a transient failure
-    // (e.g. rate limit) shows "Checking agent status…" instead of "No nodes".
-    if (ok) setStatusLoaded((m) => ({ ...m, [clusterId]: true }));
   }, [nsId]);
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/controller/CspMonitoringController.java
@@ -7,6 +7,7 @@ import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
 import com.mcmp.o11ymanager.manager.service.cache.ClusterListCacheService;
 import com.mcmp.o11ymanager.manager.service.cache.CspCacheKey;
 import com.mcmp.o11ymanager.manager.service.cache.CspCacheService;
+import feign.FeignException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -83,7 +84,7 @@ public class CspMonitoringController {
                                 nodeName,
                                 measurement,
                                 e.toString());
-                        return emptyData(measurement);
+                        return emptyData(measurement, isUnsupported(e));
                     }
                 });
     }
@@ -136,20 +137,49 @@ public class CspMonitoringController {
                                 nodeNumber,
                                 measurement,
                                 e.toString());
-                        return emptyData(measurement);
+                        return emptyData(measurement, isUnsupported(e));
                     }
                 });
     }
 
     /**
-     * An empty series flagged unsupported, used when cb-spider can't monitor the resource/metric.
+     * An empty series. {@code unsupported=true} only when cb-spider genuinely can't serve the
+     * metric/resource (a 4xx — not found / invalid metric); a transient failure (5xx, timeout,
+     * rate-limit) leaves it false so the UI shows a retryable "no data" rather than "not
+     * supported".
      */
-    private static SpiderMonitoringInfo.Data emptyData(String measurement) {
+    private static SpiderMonitoringInfo.Data emptyData(String measurement, boolean unsupported) {
         SpiderMonitoringInfo.Data d = new SpiderMonitoringInfo.Data();
         d.setMetricName(measurement);
         d.setTimestampValues(java.util.List.of());
-        d.setUnsupported(true);
+        d.setUnsupported(unsupported);
         return d;
+    }
+
+    /**
+     * True when the cb-spider error means the metric/resource is genuinely unsupported (HTTP 4xx,
+     * or a message like "not found" / "invalid metric"), as opposed to a transient/server error.
+     */
+    private static boolean isUnsupported(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            // Check the message first — cb-spider returns 500 with "Invalid Metric Type" for an
+            // unsupported metric (e.g. AWS EKS cluster nodes), which is a genuine "unsupported",
+            // not a transient server error.
+            String m = t.getMessage();
+            if (m != null) {
+                String lm = m.toLowerCase();
+                if (lm.contains("not found")
+                        || lm.contains("invalid metric")
+                        || lm.contains("not supported")
+                        || lm.contains("unsupported")) {
+                    return true;
+                }
+            }
+            if (t instanceof FeignException fe && fe.status() >= 400 && fe.status() < 500) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @GetMapping("/cache/stats")

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -72,9 +72,7 @@ public class K8sAgentService {
 
     private static final List<String> DEFAULT_METRICS = new ArrayList<>(INPUTS.keySet());
 
-    /** Log agent (fluent-bit) runs as a podman container on the node host, shipping to Loki. */
-    private static final String FLUENT_BIT_IMAGE = "docker.io/fluent/fluent-bit:3.2.4";
-
+    /** Log agent: Fluent Bit installed as a host binary (official OS package), shipping to Loki. */
     private static final int LOKI_PORT = 3100;
 
     private final HttpClient http =
@@ -434,12 +432,17 @@ public class K8sAgentService {
 
     private String logInstallScript(
             String nsId, String clusterId, String nodeName, String lokiHost) {
+        // Install Fluent Bit as a host binary via its official OS package (the install.sh detects
+        // apt/dnf/yum and adds the right repo). This works across Ubuntu and Amazon Linux 2023 —
+        // unlike the previous podman approach, since EKS AL2023 nodes have no podman in their
+        // repos.
         return """
                 set -e
-                export DEBIAN_FRONTEND=noninteractive
-                if ! command -v podman >/dev/null 2>&1; then apt-get update -qq && apt-get install -y -qq podman; fi
-                PODMAN=$(command -v podman)
-                "$PODMAN" pull %s
+                if [ ! -x /opt/fluent-bit/bin/fluent-bit ] && ! command -v fluent-bit >/dev/null 2>&1; then
+                  curl -fsSL https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh -o /tmp/cmp-fbi.sh
+                  sh /tmp/cmp-fbi.sh
+                fi
+                FB=$(command -v fluent-bit || echo /opt/fluent-bit/bin/fluent-bit)
                 mkdir -p /etc/cmp-fluent-bit
                 cat > /etc/cmp-fluent-bit/fluent-bit.conf <<'CONF'
                 [SERVICE]
@@ -448,7 +451,7 @@ public class K8sAgentService {
                 [INPUT]
                     name tail
                     tag k8slog
-                    path /var/log/syslog,/var/log/containers/*.log
+                    path /var/log/messages,/var/log/syslog,/var/log/containers/*.log
                     Read_from_Head false
                 [OUTPUT]
                     name loki
@@ -457,16 +460,13 @@ public class K8sAgentService {
                     port %d
                     labels NS_ID=%s, INFRA_ID=%s, NODE_ID=%s
                 CONF
-                "$PODMAN" rm -f cmp-fluent-bit >/dev/null 2>&1 || true
                 cat > /etc/systemd/system/cmp-fluent-bit.service <<SVC
                 [Unit]
                 Description=CMP Fluent Bit (k8s node host log agent)
                 After=network-online.target
                 Wants=network-online.target
                 [Service]
-                ExecStartPre=-$PODMAN rm -f cmp-fluent-bit
-                ExecStart=$PODMAN run --rm --name cmp-fluent-bit --network=host -v /var/log:/var/log:ro -v /etc/cmp-fluent-bit:/etc/cmp-fluent-bit:ro %s -c /etc/cmp-fluent-bit/fluent-bit.conf
-                ExecStop=$PODMAN stop -t 10 cmp-fluent-bit
+                ExecStart=$FB -c /etc/cmp-fluent-bit/fluent-bit.conf
                 Restart=always
                 RestartSec=5
                 [Install]
@@ -475,21 +475,12 @@ public class K8sAgentService {
                 systemctl daemon-reload
                 systemctl enable --now cmp-fluent-bit
                 """
-                .formatted(
-                        FLUENT_BIT_IMAGE,
-                        lokiHost,
-                        LOKI_PORT,
-                        nsId,
-                        clusterId,
-                        nodeName,
-                        FLUENT_BIT_IMAGE);
+                .formatted(lokiHost, LOKI_PORT, nsId, clusterId, nodeName);
     }
 
     private String logUninstallScript() {
         return """
                 systemctl disable --now cmp-fluent-bit 2>/dev/null || true
-                PODMAN=$(command -v podman)
-                [ -n "$PODMAN" ] && "$PODMAN" rm -f cmp-fluent-bit 2>/dev/null || true
                 rm -f /etc/systemd/system/cmp-fluent-bit.service
                 rm -rf /etc/cmp-fluent-bit
                 systemctl daemon-reload 2>/dev/null || true


### PR DESCRIPTION
## Summary
1. **K8s 로그 에이전트(Fluent Bit) 설치 — EKS 호환 수정**: 기존엔 podman 컨테이너로
   띄웠는데, **AWS EKS 노드(Amazon Linux 2023)는 podman이 기본 레포에 없어**
   설치 Job이 실패했음. Fluent Bit 공식 install.sh(apt/dnf/yum 자동 감지)로 **호스트
   바이너리(`/opt/fluent-bit/bin/fluent-bit`)를 설치하고 systemd로 직접 실행**하도록
   변경 — Ubuntu/Amazon Linux 모두 동작. (telegraf와 동일하게 OS 무관.)
2. **CSP "지원 안됨" 판정 정교화**: cb-spider 실패를 무조건 unsupported로 표시하던 것을,
   **진짜 미지원(메시지 "Invalid Metric Type"/"Not Found" 또는 4xx)만 unsupported**,
   일시 오류(5xx/timeout)는 "no data"(재시도)로 구분.
3. **Config K8s 패널 멈춤 수정**: best-effort인 로그 상태 요청이 느리면 패널이
   "Checking agent status…"에 갇히던 것을, agent status가 오면 즉시 로드 처리.

## Verification (AWS EKS 구동)
- 로그 에이전트 설치: `ok:false → ok:true, "installed"` (Fluent Bit v5.0.8 바이너리 설치 확인)
- EKS는 cb-spider가 클러스터노드의 memory 모니터링을 미지원("Invalid Metric Type") → unsupported 표시 정확
