### PR TITLE
fix: clear 400 on the second VM connect check

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -141,7 +141,9 @@ public class VMFacadeService {
                         ? VMStatus.RUNNING
                         : VMStatus.FAILED;
         if (status != VMStatus.RUNNING) {
-            throw new RuntimeException("FAILED TO CONNECT VM");
+            throw new IllegalArgumentException(
+                    "Cannot connect to the VM — it must be running and reachable to"
+                            + " install/uninstall an agent. Start the VM and try again.");
         }
         Long influxSeq = influxDbService.resolveInfluxDb(nsId, infraId);
         VMRequestDTO dto = VMRequestDTO.builder().name(nodeId).build();


### PR DESCRIPTION
이전 PR(#343)에서 `FAILED TO CONNECT VM` 두 곳 중 들여쓰기가 달라 한 곳만 IllegalArgumentException(400)으로 바뀌었음.