### PR TITLE
fix: prune stale monitoring targets, show K8s node lifecycle status, retry tumblebug 429s

### DIFF
--- a/front/src/pages/InfraOverview.jsx
+++ b/front/src/pages/InfraOverview.jsx
@@ -471,14 +471,22 @@ function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart,
   const cspSupported = isCspSupported(info.connectionName);
   const nodeName = info.node?.NameId || info.node?.SystemId || `${info.nodeGroupName} #${info.nodeNumber}`;
   const powered = info.powered !== false;
+  // A K8s node is only truly "Running" when its cluster is Active. While the cluster is
+  // Creating/Updating/Deleting/etc., cb-spider still returns node entries, so reflect the
+  // cluster lifecycle status instead of blindly showing "Running". Placeholder nodes
+  // (cluster off / scaled down) stay "Stopped".
+  const clusterStatus = info.clusterStatus || '';
+  const isActive = clusterStatus.toLowerCase() === 'active';
+  const statusLabel = info.placeholder ? 'Stopped' : (isActive ? 'Running' : (clusterStatus || 'Running'));
+  const statusRunning = statusLabel === 'Running';
 
   const header = (
     <div className="flex items-center justify-between px-4 py-2.5 border-b bg-white">
       <div className="flex items-center gap-2 min-w-0">
         <span className="text-[10px] uppercase tracking-wide text-gray-400 font-medium">Node</span>
         <span className={`font-semibold text-sm truncate font-mono ${info.placeholder ? 'text-gray-400 italic' : ''}`}>{nodeName}</span>
-        <span className={`text-xs px-2 py-0.5 rounded-full ${powered ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{powered ? 'Running' : 'Stopped'}</span>
-        {dataSource === 'csp' && cspSupported && powered && <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600" title="CSP API Based">API</span>}
+        <span className={`text-xs px-2 py-0.5 rounded-full ${statusRunning ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>{statusLabel}</span>
+        {dataSource === 'csp' && cspSupported && statusRunning && <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600" title="CSP API Based">API</span>}
       </div>
       <div className="text-xs text-gray-400 shrink-0">
         <span className="font-mono">#{info.nodeNumber}</span>
@@ -491,6 +499,15 @@ function K8sNodeCard({ info, metrics, dataSource, metricsLoading, selectedChart,
       <div className="bg-white rounded-md border border-gray-200">
         {header}
         <div className="p-8 text-center text-sm text-gray-400">Node is powered off — start the cluster to collect metrics.</div>
+      </div>
+    );
+  }
+
+  if (!isActive) {
+    return (
+      <div className="bg-white rounded-md border border-gray-200">
+        {header}
+        <div className="p-8 text-center text-sm text-gray-400">Cluster is {clusterStatus || 'not active'} — metrics are available once it becomes Active.</div>
       </div>
     );
   }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugFeignConfig.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/infrastructure/tumblebug/TumblebugFeignConfig.java
@@ -1,6 +1,10 @@
 package com.mcmp.o11ymanager.manager.infrastructure.tumblebug;
 
+import feign.Request;
 import feign.RequestInterceptor;
+import feign.RetryableException;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,5 +28,38 @@ public class TumblebugFeignConfig {
 
             requestTemplate.header("Authorization", authHeader);
         };
+    }
+
+    /**
+     * cb-tumblebug applies a low per-path rate limiter (e.g. 2 req/s on the infra and k8sCluster
+     * read endpoints) and returns 429 with no {@code Retry-After} header, so Feign's default
+     * decoder surfaces it as a hard {@link feign.FeignException} that is never retried. Dashboards
+     * and schedulers naturally fan out several reads at once and trip it constantly, making live
+     * resources momentarily look failed/missing. Re-map 429 to a {@link RetryableException} so the
+     * {@link #tumblebugRetryer() retryer} backs off and retries instead of failing outright.
+     */
+    @Bean
+    public ErrorDecoder tumblebugErrorDecoder() {
+        ErrorDecoder defaultDecoder = new ErrorDecoder.Default();
+        return (methodKey, response) -> {
+            Exception decoded = defaultDecoder.decode(methodKey, response);
+            if (response.status() == 429 && !(decoded instanceof RetryableException)) {
+                Request request = response.request();
+                return new RetryableException(
+                        response.status(),
+                        decoded.getMessage(),
+                        request != null ? request.httpMethod() : Request.HttpMethod.GET,
+                        decoded,
+                        (Long) null, // no Retry-After header — let the retryer compute the backoff
+                        request);
+            }
+            return decoded;
+        };
+    }
+
+    /** Backoff retry for the 429s re-mapped above: ~0.8s, 1.2s, 1.8s across 3 retries. */
+    @Bean
+    public Retryer tumblebugRetryer() {
+        return new Retryer.Default(800L, 2500L, 4);
     }
 }

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/StaleTargetReconciler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/StaleTargetReconciler.java
@@ -1,0 +1,226 @@
+package com.mcmp.o11ymanager.manager.service;
+
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfra;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugInfraList;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugK8sCluster;
+import com.mcmp.o11ymanager.manager.dto.tumblebug.TumblebugNS;
+import com.mcmp.o11ymanager.manager.entity.K8sAgentTaskEntity;
+import com.mcmp.o11ymanager.manager.entity.VMEntity;
+import com.mcmp.o11ymanager.manager.infrastructure.tumblebug.TumblebugClient;
+import com.mcmp.o11ymanager.manager.repository.K8sAgentTaskJpaRepository;
+import com.mcmp.o11ymanager.manager.repository.VMJpaRepository;
+import feign.FeignException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Removes monitoring targets that have been deleted in cb-tumblebug but still linger in the
+ * observability DB. Those stale rows keep showing up in the monitoring node list, the monitoring
+ * config page, and the alert-setting target dropdowns because {@code node} / {@code k8s_agent_task}
+ * rows are only ever inserted (on VM registration / agent install) and are never pruned when the
+ * underlying VM or K8s cluster disappears from Tumblebug.
+ *
+ * <p>Each pass walks every Tumblebug namespace, builds the set of live targets, and diffs it against
+ * the persisted rows. To stay safe against id-mapping mistakes or transient Tumblebug errors, a row
+ * is deleted <b>only</b> when Tumblebug explicitly confirms it is gone with a 404 on a direct
+ * lookup — any other error (429, 5xx, network) leaves the row untouched.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(
+        prefix = "observability.reconcile.stale-targets",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@RequiredArgsConstructor
+public class StaleTargetReconciler {
+
+    /** Tumblebug rate-limits ~3 sequential calls (429); space discovery calls out. */
+    private static final long TB_CALL_SPACING_MS = 400L;
+
+    private final TumblebugClient tumblebugClient;
+    private final VMJpaRepository vmJpaRepository;
+    private final K8sAgentTaskJpaRepository k8sAgentTaskJpaRepository;
+
+    @Scheduled(cron = "${observability.reconcile.stale-targets.cron:0 */10 * * * *}")
+    public void reconcile() {
+        try {
+            reconcileOnce();
+        } catch (Exception e) {
+            log.warn("[STALE-RECONCILE] pass failed: {}", e.toString());
+        }
+    }
+
+    /** One reconciliation pass. Package-private so it can be triggered directly in tests/admin. */
+    void reconcileOnce() {
+        TumblebugNS nsList;
+        try {
+            nsList = tumblebugClient.getNSList();
+        } catch (Exception e) {
+            log.warn("[STALE-RECONCILE] getNSList failed, skipping pass: {}", e.toString());
+            return;
+        }
+        if (nsList == null || nsList.getNs() == null || nsList.getNs().isEmpty()) {
+            return;
+        }
+
+        // Per-NS live target keys, populated only for namespaces we could successfully scan.
+        Map<String, Set<String>> liveVmKeysByNs = new HashMap<>();
+        Map<String, Set<String>> liveClusterIdsByNs = new HashMap<>();
+        Set<String> vmScannedNs = new HashSet<>();
+        Set<String> k8sScannedNs = new HashSet<>();
+
+        boolean space = false;
+        for (TumblebugNS.NS ns : nsList.getNs()) {
+            if (ns == null || ns.getId() == null) {
+                continue;
+            }
+            String nsId = ns.getId();
+
+            if (space) {
+                sleepQuietly(TB_CALL_SPACING_MS);
+            }
+            space = true;
+            try {
+                TumblebugInfraList infraList = tumblebugClient.getInfraList(nsId);
+                Set<String> keys = new HashSet<>();
+                if (infraList != null && infraList.getInfra() != null) {
+                    for (TumblebugInfra infra : infraList.getInfra()) {
+                        if (infra == null || infra.getId() == null || infra.getNode() == null) {
+                            continue;
+                        }
+                        for (TumblebugInfra.Node node : infra.getNode()) {
+                            if (node != null && node.getId() != null) {
+                                keys.add(vmKey(infra.getId(), node.getId()));
+                            }
+                        }
+                    }
+                }
+                liveVmKeysByNs.put(nsId, keys);
+                vmScannedNs.add(nsId);
+            } catch (Exception e) {
+                log.warn(
+                        "[STALE-RECONCILE] getInfraList failed ns={}, skipping VM reconcile: {}",
+                        nsId,
+                        e.toString());
+            }
+
+            sleepQuietly(TB_CALL_SPACING_MS);
+            try {
+                TumblebugK8sCluster.ListResponse resp = tumblebugClient.getK8sClusterList(nsId);
+                Set<String> clusterIds = new HashSet<>();
+                if (resp != null && resp.getK8sClusterInfo() != null) {
+                    for (TumblebugK8sCluster c : resp.getK8sClusterInfo()) {
+                        if (c != null && c.getId() != null) {
+                            clusterIds.add(c.getId());
+                        }
+                    }
+                }
+                liveClusterIdsByNs.put(nsId, clusterIds);
+                k8sScannedNs.add(nsId);
+            } catch (Exception e) {
+                log.warn(
+                        "[STALE-RECONCILE] getK8sClusterList failed ns={}, skipping K8s reconcile: {}",
+                        nsId,
+                        e.toString());
+            }
+        }
+
+        int removedVms = pruneStaleVms(vmScannedNs, liveVmKeysByNs);
+        int removedK8s = pruneStaleK8sAgentTasks(k8sScannedNs, liveClusterIdsByNs);
+        if (removedVms > 0 || removedK8s > 0) {
+            log.info(
+                    "[STALE-RECONCILE] pruned {} stale node row(s), {} stale k8s agent-task row(s)",
+                    removedVms,
+                    removedK8s);
+        }
+    }
+
+    private int pruneStaleVms(Set<String> scannedNs, Map<String, Set<String>> liveKeysByNs) {
+        int removed = 0;
+        for (VMEntity vm : vmJpaRepository.findAll()) {
+            String nsId = vm.getNsId();
+            if (nsId == null || !scannedNs.contains(nsId)) {
+                continue; // couldn't verify this NS this pass — leave it alone
+            }
+            if (liveKeysByNs.getOrDefault(nsId, Set.of())
+                    .contains(vmKey(vm.getInfraId(), vm.getNodeId()))) {
+                continue; // still present in Tumblebug
+            }
+            // Candidate looks stale — confirm with a direct lookup so a key-mapping or listing
+            // glitch can never wipe a VM that actually still exists.
+            if (!isGone(() -> tumblebugClient.getNode(nsId, vm.getInfraId(), vm.getNodeId()))) {
+                continue;
+            }
+            vmJpaRepository.delete(vm);
+            removed++;
+            log.info(
+                    "[STALE-RECONCILE] removed stale node ns={} infra={} node={}",
+                    nsId,
+                    vm.getInfraId(),
+                    vm.getNodeId());
+        }
+        return removed;
+    }
+
+    private int pruneStaleK8sAgentTasks(
+            Set<String> scannedNs, Map<String, Set<String>> liveClusterIdsByNs) {
+        int removed = 0;
+        for (K8sAgentTaskEntity task : k8sAgentTaskJpaRepository.findAll()) {
+            String nsId = task.getNsId();
+            if (nsId == null || !scannedNs.contains(nsId)) {
+                continue;
+            }
+            if (liveClusterIdsByNs.getOrDefault(nsId, Set.of()).contains(task.getClusterId())) {
+                continue;
+            }
+            if (!isGone(() -> tumblebugClient.getK8sCluster(nsId, task.getClusterId()))) {
+                continue;
+            }
+            k8sAgentTaskJpaRepository.delete(task);
+            removed++;
+            log.info(
+                    "[STALE-RECONCILE] removed stale k8s agent-task ns={} cluster={} node={}",
+                    nsId,
+                    task.getClusterId(),
+                    task.getNodeName());
+        }
+        return removed;
+    }
+
+    /**
+     * Returns true only when Tumblebug definitively reports the resource as gone (HTTP 404). Any
+     * other outcome (success, 429, 5xx, network error) returns false so we never delete on
+     * uncertainty.
+     */
+    private boolean isGone(Runnable lookup) {
+        try {
+            lookup.run();
+            return false;
+        } catch (FeignException.NotFound nf) {
+            return true;
+        } catch (Exception e) {
+            log.debug("[STALE-RECONCILE] existence check inconclusive, keeping row: {}", e.toString());
+            return false;
+        }
+    }
+
+    private static String vmKey(String infraId, String nodeId) {
+        return infraId + " " + nodeId;
+    }
+
+    private static void sleepQuietly(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
+++ b/java/mc-o11y-manager/src/main/java/com/mcmp/o11ymanager/manager/service/cache/CspCacheWarmScheduler.java
@@ -385,34 +385,17 @@ public class CspCacheWarmScheduler {
     }
 
     /**
-     * Wraps {@code tumblebugClient.getInfraList} with a single retry on 429. Tumblebug rate-limits
-     * aggressively (rejects 3rd call in quick succession); a short backoff lets the window reset
-     * without failing the whole discovery pass.
+     * Fetches the infra list, returning {@code null} instead of throwing so one namespace's failure
+     * doesn't abort the whole discovery pass. 429 rate-limit responses are retried with backoff at
+     * the Feign layer (see {@code TumblebugFeignConfig}), so no manual retry loop is needed here.
      */
     private TumblebugInfraList getInfraListWithRetry(String nsId) {
-        for (int attempt = 1; attempt <= 2; attempt++) {
-            try {
-                return tumblebugClient.getInfraList(nsId);
-            } catch (Exception e) {
-                String msg = e.toString();
-                boolean rateLimited = msg.contains("429") || msg.contains("TooManyRequests");
-                if (!rateLimited || attempt == 2) {
-                    log.warn(
-                            "[CSP-CACHE-WARM] getInfraList failed ns={}, attempt={}, err={}",
-                            nsId,
-                            attempt,
-                            msg);
-                    return null;
-                }
-                try {
-                    Thread.sleep(1500L);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    return null;
-                }
-            }
+        try {
+            return tumblebugClient.getInfraList(nsId);
+        } catch (Exception e) {
+            log.warn("[CSP-CACHE-WARM] getInfraList failed ns={}, err={}", nsId, e.toString());
+            return null;
         }
-        return null;
     }
 
     private void warmVmMetric(


### PR DESCRIPTION
## Summary
VM/K8s 모니터링 정확도와 cb-tumblebug 연동 안정성 관련 수정 3건입니다.

## 1. Front — K8s node status
K8sNodeCard가 노드 row만 있으면 상태를 무조건 "Running"으로 표시해서, Creating/Updating/Deleting 중인 클러스터의 노드도 Running으로 떴습니다. 이제 클러스터 라이프사이클 상태를 반영합니다 — 클러스터가 Active일 때만 노드가 "Running"이고, 그 외에는 실제 상태를 표시하며 Active 되기 전엔 메트릭 대신 안내 문구를 보여줍니다.

## 2. o11y-manager — prune stale targets
`node` / `k8s_agent_task` 행이 VM 등록·에이전트 설치 때만 추가되고 tumblebug에서 삭제돼도 제거되지 않아, 삭제된 리소스가 모니터링 목록·설정 화면·알람 타겟 드롭다운에 계속 남았습니다. tumblebug 실시간 목록과 대조해 orphan 행을 지우는 스케줄러(StaleTargetReconciler)를 추가했습니다. 단, 직접 조회(getNode/getK8sCluster)가 404를 반환할 때만 삭제하므로 일시적 오류나 id 불일치로 살아있는 리소스를 지우는 일은 없습니다.

## 3. o11y-manager — retry tumblebug 429
cb-tumblebug이 infra/k8sCluster 조회 엔드포인트를 2 req/s로 제한하고 429를 Retry-After 없이 반환하는데, Spring Cloud Feign 기본이 NEVER_RETRY라 대시보드/스케줄러가 제한에 걸리면 살아있는 리소스가 실패/누락처럼 보였습니다. Feign ErrorDecoder+Retryer를 추가해 모든 TumblebugClient 호출의 429를 백오프 재시도합니다.

## Notes
- Reconciler는 404 확인된 것만 삭제하고 스케줄(기본 10분)로 동작합니다.
- 실제 배포 환경에서의 런타임 검증은 아직입니다.
