### PR TITLE
fix: no agent install/uninstall buttons on non-running VMs

### DIFF
--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -111,7 +111,7 @@ export default function MonitoringConfig() {
       for (const p of toAdd) await createNodeItem(nsId, infra, selectedNode.id, { pluginSeq: p.seq });
       setItems(await getNodeItems(nsId, infra, selectedNode.id));
     } catch (err) {
-      alert('Failed: ' + (err.response?.data?.error_message || err.message));
+      alert('Failed: ' + (err.response?.data?.error_message || err.response?.data?.message || err.message));
     }
     setBusy(false); setBusyMsg('');
   }
@@ -134,7 +134,7 @@ export default function MonitoringConfig() {
       await a[op](nsId, infra, node.id);
       startPolling(node.id, infra, a.field, `${verb}ing ${a.label}`, kind, op);
     } catch (err) {
-      alert(`${verb} failed: ` + (err.response?.data?.error_message || err.message));
+      alert(`${verb} failed: ` + (err.response?.data?.error_message || err.response?.data?.message || err.message));
       setGlobalBusy(false);
       setBusyMsg('');
     }
@@ -192,7 +192,7 @@ export default function MonitoringConfig() {
       }
       setItems(await getNodeItems(nsId, selectedNodeInfraId || infraId, selectedNode.id));
     } catch (err) {
-      alert('Failed: ' + (err.response?.data?.error_message || err.message));
+      alert('Failed: ' + (err.response?.data?.error_message || err.response?.data?.message || err.message));
     }
     setBusy(false);
     setBusyMsg('');
@@ -258,8 +258,13 @@ export default function MonitoringConfig() {
                     const installed = isAgentInstalled(status);
                     if (status === 'INSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>;
                     if (status === 'UNINSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Uninstalling…</span>;
+                    // Install AND uninstall both connect to the host over SSH, which fails ("FAILED
+                    // TO CONNECT VM") on a VM that isn't running (suspended/failed/stopped). Don't
+                    // offer either button then — just reflect the current agent state.
+                    if (run !== 'running') {
+                      return <span className="text-xs text-gray-400" title={`Node is not running (${node.status || 'unknown'})`}>{installed ? 'installed' : '—'}</span>;
+                    }
                     if (installed) return <button onClick={(e) => handleAgent(e, node, kind, 'uninstall')} disabled={busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
-                    if (run !== 'running') return <span className="text-xs text-gray-400" title="Node is not running">—</span>;
                     return <button onClick={(e) => handleAgent(e, node, kind, 'install')} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>;
                   };
                   return (

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -52,7 +52,9 @@ public class VMFacadeService {
                             : VMStatus.FAILED;
 
             if (status != VMStatus.RUNNING) {
-                throw new RuntimeException("FAILED TO CONNECT VM");
+                throw new IllegalArgumentException(
+                        "Cannot connect to the VM — it must be running and reachable to"
+                                + " install/uninstall an agent. Start the VM and try again.");
             }
 
             Long influxSeq = influxDbService.resolveInfluxDb(nsId, infraId);


### PR DESCRIPTION
## Summary
- **정지/실패 VM에서 agent install·uninstall 버튼 숨김**: Config의 VM 목록에서 VM이
  running이 아닐 때(suspended/failed/stopped) install/uninstall 둘 다 호스트에 SSH
  연결이 필요해 실패하므로, 버튼 대신 현재 상태('installed' 또는 '—')만 표시.
  (기존엔 설치돼 있으면 정지 상태에서도 Uninstall이 노출돼 누르면 500.)
- **연결 실패 시 500 → 400(명확 메시지)**: VM에 연결 못 할 때 `RuntimeException("FAILED
  TO CONNECT VM")`로 500을 던지던 것을, 사유가 담긴 `IllegalArgumentException`(400)으로
  변경 → 프론트 alert에 "Start the VM and try again" 안내가 보이게.
- 프론트 에러 alert이 응답의 `message` 필드도 읽도록 보강.

## Changes
- `MonitoringConfig`: agentControl이 running이 아니면 버튼 미노출
- `VMFacadeService`: 연결 실패 시 400(IllegalArgumentException) + 명확 메시지
