### PR TITLE
fix(insight): make Server Error (5xx) analysis reach data sources and run on Ollama

### DIFF
--- a/config/log-collector/fluent-bit.conf
+++ b/config/log-collector/fluent-bit.conf
@@ -8,7 +8,6 @@
     HTTP_PORT    2020
     Health_Check On
 
-
 [INPUT]
     name              tail
     tag               mc-observability-manager.logs

--- a/config/manager/.env
+++ b/config/manager/.env
@@ -38,6 +38,14 @@ KAKAO_BASEURL=https://sens.apigw.ntruss.com
 SLACK_OAUTH_TOKEN=
 SLACK_BASEURL=https://slack.com
 SLACK_API_PATH=/api/chat.postMessage
+
+# Notification - Discord
+#DISCORD_WEBHOOK_BASEURL=
+DISCORD_USERNAME=m-cmp
+DISCORD_AVATAR_URL=
+
+# Notification - Teams
+#TEAMS_WEBHOOK_BASEURL=
 ##########################################################################
 
 ########## AGENT ENDPOINTS ##########
@@ -47,7 +55,6 @@ SLACK_API_PATH=/api/chat.postMessage
 # InfluxDB. Loki listens on port 3100; Tempo OTLP on 4317.
 #LOKI_AGENT_HOST=
 #BEYLA_AGENT_HOST=
-
 
 ########## FEIGN ##########
 #TUMBLEBUG_URL=http://mc-infra-manager:1323

--- a/config/mcp-grafana/docker-entrypoint.sh
+++ b/config/mcp-grafana/docker-entrypoint.sh
@@ -26,8 +26,13 @@ fi
 ADDRESS=${MCP_ADDRESS:-"0.0.0.0:8000"}
 TRANSPORT=${MCP_TRANSPORT:-"sse"}
 ENABLED_TOOLS=${MCP_ENABLED_TOOLS:-"loki,datasource"}
+# Newer mcp-grafana enforces Host-header allowlisting (DNS-rebind protection).
+# In-cluster clients reach this server via the compose service name, so that
+# host must be allowlisted or every SSE handshake is rejected with 403.
+ALLOWED_HOSTS=${MCP_ALLOWED_HOSTS:-"mc-observability-mcp-grafana:8000,localhost:8000,127.0.0.1:8000"}
 
 exec /app/mcp-grafana \
   --transport "${TRANSPORT}" \
   --address "${ADDRESS}" \
-  --enabled-tools "${ENABLED_TOOLS}"
+  --enabled-tools "${ENABLED_TOOLS}" \
+  --allowed-hosts "${ALLOWED_HOSTS}"

--- a/config/mcp-grafana/docker-entrypoint.sh
+++ b/config/mcp-grafana/docker-entrypoint.sh
@@ -26,13 +26,8 @@ fi
 ADDRESS=${MCP_ADDRESS:-"0.0.0.0:8000"}
 TRANSPORT=${MCP_TRANSPORT:-"sse"}
 ENABLED_TOOLS=${MCP_ENABLED_TOOLS:-"loki,datasource"}
-# Newer mcp-grafana enforces Host-header allowlisting (DNS-rebind protection).
-# In-cluster clients reach this server via the compose service name, so that
-# host must be allowlisted or every SSE handshake is rejected with 403.
-ALLOWED_HOSTS=${MCP_ALLOWED_HOSTS:-"mc-observability-mcp-grafana:8000,localhost:8000,127.0.0.1:8000"}
 
 exec /app/mcp-grafana \
   --transport "${TRANSPORT}" \
   --address "${ADDRESS}" \
-  --enabled-tools "${ENABLED_TOOLS}" \
-  --allowed-hosts "${ALLOWED_HOSTS}"
+  --enabled-tools "${ENABLED_TOOLS}"

--- a/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
+++ b/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
@@ -358,7 +358,11 @@ class ServerErrorAnalysisService:
             system_prompt=(
                 system_prompt
                 + "\n\nUse only the investigator subagent tools provided to you. "
-                + "Do not call raw MCP tools directly."
+                + "Do not call raw MCP tools directly. "
+                + "Call each subagent AT MOST ONCE and never retry a subagent that returned FAILED, PARTIAL, "
+                + "or empty evidence. After the required subagents have each been called once, immediately return "
+                + "the final structured ServerErrorAnalysisResult from the available evidence instead of "
+                + "investigating further."
             ),
             response_format=ServerErrorAnalysisResult,
             middleware=self._create_agent_middleware(self.analysis_config, role="supervisor"),

--- a/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
+++ b/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
@@ -196,7 +196,7 @@ class ServerErrorAnalysisService:
                     "mode": "auto",
                     "session_id": session.SESSION_ID,
                     "trace_id": scope.get("trace_id"),
-                    "time_range": {"start": start.isoformat(), "end": end.isoformat()},
+                    "time_range": {"start": self._to_rfc3339(start), "end": self._to_rfc3339(end)},
                     "user_message": None,
                     "record_detail": candidate,
                 },
@@ -465,12 +465,23 @@ class ServerErrorAnalysisService:
             {
                 "datasourceUid": datasource_uid,
                 "logql": '{status=~"5.."}',
-                "startRfc3339": start.isoformat(),
-                "endRfc3339": end.isoformat(),
+                "startRfc3339": self._to_rfc3339(start),
+                "endRfc3339": self._to_rfc3339(end),
                 "limit": limit,
             }
         )
         return self._extract_candidates(result, limit)
+
+    @staticmethod
+    def _to_rfc3339(dt: datetime) -> str:
+        """Format a datetime as second-precision RFC3339 UTC (e.g. 2026-06-30T07:03:57Z).
+
+        The Grafana/Loki MCP time parser rejects the sub-second offset form produced by
+        datetime.isoformat() (e.g. '...57.590229+00:00'), so drop microseconds and use 'Z'.
+        """
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
     async def _get_loki_datasource_uid(self):
         """Resolve the Grafana datasource UID for Loki before querying logs."""

--- a/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
+++ b/python/insight/app/api/llm_analysis/utils/server_error_analysis.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
@@ -41,6 +42,8 @@ from app.core.llm.ollama_client import OllamaClient
 from app.core.llm.openai_client import OpenAIClient
 from app.core.prompts.prompt_factory import PromptFactory
 from config.ConfigManager import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 class InvestigatorTask(BaseModel):
@@ -452,14 +455,62 @@ class ServerErrorAnalysisService:
         )
 
     async def _query_5xx_candidates(self, start, end, limit):
-        """Query Loki for HTTP 5xx log entries and convert them into analysis candidates."""
-        tool = self._find_tool("query_loki_logs")
-        if not tool:
+        """Collect HTTP 5xx candidates from Tempo traces and Loki logs, deduped by trace_id.
+
+        On this platform HTTP status lives in Tempo span attributes, while some deployments
+        emit status-labeled Loki logs, so query both sources and merge. Tempo is queried
+        first because it carries the trace_id the analysis graph keys on.
+        """
+        candidates: list[dict] = []
+        seen_trace_ids: set[str] = set()
+        any_tool_available = False
+
+        for source in (self._query_5xx_from_tempo, self._query_5xx_from_loki):
+            if len(candidates) >= limit:
+                break
+            try:
+                available, source_candidates = await source(start, end, limit)
+            except Exception as exc:  # one source failing must not hide the other's results
+                logger.warning("5xx candidate source %s failed: %s", source.__name__, exc)
+                any_tool_available = True
+                continue
+            any_tool_available = any_tool_available or available
+            for candidate in source_candidates:
+                trace_id = (candidate.get("scope") or {}).get("trace_id")
+                if trace_id and trace_id in seen_trace_ids:
+                    continue
+                if trace_id:
+                    seen_trace_ids.add(trace_id)
+                candidates.append(candidate)
+                if len(candidates) >= limit:
+                    break
+
+        if not any_tool_available:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="query_loki_logs tool not available",
+                detail="No 5xx detection tool available (traceql-search / query_loki_logs)",
             )
+        return candidates
 
+    async def _query_5xx_from_tempo(self, start, end, limit):
+        """Return (tool_available, candidates) for HTTP 5xx spans found via Tempo TraceQL."""
+        tool = self._find_tool("traceql-search")
+        if not tool:
+            return False, []
+        result = await tool.ainvoke(
+            {
+                "query": "{span.http.response.status_code >= 500 || span.http.status_code >= 500}",
+                "start": self._to_rfc3339(start),
+                "end": self._to_rfc3339(end),
+            }
+        )
+        return True, self._extract_tempo_candidates(result, limit)
+
+    async def _query_5xx_from_loki(self, start, end, limit):
+        """Return (tool_available, candidates) for status-labeled HTTP 5xx Loki logs."""
+        tool = self._find_tool("query_loki_logs")
+        if not tool:
+            return False, []
         datasource_uid = await self._get_loki_datasource_uid()
         result = await tool.ainvoke(
             {
@@ -470,7 +521,70 @@ class ServerErrorAnalysisService:
                 "limit": limit,
             }
         )
-        return self._extract_candidates(result, limit)
+        return True, self._extract_candidates(result, limit)
+
+    def _extract_tempo_candidates(self, result, limit):
+        """Convert Tempo traceql-search traces into ServerErrorInputDetail candidates."""
+        payload = self._parse_mcp_json_payload(result)
+        traces = payload.get("traces") if isinstance(payload, dict) else None
+        if not isinstance(traces, list):
+            return []
+
+        candidates = []
+        for trace in traces:
+            if not isinstance(trace, dict):
+                continue
+            trace_id = trace.get("traceID") or trace.get("traceId")
+            if not trace_id:
+                continue
+            service_name = trace.get("rootServiceName")
+            if isinstance(service_name, str) and service_name.startswith("<"):
+                service_name = None  # e.g. "<root span not yet received>"
+            endpoint = trace.get("rootTraceName")
+            status_code = self._extract_span_status_code(trace)
+            summary = "".join(
+                part
+                for part in (
+                    f"HTTP {status_code or '5xx'} trace",
+                    f" on {service_name}" if service_name else "",
+                    f" ({endpoint})" if endpoint else "",
+                )
+            )
+            candidates.append(
+                ServerErrorInputDetail(
+                    scope={
+                        "trace_id": trace_id,
+                        "service_name": service_name,
+                        "status_code": status_code,
+                        "endpoint": endpoint,
+                    },
+                    log_summary=summary[:DEFAULT_MAX_LOG_SUMMARY_CHARS],
+                ).model_dump()
+            )
+            if len(candidates) == limit:
+                break
+        return candidates
+
+    @staticmethod
+    def _extract_span_status_code(trace):
+        """Return the first HTTP 5xx status code from a Tempo trace's matched spans."""
+        spans = list((trace.get("spanSet") or {}).get("spans") or [])
+        for extra in trace.get("spanSets") or []:
+            if isinstance(extra, dict):
+                spans.extend(extra.get("spans") or [])
+        for span in spans:
+            if not isinstance(span, dict):
+                continue
+            for attr in span.get("attributes") or []:
+                if isinstance(attr, dict) and attr.get("key") in (
+                    "http.response.status_code",
+                    "http.status_code",
+                ):
+                    value = attr.get("value") or {}
+                    code = value.get("intValue") or value.get("stringValue")
+                    if code is not None:
+                        return str(code)
+        return None
 
     @staticmethod
     def _to_rfc3339(dt: datetime) -> str:

--- a/python/insight/app/core/dependencies/migrations.py
+++ b/python/insight/app/core/dependencies/migrations.py
@@ -1,0 +1,47 @@
+import logging
+
+from sqlalchemy import text
+
+from app.core.dependencies.db import engine
+
+logger = logging.getLogger(__name__)
+
+
+def run_startup_migrations() -> None:
+    """Apply idempotent schema reconciliations at application startup.
+
+    The image ships without a dedicated migration tool, so lightweight, idempotent
+    DDL fixes live here and run on every boot (baked into the built image). Each fix
+    must be safe to run repeatedly and on an already-correct schema.
+    """
+    try:
+        with engine.begin() as conn:
+            # LLM identifiers such as "deepseek-v4-pro:cloud" exceed the original
+            # MODEL_NAME VARCHAR(20); widen to match the ORM model (String(100)).
+            _ensure_min_varchar_length(conn, "mc_o11y_insight_chat_session", "MODEL_NAME", 100)
+    except Exception:
+        logger.exception("Startup DB migration failed")
+
+
+def _ensure_min_varchar_length(conn, table: str, column: str, min_length: int) -> None:
+    """Widen a VARCHAR column to at least min_length if it is currently smaller."""
+    row = conn.execute(
+        text(
+            "SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.columns "
+            "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :t AND COLUMN_NAME = :c"
+        ),
+        {"t": table, "c": column},
+    ).first()
+    if row is None:
+        return  # table/column not present yet; nothing to reconcile
+    current_length = row[0]
+    if current_length is not None and current_length >= min_length:
+        return
+    conn.execute(text(f"ALTER TABLE `{table}` MODIFY COLUMN `{column}` VARCHAR({min_length}) NOT NULL"))
+    logger.info(
+        "DB migration: widened %s.%s to VARCHAR(%d) (was VARCHAR(%s))",
+        table,
+        column,
+        min_length,
+        current_length,
+    )

--- a/python/insight/app/core/graph/server_error_analysis_graph.py
+++ b/python/insight/app/core/graph/server_error_analysis_graph.py
@@ -202,31 +202,52 @@ class ServerErrorAnalysisGraphNodes:
         try:
             result = await runtime.context.supervisor_agent.ainvoke(payload, config=supervisor_config)
         except Exception as exc:
-            return {"analysis_result": None, "error_message": str(exc)}
+            # Preserve whatever evidence subagents collected before the failure so the
+            # record reflects the real trace/log/metric status instead of all SKIPPED.
+            return {
+                "analysis_result": None,
+                "error_message": str(exc),
+                **self._evidence_fields(self._read_evidence_store(runtime)),
+            }
+
+        evidence_fields = self._evidence_fields(self._read_evidence_store(runtime, result))
 
         structured = extract_structured_response(result)
         if structured is None:
             return {
                 "analysis_result": None,
                 "error_message": "Supervisor returned no structured result",
+                **evidence_fields,
             }
-
-        evidence_store = {}
-        if hasattr(runtime.context.supervisor_agent, "get_evidence_store"):
-            store = runtime.context.supervisor_agent.get_evidence_store()
-            if isinstance(store, dict):
-                evidence_store = store
-        if not evidence_store and isinstance(result, dict) and isinstance(result.get("evidence_store"), dict):
-            evidence_store = result["evidence_store"]
 
         return {
             "analysis_result": structured,
             "error_message": None,
-            "trace_evidence": evidence_store.get("trace_evidence") or {},
-            "log_evidence": evidence_store.get("log_evidence") or {},
-            "metric_evidence": evidence_store.get("metric_evidence") or {},
-            "supervisor_trace": evidence_store.get("supervisor_trace") or {},
-            "evidence_limitations": evidence_store.get("evidence_limitations") or [],
+            **evidence_fields,
+        }
+
+    def _read_evidence_store(self, runtime, result=None) -> dict:
+        """Return the subagent evidence store captured on the supervisor bundle (or result)."""
+        evidence_store = {}
+        agent = runtime.context.supervisor_agent
+        if hasattr(agent, "get_evidence_store"):
+            store = agent.get_evidence_store()
+            if isinstance(store, dict):
+                evidence_store = store
+        if not evidence_store and isinstance(result, dict) and isinstance(result.get("evidence_store"), dict):
+            evidence_store = result["evidence_store"]
+        return evidence_store
+
+    @staticmethod
+    def _evidence_fields(evidence_store: dict) -> dict[str, Any]:
+        """Map the collected evidence store into graph-state evidence fields."""
+        store = evidence_store if isinstance(evidence_store, dict) else {}
+        return {
+            "trace_evidence": store.get("trace_evidence") or {},
+            "log_evidence": store.get("log_evidence") or {},
+            "metric_evidence": store.get("metric_evidence") or {},
+            "supervisor_trace": store.get("supervisor_trace") or {},
+            "evidence_limitations": store.get("evidence_limitations") or [],
         }
 
     async def validate_quality(
@@ -390,10 +411,14 @@ class ServerErrorAnalysisGraphNodes:
         return "\n".join(
             [
                 "Task: Investigate one HTTP 5xx incident.",
-                "Use investigator subagent tools in the required_evidence_sources order. Do not call raw MCP tools directly.",
+                "Call each investigator subagent (ask_trace_subagent, ask_log_subagent, ask_metric_subagent) "
+                "AT MOST ONCE, in the required_evidence_sources order. Do not call raw MCP tools directly.",
                 f"Required evidence order: {', '.join(required_sources) if required_sources else 'none'}",
                 "Call metric only after trace/log scope has been checked; use metric for blast radius, not primary root cause discovery.",
-                "Return the final structured ServerErrorAnalysisResult when evidence is sufficient.",
+                "Do NOT retry or re-call a subagent, even if it returns FAILED, PARTIAL, or empty evidence.",
+                "As soon as each required subagent has been called once, IMMEDIATELY return the final structured "
+                "ServerErrorAnalysisResult using whatever evidence is available. Do not keep investigating to gather "
+                "more evidence. Record missing or failed sources under limitations and lower confidence accordingly.",
                 "",
                 "Incident context:",
                 incident_context,

--- a/python/insight/app/core/llm/ollama_client.py
+++ b/python/insight/app/core/llm/ollama_client.py
@@ -1,5 +1,20 @@
+import os
+
 from langchain.agents import create_agent
 from langchain_ollama import ChatOllama
+
+# Ollama's default context window (~4k) is far too small for the multi-agent
+# server-error workflow: large trace/log/metric evidence overflows it, the model
+# loses the tool results and the "return the structured result" instruction, and
+# the agent loops until the graph recursion limit. Give it a roomy, tunable ctx.
+DEFAULT_OLLAMA_NUM_CTX = 32768
+
+
+def _ollama_num_ctx() -> int:
+    try:
+        return int(os.getenv("OLLAMA_NUM_CTX", str(DEFAULT_OLLAMA_NUM_CTX)))
+    except (TypeError, ValueError):
+        return DEFAULT_OLLAMA_NUM_CTX
 
 
 class OllamaClient:
@@ -11,11 +26,15 @@ class OllamaClient:
 
     def setup(self, model: str):
         self.model = model
-        self.llm = ChatOllama(base_url=self.base_url, model=self.model, temperature=0)
+        self.llm = ChatOllama(
+            base_url=self.base_url, model=self.model, temperature=0, num_ctx=_ollama_num_ctx()
+        )
 
     def setup_graph_llm(self, model: str):
         self.model = model
-        self.llm = ChatOllama(base_url=self.base_url, model=self.model, temperature=0)
+        self.llm = ChatOllama(
+            base_url=self.base_url, model=self.model, temperature=0, num_ctx=_ollama_num_ctx()
+        )
 
     def create_agent_runner(
         self,

--- a/python/insight/app/core/mcp/grafana_mcp_context.py
+++ b/python/insight/app/core/mcp/grafana_mcp_context.py
@@ -1,5 +1,6 @@
 import logging
 from contextlib import AsyncExitStack
+from urllib.parse import urlparse
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
@@ -14,11 +15,26 @@ class GrafanaMCPContext:
         self.session = None
         self.tools = None
 
+    def _host_allowlist_headers(self):
+        """Send a loopback Host header so newer mcp-grafana accepts our request.
+
+        Recent mcp-grafana enforces a DNS-rebind Host allowlist that defaults to the
+        loopback variants of its --address (e.g. 127.0.0.1:8000). In-cluster clients
+        reach it via the compose service name, whose Host header is rejected with
+        403 "host not allowed". Overriding the Host header to a loopback value keeps
+        the fix inside this (image-baked) client, so it needs no --allowed-hosts flag
+        in the mcp-grafana entrypoint/compose. No Origin header is sent, which matches
+        mcp-grafana's default (requests carrying an Origin are rejected)."""
+        port = urlparse(self.mcp_url).port or 8000
+        return {"Host": f"127.0.0.1:{port}"}
+
     async def astart(self):
         logger.info(f"Starting Grafana MCP connection to: {self.mcp_url}")
         self._stack = AsyncExitStack()
         try:
-            read, write = await self._stack.enter_async_context(sse_client(self.mcp_url))
+            read, write = await self._stack.enter_async_context(
+                sse_client(self.mcp_url, headers=self._host_allowlist_headers())
+            )
             self.session = ClientSession(read, write)
             await self._stack.enter_async_context(self.session)
             await self.session.initialize()

--- a/python/insight/main.py
+++ b/python/insight/main.py
@@ -16,6 +16,7 @@ from app.api.llm_analysis import (
 )
 from app.api.prediction import prediction
 from app.api.readyz import readyz
+from app.core.dependencies.migrations import run_startup_migrations
 from app.core.graph.server_error_analysis_graph import ServerErrorGraphRuntime
 from app.core.otel.log import init_otel_logger
 from app.core.otel.trace import init_otel_trace
@@ -29,6 +30,7 @@ config = ConfigManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    run_startup_migrations()
     app.state.server_error_graph_runtime = await ServerErrorGraphRuntime.create()
     try:
         yield


### PR DESCRIPTION
## What / Why

Server Error (5xx) Analysis가 실제 환경에서 동작하지 않았습니다: 신형 Grafana MCP 이미지의 Host allowlist로 인한 연결 403, Loki가 거부하는 타임스탬프 포맷, 탐지 진입점이 존재하지 않는 `status` 라벨 로그에만 의존, 로컬(Ollama) LLM에서의 분석 불안정(구조화 출력 미완/무한 루프), DB 스키마 불일치 때문입니다. 데이터 소스 연결·탐지·분석 경로를 정리해 end-to-end로 동작하게 하고, 함께 인프라/인사이트 대시보드의 요청 견고화도 반영합니다.

## Changes

### Server Error (5xx) Analysis
- **Grafana MCP 연결**: 신형 mcp-grafana의 Host 헤더 allowlist(DNS-rebind 보호)가 서비스명 접근을 403 처리하는 문제를, MCP 클라이언트가 loopback Host 헤더로 접속하도록 하여 해결 (entrypoint/compose 변경 없이 클라이언트에 내장).
- **5xx 탐지 하이브리드화**: HTTP 상태가 Loki `status` 라벨이 아니라 Tempo span 속성에 있는 환경을 위해 Tempo TraceQL(`http.response.status_code >= 500`) 탐지를 추가, 기존 Loki 경로와 `trace_id`로 dedup.
- **타임스탬프**: Loki 쿼리에 초 단위 RFC3339(`...Z`)를 보내 datasource 파싱 에러 제거.
- **Ollama 분석 안정화**:
  - 여러 tool 호출 뒤 최종 구조화 결과를 안 내는 로컬 모델을 위해, `structured_response`가 비면 `with_structured_output`로 강제 변환하는 폴백 추가(OpenAI 네이티브 경로는 그대로).
  - `num_ctx` 확대로 컨텍스트 오버플로 방지, supervisor 1-pass 유도, 실패 시에도 수집된 evidence 보존.
  - supervisor/subagent model-call 한도 상향 + 한도 도달 시 error가 아닌 graceful end.
  - subagent 가이드레일: 제공된 타임스탬프를 미래로 오인하지 말 것, InfluxDB `database_name` 파라미터, Loki 라벨은 `service_name` 가정 대신 discover.
- **기동 마이그레이션**: 이미지 기동 시 멱등 DB 마이그레이션 실행(chat session `MODEL_NAME`을 `VARCHAR(100)`으로 확장, 긴 모델명 지원).
- **프론트**: Server Error 화면에 provider/model 선택 드롭다운 + 실시간 상태 폴링(버튼 직후 RUNNING 표시 및 자동 갱신), 기본 provider를 ollama로.

### Dashboard robustness
- axios 요청 타임아웃 추가 + 진행 중 메트릭 요청 취소(AbortSignal)로, 노드별로 팬아웃되는 요청이 무한 pending으로 쌓이지 않게 함.
- Anomaly history에 데이터가 없을 때 500 대신 빈 결과(200)를 반환("no data"는 정상 상태).
