### PR TITLE
fix: Speed up K8s cluster-list

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/ClusterListCacheService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/ClusterListCacheService.java
@@ -26,8 +26,12 @@ public class ClusterListCacheService {
 
     private final SpiderClient spiderClient;
 
-    /** TTL must exceed the warmer interval so warmed entries never expire between ticks. */
-    @Value("${csp.cache.cluster-list.ttl-seconds:120}")
+    /**
+     * TTL must comfortably exceed one warm pass so entries don't expire mid-cycle and force the UI
+     * onto the slow cb-spider path. A warm pass can take minutes when some CSP connections are slow
+     * to list, so keep this generous — the warmer refreshes entries well before they expire.
+     */
+    @Value("${csp.cache.cluster-list.ttl-seconds:600}")
     private long ttlSeconds;
 
     private Cache<String, List<SpiderClusterInfo>> cache;
@@ -58,15 +62,26 @@ public class ClusterListCacheService {
 
     private List<SpiderClusterInfo> load(String connectionName) {
         List<SpiderClusterInfo> out = new ArrayList<>();
-        SpiderClusterList list = spiderClient.listClusters(connectionName);
-        if (list != null && list.getCluster() != null) {
-            for (SpiderClusterInfo c : list.getCluster()) {
-                try {
-                    out.add(spiderClient.getCluster(c.getIId().getNameId(), connectionName));
-                } catch (Exception e) {
-                    out.add(c);
+        try {
+            SpiderClusterList list = spiderClient.listClusters(connectionName);
+            if (list != null && list.getCluster() != null) {
+                for (SpiderClusterInfo c : list.getCluster()) {
+                    try {
+                        out.add(spiderClient.getCluster(c.getIId().getNameId(), connectionName));
+                    } catch (Exception e) {
+                        out.add(c);
+                    }
                 }
             }
+        } catch (Exception e) {
+            // cb-spider is slow/erroring for this connection (read timeout, 5xx, stale clusters).
+            // Cache an empty result so the UI returns instantly instead of repeatedly paying the
+            // slow cb-spider cost; the warmer keeps retrying and fills in real data once it
+            // recovers.
+            log.warn(
+                    "[CLUSTER-LIST] conn={} list failed, caching empty: {}",
+                    connectionName,
+                    e.toString());
         }
         return out;
     }


### PR DESCRIPTION
## Summary
K8s 뷰가 느렸던 원인: cb-spider가 일부 CSP 연결에서 listClusters를 read-timeout/5xx로 실패(예: aws-ap-northeast-1 Read timed out, tencent 500). 기존 `ClusterListCacheService.load()`는 실패 시 예외를 전파해 **캐시에 안 남았고**, 프론트가 매 요청마다 느린 cb-spider를 직접 침. 워머 한 바퀴도 이 timeout들 때문에 ~180초.

## Changes
- `load()`: cb-spider 실패 시 빈 결과를 반환→**캐싱**(negative cache). 프론트는 즉시 응답, 워머가 백그라운드로 재시도해 복구되면 실제 데이터로 채움.
- cluster-list 캐시 TTL 기본 120s→600s: 느린 워머 한 바퀴를 넘겨 엔트리가 중간에 만료돼 콜드 경로로 떨어지지 않도록.

## Verification
- aws-ap-northeast-1: Read timeout → 0.005s
- tencent-ap-tokyo: 500 → 0.16s (200)
- aws-ap-northeast-2: 0.006s