### PR TITLE
feat: persist K8s node agent task state (per-node lock + cross-tab progress)

### DIFF
--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -130,6 +130,13 @@ export default function K8sAgentPanel({ nsId }) {
                     // Agents can only be installed/uninstalled on a powered-on node with a real name.
                     const actionable = powered && !n.placeholder;
                     const selectable = !n.placeholder;
+                    // Durable, cross-tab agent task state from the server (INSTALLING/UNINSTALLING/…).
+                    const monTask = n.taskStatus;
+                    const monPending = monTask === 'INSTALLING' || monTask === 'UNINSTALLING';
+                    const logNode = (logMap[c.id] || []).find((x) => x.node === n.node);
+                    const logInstalled = logNode?.installed;
+                    const logTask = logNode?.taskStatus;
+                    const logPending = logTask === 'INSTALLING' || logTask === 'UNINSTALLING';
                     return (
                       <tr key={n.node} onClick={() => selectable && selectNode(c.id, n.node)}
                         className={`${selectable ? 'cursor-pointer hover:bg-blue-50' : 'cursor-default'} ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
@@ -142,20 +149,24 @@ export default function K8sAgentPanel({ nsId }) {
                         </td>
                         <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
                           <div className="flex items-center gap-2">
-                            <AgentBadge running={monOn} installed={n.installed} powered={powered} />
+                            <AgentBadge running={monOn} installed={n.installed} powered={powered} pending={monTask} />
                             {!actionable
                               ? <span className="text-xs text-gray-400">{powered ? '' : 'start cluster to manage'}</span>
-                              : !monOn
+                              : monPending
+                              ? <PendingLabel kind={monTask} />
+                              : !n.installed
                               ? <button onClick={() => run(`${c.id}/${n.node}/mon`, `Installing agent on ${n.node}…`, () => installK8sNode(nsId, c.id, n.node, null), c.id)} disabled={!!busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
                               : <button onClick={() => run(`${c.id}/${n.node}/mon`, `Uninstalling agent from ${n.node}…`, () => uninstallK8sNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
                           </div>
                         </td>
                         <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
                           <div className="flex items-center gap-2">
-                            <AgentBadge running={logOn} powered={powered} />
+                            <AgentBadge running={logOn} installed={logInstalled} powered={powered} pending={logTask} />
                             {!actionable
                               ? <span className="text-xs text-gray-400">{powered ? '' : 'start cluster to manage'}</span>
-                              : !logOn
+                              : logPending
+                              ? <PendingLabel kind={logTask} />
+                              : !logInstalled
                               ? <button onClick={() => run(`${c.id}/${n.node}/log`, `Installing log agent on ${n.node}…`, () => installK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
                               : <button onClick={() => run(`${c.id}/${n.node}/log`, `Uninstalling log agent from ${n.node}…`, () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
                           </div>
@@ -212,9 +223,23 @@ export default function K8sAgentPanel({ nsId }) {
   );
 }
 
-function AgentBadge({ running, installed, powered }) {
+function AgentBadge({ running, installed, powered, pending }) {
+  if (pending === 'INSTALLING' || pending === 'UNINSTALLING')
+    return <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700">{pending === 'INSTALLING' ? 'Installing…' : 'Uninstalling…'}</span>;
   if (running) return <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">Running</span>;
+  if (pending === 'FAILED') return <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700">Failed</span>;
   if (installed && powered === false) return <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">Installed · off</span>;
+  if (installed) return <span className="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">Installed</span>;
   if (powered === false) return <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-400">—</span>;
   return <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">Not installed</span>;
+}
+
+/** Inline spinner + label shown while a node's agent install/uninstall is running (any tab). */
+function PendingLabel({ kind }) {
+  return (
+    <span className="text-xs text-gray-500 inline-flex items-center gap-1">
+      <span className="w-3 h-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+      {kind === 'UNINSTALLING' ? 'Uninstalling…' : 'Installing…'}
+    </span>
+  );
 }

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -24,6 +24,9 @@ export default function MonitoringConfig() {
   const [itemLoading, setItemLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [busyMsg, setBusyMsg] = useState('');
+  // Node id the metric apply/toggle overlay belongs to, so switching to another node mid-apply
+  // doesn't show "Applying…" on that other node's panel.
+  const [busyNodeId, setBusyNodeId] = useState(null);
   const [globalBusy, setGlobalBusy] = useState(false);
   const pollRef = useRef(null);
 
@@ -105,15 +108,17 @@ export default function MonitoringConfig() {
     const toAdd = inputPlugins.filter((p) => picked.has(p.seq) && !active.has(p.seq));
     const toRemove = items.filter((it) => !picked.has(it.pluginSeq));
     if (toAdd.length === 0 && toRemove.length === 0) return;
-    setBusy(true); setBusyMsg('Applying metric selection...');
+    const targetId = selectedNode.id;
+    setBusy(true); setBusyNodeId(targetId); setBusyMsg('Applying metric selection...');
     try {
-      for (const it of toRemove) await deleteNodeItem(nsId, infra, selectedNode.id, it.seq);
-      for (const p of toAdd) await createNodeItem(nsId, infra, selectedNode.id, { pluginSeq: p.seq });
-      setItems(await getNodeItems(nsId, infra, selectedNode.id));
+      for (const it of toRemove) await deleteNodeItem(nsId, infra, targetId, it.seq);
+      for (const p of toAdd) await createNodeItem(nsId, infra, targetId, { pluginSeq: p.seq });
+      const fresh = await getNodeItems(nsId, infra, targetId);
+      if (selectedNode?.id === targetId) setItems(fresh);
     } catch (err) {
       alert('Failed: ' + (err.response?.data?.error_message || err.response?.data?.message || err.message));
     }
-    setBusy(false); setBusyMsg('');
+    setBusy(false); setBusyNodeId(null); setBusyMsg('');
   }
 
   // --- Per-agent install / uninstall with polling (monitoring = telegraf, log = fluent-bit) ---
@@ -181,20 +186,23 @@ export default function MonitoringConfig() {
     const action = isActive ? 'Disable' : 'Enable';
     if (!confirm(`${action} "${plugin.name}" monitoring metric on ${selectedNode.name || selectedNode.id}?`)) return;
 
-    setBusy(true);
+    const targetId = selectedNode.id;
+    const infra = selectedNodeInfraId || infraId;
+    setBusy(true); setBusyNodeId(targetId);
     setBusyMsg(`${action === 'Enable' ? 'Enabling' : 'Disabling'} ${plugin.name} metric...`);
     try {
       if (isActive) {
         const item = items.find((it) => it.pluginSeq === plugin.seq);
-        if (item) await deleteNodeItem(nsId, selectedNodeInfraId || infraId, selectedNode.id, item.seq);
+        if (item) await deleteNodeItem(nsId, infra, targetId, item.seq);
       } else {
-        await createNodeItem(nsId, selectedNodeInfraId || infraId, selectedNode.id, { pluginSeq: plugin.seq });
+        await createNodeItem(nsId, infra, targetId, { pluginSeq: plugin.seq });
       }
-      setItems(await getNodeItems(nsId, selectedNodeInfraId || infraId, selectedNode.id));
+      const fresh = await getNodeItems(nsId, infra, targetId);
+      if (selectedNode?.id === targetId) setItems(fresh);
     } catch (err) {
       alert('Failed: ' + (err.response?.data?.error_message || err.response?.data?.message || err.message));
     }
-    setBusy(false);
+    setBusy(false); setBusyNodeId(null);
     setBusyMsg('');
   }
 
@@ -299,8 +307,8 @@ export default function MonitoringConfig() {
         <div className="bg-white rounded-lg shadow mt-3">
           <div className="px-4 py-3 border-b font-semibold">Monitoring Metrics — {selectedNode.name || selectedNode.id}</div>
           <div className="p-4 relative">
-            {/* Metric toggle busy overlay */}
-            {busy && (
+            {/* Metric toggle busy overlay — only on the node the apply/toggle actually targets */}
+            {busy && busyNodeId === selectedNode.id && (
               <div className="absolute inset-0 bg-white/70 backdrop-blur-[2px] z-10 flex items-center justify-center rounded">
                 <div className="text-center">
                   <div className="w-6 h-6 border-3 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/K8sAgentTaskEntity.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/K8sAgentTaskEntity.java
@@ -1,0 +1,49 @@
+package com.mcmp.o11ymanager.manager.entity;
+
+import com.mcmp.o11ymanager.manager.model.host.VMAgentTaskStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+/**
+ * Persisted agent-task state for a single Kubernetes node. K8s node metric/log presence is
+ * otherwise derived live (cb-spider + InfluxDB/Loki), which has no notion of "an install is
+ * currently running" — so two browser tabs both see an enabled Install button and can race. This
+ * row gives the install/uninstall flow a durable, cross-tab status
+ * (INSTALLING/UNINSTALLING/FINISHED/...), mirroring how VM nodes track it in the {@code node}
+ * table.
+ */
+@Entity
+@Table(name = "k8s_agent_task")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@DynamicUpdate
+@IdClass(K8sAgentTaskId.class)
+public class K8sAgentTaskEntity {
+
+    @Id private String nsId;
+
+    @Id private String clusterId;
+
+    @Id private String nodeName;
+
+    /** Telegraf (monitoring) agent task state. */
+    @Enumerated(EnumType.STRING)
+    private VMAgentTaskStatus monitoringTaskStatus;
+
+    /** Fluent Bit (log) agent task state. */
+    @Enumerated(EnumType.STRING)
+    private VMAgentTaskStatus logTaskStatus;
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/K8sAgentTaskId.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/entity/K8sAgentTaskId.java
@@ -1,0 +1,21 @@
+package com.mcmp.o11ymanager.manager.entity;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Composite primary key for {@link K8sAgentTaskEntity}: (nsId, clusterId, nodeName). */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class K8sAgentTaskId implements Serializable {
+
+    private String nsId;
+    private String clusterId;
+    private String nodeName;
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/repository/K8sAgentTaskJpaRepository.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/repository/K8sAgentTaskJpaRepository.java
@@ -1,0 +1,18 @@
+package com.mcmp.o11ymanager.manager.repository;
+
+import com.mcmp.o11ymanager.manager.entity.K8sAgentTaskEntity;
+import com.mcmp.o11ymanager.manager.entity.K8sAgentTaskId;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface K8sAgentTaskJpaRepository
+        extends JpaRepository<K8sAgentTaskEntity, K8sAgentTaskId> {
+
+    Optional<K8sAgentTaskEntity> findByNsIdAndClusterIdAndNodeName(
+            String nsId, String clusterId, String nodeName);
+
+    List<K8sAgentTaskEntity> findByNsIdAndClusterId(String nsId, String clusterId);
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/K8sAgentService.java
@@ -6,9 +6,12 @@ import com.mcmp.o11ymanager.manager.dto.SpiderClusterInfo;
 import com.mcmp.o11ymanager.manager.dto.influx.InfluxDTO;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
 import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sToken;
+import com.mcmp.o11ymanager.manager.entity.K8sAgentTaskEntity;
 import com.mcmp.o11ymanager.manager.facade.InfluxDbFacadeService;
 import com.mcmp.o11ymanager.manager.infrastructure.spider.SpiderClient;
 import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
+import com.mcmp.o11ymanager.manager.model.host.VMAgentTaskStatus;
+import com.mcmp.o11ymanager.manager.repository.K8sAgentTaskJpaRepository;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
@@ -29,6 +32,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +54,7 @@ public class K8sAgentService {
     private final TumblebugClient tumblebugClient;
     private final InfluxDbFacadeService influxDbFacadeService;
     private final SpiderClient spiderClient;
+    private final K8sAgentTaskJpaRepository agentTaskRepo;
 
     private static final String JOB_NS = "default";
     private static final String TELEGRAF_VERSION = "1.29.5";
@@ -90,6 +96,48 @@ public class K8sAgentService {
     private final Cache<String, List<NodeStatus>> logStatusCache =
             Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(15)).maximumSize(500).build();
 
+    // Per-node lock: serialize install/uninstall on a single k8s node so concurrent requests (e.g.
+    // two browser tabs) don't launch two Jobs that, sharing a name, delete each other mid-run.
+    private final ConcurrentHashMap<String, ReentrantLock> nodeLocks = new ConcurrentHashMap<>();
+
+    private ReentrantLock lockFor(String nsId, String clusterId, String node) {
+        return nodeLocks.computeIfAbsent(
+                nsId + "/" + clusterId + "/" + node, k -> new ReentrantLock());
+    }
+
+    private K8sAgentTaskEntity taskRow(String nsId, String clusterId, String node) {
+        return agentTaskRepo
+                .findByNsIdAndClusterIdAndNodeName(nsId, clusterId, node)
+                .orElseGet(
+                        () ->
+                                K8sAgentTaskEntity.builder()
+                                        .nsId(nsId)
+                                        .clusterId(clusterId)
+                                        .nodeName(node)
+                                        .build());
+    }
+
+    private void setMonitoringTask(
+            String nsId, String clusterId, String node, VMAgentTaskStatus status) {
+        K8sAgentTaskEntity e = taskRow(nsId, clusterId, node);
+        e.setMonitoringTaskStatus(status);
+        agentTaskRepo.save(e);
+    }
+
+    private void setLogTask(String nsId, String clusterId, String node, VMAgentTaskStatus status) {
+        K8sAgentTaskEntity e = taskRow(nsId, clusterId, node);
+        e.setLogTaskStatus(status);
+        agentTaskRepo.save(e);
+    }
+
+    /** Rejects a new op when one is already running on the node (durable, visible across tabs). */
+    private void assertNotBusy(VMAgentTaskStatus current) {
+        if (current != null && current.isBusy()) {
+            throw new IllegalStateException(
+                    "An agent task is already in progress on this node (" + current + ").");
+        }
+    }
+
     @Getter
     @lombok.AllArgsConstructor
     public static class NodeResult {
@@ -117,6 +165,7 @@ public class K8sAgentService {
         private String lastSeen; // ISO timestamp or null
         private PowerState powerState; // node host power state
         private boolean placeholder; // synthesized stopped node (real name not retrievable)
+        private String taskStatus; // durable agent task state (INSTALLING/UNINSTALLING/...) or null
     }
 
     /** One node discovered for a cluster, with whether its host is currently up. */
@@ -224,9 +273,27 @@ public class K8sAgentService {
 
     public NodeResult installNode(
             String nsId, String clusterId, String nodeName, List<String> metrics) {
-        InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
-        try (KubernetesClient k8s = client(nsId, clusterId)) {
-            return installOne(k8s, nsId, clusterId, nodeName, influx, metrics);
+        ReentrantLock lock = lockFor(nsId, clusterId, nodeName);
+        lock.lock();
+        try {
+            assertNotBusy(taskRow(nsId, clusterId, nodeName).getMonitoringTaskStatus());
+            setMonitoringTask(nsId, clusterId, nodeName, VMAgentTaskStatus.INSTALLING);
+            InfluxDTO influx = influxDbFacadeService.resolveForVM(nsId, clusterId);
+            NodeResult r;
+            try (KubernetesClient k8s = client(nsId, clusterId)) {
+                r = installOne(k8s, nsId, clusterId, nodeName, influx, metrics);
+            }
+            setMonitoringTask(
+                    nsId,
+                    clusterId,
+                    nodeName,
+                    r.isOk() ? VMAgentTaskStatus.FINISHED : VMAgentTaskStatus.FAILED);
+            return r;
+        } catch (RuntimeException e) {
+            setMonitoringTask(nsId, clusterId, nodeName, VMAgentTaskStatus.FAILED);
+            throw e;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -241,8 +308,26 @@ public class K8sAgentService {
     }
 
     public NodeResult uninstallNode(String nsId, String clusterId, String nodeName) {
-        try (KubernetesClient k8s = client(nsId, clusterId)) {
-            return uninstallOne(k8s, nodeName);
+        ReentrantLock lock = lockFor(nsId, clusterId, nodeName);
+        lock.lock();
+        try {
+            assertNotBusy(taskRow(nsId, clusterId, nodeName).getMonitoringTaskStatus());
+            setMonitoringTask(nsId, clusterId, nodeName, VMAgentTaskStatus.UNINSTALLING);
+            NodeResult r;
+            try (KubernetesClient k8s = client(nsId, clusterId)) {
+                r = uninstallOne(k8s, nodeName);
+            }
+            setMonitoringTask(
+                    nsId,
+                    clusterId,
+                    nodeName,
+                    r.isOk() ? VMAgentTaskStatus.NOT_INSTALLED : VMAgentTaskStatus.FAILED);
+            return r;
+        } catch (RuntimeException e) {
+            setMonitoringTask(nsId, clusterId, nodeName, VMAgentTaskStatus.FAILED);
+            throw e;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -318,9 +403,27 @@ public class K8sAgentService {
     }
 
     public NodeResult installLogNode(String nsId, String clusterId, String nodeName) {
-        String lokiHost = lokiHost(nsId, clusterId);
-        try (KubernetesClient k8s = client(nsId, clusterId)) {
-            return installLogOne(k8s, nsId, clusterId, nodeName, lokiHost);
+        ReentrantLock lock = lockFor(nsId, clusterId, nodeName);
+        lock.lock();
+        try {
+            assertNotBusy(taskRow(nsId, clusterId, nodeName).getLogTaskStatus());
+            setLogTask(nsId, clusterId, nodeName, VMAgentTaskStatus.INSTALLING);
+            String lokiHost = lokiHost(nsId, clusterId);
+            NodeResult r;
+            try (KubernetesClient k8s = client(nsId, clusterId)) {
+                r = installLogOne(k8s, nsId, clusterId, nodeName, lokiHost);
+            }
+            setLogTask(
+                    nsId,
+                    clusterId,
+                    nodeName,
+                    r.isOk() ? VMAgentTaskStatus.FINISHED : VMAgentTaskStatus.FAILED);
+            return r;
+        } catch (RuntimeException e) {
+            setLogTask(nsId, clusterId, nodeName, VMAgentTaskStatus.FAILED);
+            throw e;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -335,14 +438,34 @@ public class K8sAgentService {
     }
 
     public NodeResult uninstallLogNode(String nsId, String clusterId, String nodeName) {
-        try (KubernetesClient k8s = client(nsId, clusterId)) {
-            return uninstallLogOne(k8s, nodeName);
+        ReentrantLock lock = lockFor(nsId, clusterId, nodeName);
+        lock.lock();
+        try {
+            assertNotBusy(taskRow(nsId, clusterId, nodeName).getLogTaskStatus());
+            setLogTask(nsId, clusterId, nodeName, VMAgentTaskStatus.UNINSTALLING);
+            NodeResult r;
+            try (KubernetesClient k8s = client(nsId, clusterId)) {
+                r = uninstallLogOne(k8s, nodeName);
+            }
+            setLogTask(
+                    nsId,
+                    clusterId,
+                    nodeName,
+                    r.isOk() ? VMAgentTaskStatus.NOT_INSTALLED : VMAgentTaskStatus.FAILED);
+            return r;
+        } catch (RuntimeException e) {
+            setLogTask(nsId, clusterId, nodeName, VMAgentTaskStatus.FAILED);
+            throw e;
+        } finally {
+            lock.unlock();
         }
     }
 
     /** Per-node log agent status (running = node logs present in Loki recently). */
     public List<NodeStatus> logStatus(String nsId, String clusterId) {
-        return logStatusCache.get(nsId + "/" + clusterId, k -> computeLogStatus(nsId, clusterId));
+        List<NodeStatus> base =
+                logStatusCache.get(nsId + "/" + clusterId, k -> computeLogStatus(nsId, clusterId));
+        return overlayTaskStatus(nsId, clusterId, base, true);
     }
 
     private List<NodeStatus> computeLogStatus(String nsId, String clusterId) {
@@ -366,7 +489,7 @@ public class K8sAgentService {
                             && !ref.placeholder
                             && lokiHasRecent(lokiHost, nsId, clusterId, ref.name);
             PowerState power = PowerState.of(ref.running || logging);
-            out.add(new NodeStatus(ref.name, logging, logging, null, power, ref.placeholder));
+            out.add(new NodeStatus(ref.name, logging, logging, null, power, ref.placeholder, null));
         }
         return out;
     }
@@ -513,7 +636,54 @@ public class K8sAgentService {
     }
 
     public List<NodeStatus> status(String nsId, String clusterId) {
-        return statusCache.get(nsId + "/" + clusterId, k -> computeStatus(nsId, clusterId));
+        List<NodeStatus> base =
+                statusCache.get(nsId + "/" + clusterId, k -> computeStatus(nsId, clusterId));
+        return overlayTaskStatus(nsId, clusterId, base, false);
+    }
+
+    /**
+     * Overlays the durable per-node agent task state onto the (cached) live status. Kept out of the
+     * cache so an in-flight install/uninstall is reflected immediately and consistently across
+     * tabs: a busy state ({@code INSTALLING}/{@code UNINSTALLING}) is surfaced as {@code
+     * taskStatus} so the UI can disable its button, and a {@code FINISHED} state marks the node
+     * installed even before its first metric/log arrives (so the button doesn't briefly flip back
+     * to Install).
+     */
+    private List<NodeStatus> overlayTaskStatus(
+            String nsId, String clusterId, List<NodeStatus> base, boolean log) {
+        Map<String, K8sAgentTaskEntity> byNode = new java.util.HashMap<>();
+        try {
+            for (K8sAgentTaskEntity e : agentTaskRepo.findByNsIdAndClusterId(nsId, clusterId)) {
+                byNode.put(e.getNodeName(), e);
+            }
+        } catch (Exception ignore) {
+            return base; // DB unavailable -> fall back to live status without the overlay
+        }
+        if (byNode.isEmpty()) {
+            return base;
+        }
+        List<NodeStatus> out = new ArrayList<>(base.size());
+        for (NodeStatus s : base) {
+            K8sAgentTaskEntity e = byNode.get(s.getNode());
+            VMAgentTaskStatus t =
+                    e == null ? null : (log ? e.getLogTaskStatus() : e.getMonitoringTaskStatus());
+            if (t == null) {
+                out.add(s);
+                continue;
+            }
+            boolean installed = s.isInstalled() || t == VMAgentTaskStatus.FINISHED;
+            String taskStatus = (t.isBusy() || t == VMAgentTaskStatus.FAILED) ? t.name() : null;
+            out.add(
+                    new NodeStatus(
+                            s.getNode(),
+                            installed,
+                            s.isRunning(),
+                            s.getLastSeen(),
+                            s.getPowerState(),
+                            s.isPlaceholder(),
+                            taskStatus));
+        }
+        return out;
     }
 
     private List<NodeStatus> computeStatus(String nsId, String clusterId) {
@@ -538,7 +708,9 @@ public class K8sAgentService {
             PowerState power = PowerState.of(ref.running || reporting);
             // "installed" = the agent has reported at least once (so it was installed on this node)
             boolean installed = ts != null;
-            out.add(new NodeStatus(ref.name, installed, reporting, ts, power, ref.placeholder));
+            out.add(
+                    new NodeStatus(
+                            ref.name, installed, reporting, ts, power, ref.placeholder, null));
         }
         return out;
     }


### PR DESCRIPTION
## What / Why

K8s 노드의 에이전트 설치 여부는 cb-spider 노드목록 + InfluxDB/Loki 보고로 즉석 계산만 되어 "설치/삭제 진행 중"이라는 개념이 없었습니다. 그래서 여러 탭에서 모두 Install/Uninstall 버튼이 활성이고, 동시에 눌러 같은 노드에 Job이 경합할 수 있었습니다. VM처럼 영속 작업상태 + 노드별 락을 도입해 일관되고 탭 간에 공유되게 했습니다.

## Changes

- `k8s_agent_task` 엔티티/리포지토리 추가 (PK = ns/cluster/node, monitoring·log 작업상태). ddl-auto로 테이블 자동 생성.
- install/uninstall 시 노드별 ReentrantLock으로 직렬화하고, 작업상태를 INSTALLING/UNINSTALLING → FINISHED/NOT_INSTALLED/FAILED로 영속.
- status()/logStatus()가 (15초 캐시 결과 위에) 작업상태를 실시간으로 overlay: 진행 중이면 어느 탭에서든 버튼이 비활성되고 "Installing…/Uninstalling…" 표시, FINISHED는 첫 메트릭/로그 도착 전에도 installed로 처리(버튼이 잠깐 되돌아가는 깜빡임 제거).
- 프론트: K8sAgentPanel이 taskStatus를 반영(크로스탭 진행표시), Config 메트릭 적용 오버레이를 적용 대상 노드로 스코프하여 다른 VM 선택 시 잘못 뜨던 문제 수정.
