### PR TITLE
fix: harden k8s/VM agent install and status

### DIFF
--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/facade/VMFacadeService.java
@@ -127,7 +127,14 @@ public class VMFacadeService {
     private void ensureRegistered(String nsId, String infraId, String nodeId, Agent installing) {
         boolean exists;
         try {
-            vmService.getByNsVm(nsId, nodeId);
+            // Must check by the full (nsId, infraId, nodeId) key, not (nsId, nodeId): node ids are
+            // only unique within an MCI, so different MCIs routinely share one (e.g. every
+            // cluster's
+            // first node is "n1-1"). A (nsId, nodeId) lookup matches a *different* MCI's node, so
+            // we
+            // wrongly conclude this node is already registered, skip the insert, and the subsequent
+            // agent install fails with "VMEntity ID does not exist".
+            vmService.get(nsId, infraId, nodeId);
             exists = true;
         } catch (Exception e) {
             exists = false;
@@ -181,7 +188,31 @@ public class VMFacadeService {
         try {
             hostLock.lock();
 
-            VMDTO savedVM = vmService.get(nsId, infraId, nodeId);
+            VMDTO savedVM;
+            try {
+                savedVM = vmService.get(nsId, infraId, nodeId);
+            } catch (Exception notRegistered) {
+                // The node exists in cb-tumblebug but was never registered for monitoring (no
+                // agent installed yet). Don't 500 here — the monitoring-config page polls this for
+                // every tumblebug node, and a hard error makes the UI retry in a tight loop and
+                // pile requests up. Report the node as installable (NOT_INSTALLED) so the page can
+                // render an Install button. Display name is best-effort from tumblebug.
+                String name = nodeId;
+                try {
+                    name = tumblebugService.getNode(nsId, infraId, nodeId).getName();
+                } catch (Exception ignore) {
+                    // tumblebug node lookup is best-effort for the label only
+                }
+                return VMDTO.builder()
+                        .nodeId(nodeId)
+                        .name(name != null ? name : nodeId)
+                        .nsId(nsId)
+                        .infraId(infraId)
+                        .monitoringAgentStatus(AgentStatus.NOT_INSTALLED)
+                        .logAgentStatus(AgentStatus.NOT_INSTALLED)
+                        .traceAgentStatus(AgentStatus.NOT_INSTALLED)
+                        .build();
+            }
             TumblebugInfra.Node node = tumblebugService.getNode(nsId, infraId, nodeId);
             String userName = node.getNodeUserName();
             log.info(

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/model/host/VMAgentTaskStatus.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/model/host/VMAgentTaskStatus.java
@@ -20,4 +20,19 @@ public enum VMAgentTaskStatus {
     VMAgentTaskStatus(String message) {
         this.message = message;
     }
+
+    /**
+     * Whether an agent task is actively running, i.e. a new install/uninstall must be rejected.
+     * IDLE/FINISHED/FAILED/NOT_INSTALLED are all settled states from which a new task may start —
+     * notably NOT_INSTALLED, which is the resting state of the *other* agent after one agent is
+     * installed and must not block installing it.
+     */
+    public boolean isBusy() {
+        return this == PREPARING
+                || this == INSTALLING
+                || this == UPDATING
+                || this == UPDATING_CONFIG
+                || this == UNINSTALLING
+                || this == RESTARTING;
+    }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -1,5 +1,7 @@
 package com.mcmp.o11ymanager.manager.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
 import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
@@ -77,6 +79,16 @@ public class K8sAgentService {
 
     private final HttpClient http =
             HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+    // Per-node status is expensive: a live cb-spider getCluster (CSP round-trip) plus InfluxDB
+    // cardinality/last-seen queries, run once per cluster. The UI polls every cluster's agent and
+    // log-agent status on a short interval, so without caching those slow calls pile up in the
+    // Tomcat queue and the whole UI stalls behind them. A short TTL collapses a burst of polls into
+    // a single backend pass while keeping status fresh enough to be useful.
+    private final Cache<String, List<NodeStatus>> statusCache =
+            Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(15)).maximumSize(500).build();
+    private final Cache<String, List<NodeStatus>> logStatusCache =
+            Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(15)).maximumSize(500).build();
 
     @Getter
     @lombok.AllArgsConstructor
@@ -330,6 +342,10 @@ public class K8sAgentService {
 
     /** Per-node log agent status (running = node logs present in Loki recently). */
     public List<NodeStatus> logStatus(String nsId, String clusterId) {
+        return logStatusCache.get(nsId + "/" + clusterId, k -> computeLogStatus(nsId, clusterId));
+    }
+
+    private List<NodeStatus> computeLogStatus(String nsId, String clusterId) {
         String lokiHost = null;
         Map<String, String> historical = Map.of();
         try {
@@ -489,6 +505,10 @@ public class K8sAgentService {
     }
 
     public List<NodeStatus> status(String nsId, String clusterId) {
+        return statusCache.get(nsId + "/" + clusterId, k -> computeStatus(nsId, clusterId));
+    }
+
+    private List<NodeStatus> computeStatus(String nsId, String clusterId) {
         // InfluxDB may be unresolvable (e.g. a cluster that never had an agent / no monitoring
         // target). That just means no agent history — still list the nodes from cb-spider.
         Map<String, String> lastSeen = Map.of();
@@ -617,15 +637,57 @@ public class K8sAgentService {
                     return n.getMetadata().getName();
                 }
             }
+            // Azure AKS: cb-spider names the node "<vmss>_<index>" (with an underscore, which is
+            // not
+            // even a valid k8s node name) while the real node name is the VMSS instance DNS
+            // ("<vmss>00000<index>"). Link them through the providerID
+            // (.../virtualMachineScaleSets/<vmss>/virtualMachines/<index>).
+            java.util.regex.Pattern vmss =
+                    java.util.regex.Pattern.compile(
+                            "virtualMachineScaleSets/([^/]+)/virtualMachines/([^/]+)");
+            for (Node n : nodes) {
+                String pid = n.getSpec() == null ? null : n.getSpec().getProviderID();
+                if (pid == null) {
+                    continue;
+                }
+                java.util.regex.Matcher m = vmss.matcher(pid);
+                if (m.find() && (m.group(1) + "_" + m.group(2)).equals(nodeName)) {
+                    return n.getMetadata().getName();
+                }
+            }
         } catch (Exception e) {
             log.warn("resolveK8sNodeName failed for node={}: {}", nodeName, e.toString());
         }
         return nodeName;
     }
 
+    /**
+     * Builds a Job name that stays within Kubernetes' 63-character label limit. The Job controller
+     * copies the Job name into the pod template's {@code job-name} label, so an over-long name
+     * (e.g. EKS {@code ip-…-ap-northeast-2.compute.internal} or NHN {@code
+     * …-default-worker-node-0}) makes the API server reject the Job with "spec.template.labels …
+     * must be no more than 63 characters". Keep it unique by appending a short hash of the full
+     * node name when truncation is needed.
+     */
+    private static String boundedJobName(String prefix, String nodeName) {
+        String full = prefix + sanitize(nodeName);
+        if (full.length() <= 63) {
+            return full;
+        }
+        String hash = Integer.toHexString(nodeName.hashCode());
+        int keep = 63 - prefix.length() - 1 - hash.length();
+        String head = sanitize(nodeName);
+        if (keep < 1) {
+            head = "";
+        } else if (head.length() > keep) {
+            head = head.substring(0, keep);
+        }
+        return (prefix + head + "-" + hash).replaceAll("-+", "-").replaceAll("-+$", "");
+    }
+
     private void runJob(KubernetesClient k8s, String prefix, String nodeName, String script) {
         String b64 = Base64.getEncoder().encodeToString(script.getBytes(StandardCharsets.UTF_8));
-        String jobName = prefix + sanitize(nodeName);
+        String jobName = boundedJobName(prefix, nodeName);
         // Clean any stale job with the same name first.
         k8s.batch().v1().jobs().inNamespace(JOB_NS).withName(jobName).delete();
 

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/VMServiceImpl.java
@@ -179,12 +179,10 @@ public class VMServiceImpl implements VMService {
                                         new ResourceNotExistsException(
                                                 requestInfo.getRequestId(), "VMEntity", nodeId));
 
-        if (vm.getMonitoringAgentTaskStatus() != VMAgentTaskStatus.IDLE) {
+        VMAgentTaskStatus status = vm.getMonitoringAgentTaskStatus();
+        if (status != null && status.isBusy()) {
             throw new VMAgentTaskProcessingException(
-                    requestInfo.getRequestId(),
-                    nodeId,
-                    "monitoringAgentTask",
-                    vm.getMonitoringAgentTaskStatus());
+                    requestInfo.getRequestId(), nodeId, "monitoringAgentTask", status);
         }
     }
 
@@ -198,9 +196,10 @@ public class VMServiceImpl implements VMService {
                                         new ResourceNotExistsException(
                                                 requestInfo.getRequestId(), "VMEntity", nodeId));
 
-        if (vm.getLogAgentTaskStatus() != VMAgentTaskStatus.IDLE) {
+        VMAgentTaskStatus status = vm.getLogAgentTaskStatus();
+        if (status != null && status.isBusy()) {
             throw new VMAgentTaskProcessingException(
-                    requestInfo.getRequestId(), nodeId, "로그", vm.getLogAgentTaskStatus());
+                    requestInfo.getRequestId(), nodeId, "로그", status);
         }
     }
 
@@ -218,7 +217,7 @@ public class VMServiceImpl implements VMService {
         // NULL은 아직 Beyla 작업이 한 번도 없었던 상태로 간주하고 IDLE과 동일하게 취급.
         // ddl-auto:update로 trace_agent_task_status 컬럼이 새로 추가되면서
         // 기존 VM 레코드들이 NULL로 남아있는 경우를 대응.
-        if (status != null && status != VMAgentTaskStatus.IDLE) {
+        if (status != null && status.isBusy()) {
             throw new VMAgentTaskProcessingException(
                     requestInfo.getRequestId(), nodeId, "traceAgent", status);
         }


### PR DESCRIPTION
## Changed

여러 CSP에 걸쳐 많은 노드를 모니터링할 때 드러난, 매니저의 VM/K8s 에이전트 설치·상태 경로에 대한 견고성 수정입니다.

- **K8s 에이전트/로그-에이전트 상태 캐싱** — `status()`/`logStatus()`는 클러스터마다 cb-spider `getCluster`(CSP 왕복)와 InfluxDB cardinality/last-seen 쿼리를 수행합니다. UI가 모든 클러스터의 상태를 짧은 주기로 폴링하다 보니 이 느린 호출들이 Tomcat 큐에 쌓여 UI 전체가 멈췄습니다. 15초 Caffeine 캐시를 추가해 폴링 버스트를 한 번의 백엔드 호출로 합칩니다.

- **미등록 노드에 대한 getVM graceful 처리** — 모니터링 설정 페이지는 모든 tumblebug 노드에 대해 `getVM`을 폴링하는데, 아직 에이전트가 없는 노드는 `ResourceNotExistsException`(HTTP 500)을 던졌고 UI가 이를 타이트한 루프로 재시도했습니다. 이제 NOT_INSTALLED 상태를 반환해 페이지가 Install 버튼을 표시할 수 있게 합니다.

- **ensureRegistered가 (ns, infra, node) 전체 키 사용** — 노드 id는 MCI 내에서만 유일하므로 서로 다른 MCI가 같은 id를 흔히 공유합니다(예: 모든 클러스터의 첫 노드 `n1-1`). (ns, node)만으로 조회하면 다른 MCI의 노드를 찾아 등록을 잘못 건너뛰어 "VMEntity ID does not exist"로 설치가 실패했습니다.

- **에이전트 작업 가드가 실제 진행 중 상태만 차단** — 한 에이전트를 설치하면 다른 에이전트는 NOT_INSTALLED로 남는데, idle 체크가 이를 "진행 중"으로 잘못 거부했습니다. 이제 PREPARING/INSTALLING/UPDATING/UPDATING_CONFIG/UNINSTALLING/RESTARTING 상태만 새 작업을 차단합니다.

- **K8s Job 이름 길이 + Azure 노드 매핑** — Job 컨트롤러는 Job 이름을 파드 템플릿의 `job-name` 라벨(63자 제한)로 복사하므로, 긴 노드 이름(EKS `ip-…compute.internal`, NHN `…-worker-node-0`)은 거부되었습니다. 이제 Job 이름을 63자 이하로 제한(짧은 해시 사용)합니다. 또한 Azure AKS 노드 이름(`<vmss>_<index>`)을 `providerID`를 통해 실제 VMSS 노드로 매핑합니다.
