### PR TITLE
fix(front): allow concurrent agent installs instead of blocking on one at a time

### DIFF
--- a/front/src/components/K8sAgentPanel.jsx
+++ b/front/src/components/K8sAgentPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   getK8sClusters, getK8sAgentStatus, getK8sLogStatus,
   installK8sNode, uninstallK8sNode, getK8sNodeMetrics,
@@ -21,8 +21,9 @@ export default function K8sAgentPanel({ nsId }) {
   const [metrics, setMetrics] = useState({ available: [], active: [] });
   const [picked, setPicked] = useState(new Set());
   const [metricLoading, setMetricLoading] = useState(false);
-  const [busy, setBusy] = useState('');
-  const [busyMsg, setBusyMsg] = useState('');
+  // In-flight install/uninstall ops keyed by `${clusterId}/${node}/${mon|log}` -> 'INSTALLING' | 'UNINSTALLING'.
+  // A map (not a single flag) so agents on different nodes/clusters can install concurrently.
+  const [busy, setBusy] = useState({});
   const [applied, setApplied] = useState(''); // `${clusterId}/${node}` after a successful Apply
 
   const load = useCallback(() => {
@@ -54,13 +55,12 @@ export default function K8sAgentPanel({ nsId }) {
 
   useEffect(() => { clusters.forEach((c) => loadStatus(c.id)); }, [clusters, loadStatus]);
 
-  // Periodically re-check agent status so transient states settle on their own (e.g. after a
-  // node restart). Skipped while an install/uninstall is running on a cluster.
-  const busyRef = useRef('');
-  useEffect(() => { busyRef.current = busy; }, [busy]);
+  // Periodically re-check agent status so transient states settle on their own (e.g. after a node
+  // restart) and concurrent installs on other nodes reflect their progress live. In-flight ops keep
+  // their own optimistic label via `busy`, so a refresh mid-op won't clear a node's pending state.
   useEffect(() => {
     if (clusters.length === 0) return;
-    const id = setInterval(() => { if (!busyRef.current) clusters.forEach((c) => loadStatus(c.id)); }, 10000);
+    const id = setInterval(() => { clusters.forEach((c) => loadStatus(c.id)); }, 10000);
     return () => clearInterval(id);
   }, [clusters, loadStatus]);
 
@@ -81,11 +81,13 @@ export default function K8sAgentPanel({ nsId }) {
     setPicked((p) => { const n = new Set(p); n.has(name) ? n.delete(name) : n.add(name); return n; });
   }
 
-  async function run(key, msg, fn, clusterId) {
-    setBusy(key); setBusyMsg(msg);
+  // `kind` ('INSTALLING' | 'UNINSTALLING') is the optimistic label shown on this node until the
+  // server's own task status takes over. Keyed per node so other nodes' ops run independently.
+  async function run(key, kind, fn, clusterId) {
+    setBusy((b) => ({ ...b, [key]: kind }));
     try { await fn(); await loadStatus(clusterId); }
     catch (e) { alert((e.response?.data?.error_message || e.response?.data?.message || e.message)); }
-    setBusy(''); setBusyMsg('');
+    setBusy((b) => { const n = { ...b }; delete n[key]; return n; });
   }
 
   const logRunning = (cid, node) => (logMap[cid] || []).find((n) => n.node === node)?.running;
@@ -98,15 +100,7 @@ export default function K8sAgentPanel({ nsId }) {
       {clusters.map((c) => {
         const nodes = statusMap[c.id] || [];
         return (
-          <div key={c.id} className="bg-white rounded-lg shadow relative">
-            {busy && busy.startsWith(c.id) && (
-              <div className="absolute inset-0 bg-white/60 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg">
-                <div className="text-center">
-                  <div className="w-7 h-7 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
-                  <p className="text-sm text-gray-700">{busyMsg}</p>
-                </div>
-              </div>
-            )}
+          <div key={c.id} className="bg-white rounded-lg shadow">
             <div className="px-4 py-3 border-b flex items-center gap-3">
               <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 font-medium">K8s</span>
               <span className="font-semibold text-sm">{c.name || c.id}</span>
@@ -137,6 +131,9 @@ export default function K8sAgentPanel({ nsId }) {
                     const logInstalled = logNode?.installed;
                     const logTask = logNode?.taskStatus;
                     const logPending = logTask === 'INSTALLING' || logTask === 'UNINSTALLING';
+                    // Per-node in-flight ops — independent so multiple nodes install at once.
+                    const monKey = `${c.id}/${n.node}/mon`, logKey = `${c.id}/${n.node}/log`;
+                    const monLocal = busy[monKey], logLocal = busy[logKey];
                     return (
                       <tr key={n.node} onClick={() => selectable && selectNode(c.id, n.node)}
                         className={`${selectable ? 'cursor-pointer hover:bg-blue-50' : 'cursor-default'} ${sel?.clusterId === c.id && sel?.node === n.node ? 'bg-blue-100' : ''}`}>
@@ -152,11 +149,11 @@ export default function K8sAgentPanel({ nsId }) {
                             <AgentBadge running={monOn} installed={n.installed} powered={powered} pending={monTask} />
                             {!actionable
                               ? <span className="text-xs text-gray-400">{powered ? '' : 'start cluster to manage'}</span>
-                              : monPending
-                              ? <PendingLabel kind={monTask} />
+                              : (monPending || monLocal)
+                              ? <PendingLabel kind={monLocal || monTask} />
                               : !n.installed
-                              ? <button onClick={() => run(`${c.id}/${n.node}/mon`, `Installing agent on ${n.node}…`, () => installK8sNode(nsId, c.id, n.node, null), c.id)} disabled={!!busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
-                              : <button onClick={() => run(`${c.id}/${n.node}/mon`, `Uninstalling agent from ${n.node}…`, () => uninstallK8sNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                              ? <button onClick={() => run(monKey, 'INSTALLING', () => installK8sNode(nsId, c.id, n.node, null), c.id)} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>
+                              : <button onClick={() => run(monKey, 'UNINSTALLING', () => uninstallK8sNode(nsId, c.id, n.node), c.id)} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
                           </div>
                         </td>
                         <td className="px-4 py-2.5 border-b" onClick={(e) => e.stopPropagation()}>
@@ -164,11 +161,11 @@ export default function K8sAgentPanel({ nsId }) {
                             <AgentBadge running={logOn} installed={logInstalled} powered={powered} pending={logTask} />
                             {!actionable
                               ? <span className="text-xs text-gray-400">{powered ? '' : 'start cluster to manage'}</span>
-                              : logPending
-                              ? <PendingLabel kind={logTask} />
+                              : (logPending || logLocal)
+                              ? <PendingLabel kind={logLocal || logTask} />
                               : !logInstalled
-                              ? <button onClick={() => run(`${c.id}/${n.node}/log`, `Installing log agent on ${n.node}…`, () => installK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
-                              : <button onClick={() => run(`${c.id}/${n.node}/log`, `Uninstalling log agent from ${n.node}…`, () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} disabled={!!busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
+                              ? <button onClick={() => run(logKey, 'INSTALLING', () => installK8sLogNode(nsId, c.id, n.node), c.id)} className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50">Install</button>
+                              : <button onClick={() => run(logKey, 'UNINSTALLING', () => uninstallK8sLogNode(nsId, c.id, n.node), c.id)} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>}
                           </div>
                         </td>
                       </tr>
@@ -196,7 +193,7 @@ export default function K8sAgentPanel({ nsId }) {
                         );
                       })}
                     </div>
-                    <button onClick={() => run(`${c.id}/${sel.node}/mon`, `Applying metrics on ${sel.node}…`, async () => {
+                    <button onClick={() => run(`${c.id}/${sel.node}/mon`, 'INSTALLING', async () => {
                         await installK8sNode(nsId, c.id, sel.node, [...picked]);
                         // Keep the user's selection visible. Refresh the available list but do NOT
                         // reset `picked` from InfluxDB-derived "active" — metrics take ~1 min to
@@ -205,7 +202,7 @@ export default function K8sAgentPanel({ nsId }) {
                         try { const m = await getK8sNodeMetrics(nsId, c.id, sel.node); setMetrics((prev) => ({ ...prev, available: m.available || prev.available, active: m.active || [] })); } catch { /* keep current */ }
                         setApplied(`${c.id}/${sel.node}`);
                       }, c.id)}
-                      disabled={!!busy || picked.size === 0}
+                      disabled={!!busy[`${c.id}/${sel.node}/mon`] || picked.size === 0}
                       className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50">
                       Apply (install selected)
                     </button>

--- a/front/src/pages/MonitoringConfig.jsx
+++ b/front/src/pages/MonitoringConfig.jsx
@@ -27,8 +27,14 @@ export default function MonitoringConfig() {
   // Node id the metric apply/toggle overlay belongs to, so switching to another node mid-apply
   // doesn't show "Applying…" on that other node's panel.
   const [busyNodeId, setBusyNodeId] = useState(null);
-  const [globalBusy, setGlobalBusy] = useState(false);
-  const pollRef = useRef(null);
+  // In-flight agent installs/uninstalls keyed by `${infra}/${nodeId}/${kind}` -> 'install' | 'uninstall'.
+  // A map (not one global flag) so agents on different nodes/kinds install concurrently instead of the
+  // whole screen blocking on a single agent at a time.
+  const [pending, setPending] = useState({});
+  const pendingRef = useRef({});
+  const pollRef = useRef({}); // key -> poll interval id (one live poll per in-flight op)
+  const addPending = (key, op) => { pendingRef.current = { ...pendingRef.current, [key]: op }; setPending(pendingRef.current); };
+  const removePending = (key) => { const n = { ...pendingRef.current }; delete n[key]; pendingRef.current = n; setPending(n); };
 
   const loadNodes = useCallback(async (silent = false) => {
     if (!nsId) return;
@@ -69,7 +75,7 @@ export default function MonitoringConfig() {
     if (!silent) setLoading(false);
   }, [nsId, infraId]);
 
-  useEffect(() => { loadNodes(); return () => { if (pollRef.current) clearInterval(pollRef.current); }; }, [loadNodes]);
+  useEffect(() => { loadNodes(); return () => { Object.values(pollRef.current).forEach(clearInterval); }; }, [loadNodes]);
 
   // Silently re-poll agent status so transient states (e.g. SERVICE_INACTIVE right after a
   // VM suspend/resume, before the agent finishes restarting) self-correct without a manual
@@ -77,7 +83,13 @@ export default function MonitoringConfig() {
   const loadNodesRef = useRef(loadNodes);
   useEffect(() => { loadNodesRef.current = loadNodes; }, [loadNodes]);
   const mutatingRef = useRef(false);
-  useEffect(() => { mutatingRef.current = busy || globalBusy; }, [busy, globalBusy]);
+  // Only pause the silent status re-poll during a metric apply/toggle. Agent installs run
+  // concurrently and rely on the live re-poll (+ their own polls) to reflect INSTALLING progress.
+  useEffect(() => { mutatingRef.current = busy; }, [busy]);
+  // Track the current selection so a finishing install doesn't auto-jump the view off the node
+  // the user is looking at.
+  const selectedNodeRef = useRef(null);
+  useEffect(() => { selectedNodeRef.current = selectedNode; }, [selectedNode]);
   useEffect(() => {
     const id = setInterval(() => { if (!mutatingRef.current) loadNodesRef.current(true); }, 10000);
     return () => clearInterval(id);
@@ -85,7 +97,6 @@ export default function MonitoringConfig() {
   useEffect(() => { getPlugins().then(setPlugins).catch(() => setPlugins([])); }, []);
 
   async function selectNode(node) {
-    if (globalBusy) return;
     setSelectedNode(node);
     setSelectedNodeInfraId(node.infraId || infraId);
     setItems([]);
@@ -133,37 +144,38 @@ export default function MonitoringConfig() {
     const verb = op === 'install' ? 'Install' : 'Uninstall';
     if (!confirm(`${verb} ${a.label} on "${node.name || node.id}"?`)) return;
     const infra = node.infraId || infraId;
-    setGlobalBusy(true);
-    setBusyMsg(`${verb}ing ${a.label} on ${node.name || node.id}...`);
+    const key = `${infra}/${node.id}/${kind}`;
+    if (pendingRef.current[key]) return; // this agent is already installing/uninstalling
+    addPending(key, op);
     try {
       await a[op](nsId, infra, node.id);
-      startPolling(node.id, infra, a.field, `${verb}ing ${a.label}`, kind, op);
+      startPolling(key, node.id, infra, a.field, kind, op);
     } catch (err) {
       alert(`${verb} failed: ` + (err.response?.data?.error_message || err.response?.data?.message || err.message));
-      setGlobalBusy(false);
-      setBusyMsg('');
+      removePending(key);
     }
   }
 
-  function startPolling(nodeId, infra, statusField, msgPrefix, kind, op) {
-    if (pollRef.current) clearInterval(pollRef.current);
+  // One independent poll per in-flight agent op, so multiple installs run concurrently.
+  function startPolling(key, nodeId, infra, statusField, kind, op) {
+    if (pollRef.current[key]) clearInterval(pollRef.current[key]);
     let count = 0;
-    pollRef.current = setInterval(async () => {
+    pollRef.current[key] = setInterval(async () => {
       count++;
       try {
         const nodeData = await getNode(nsId, infra, nodeId);
         const status = nodeData?.[statusField];
-        setBusyMsg(`${msgPrefix}... (${status || 'checking'}) [${count * 5}s]`);
         // INSTALLING/UNINSTALLING are in-progress; any other resolved state ends the poll.
         const done = status && !['INSTALLING', 'UNINSTALLING', 'PREPARING', 'IDLE'].includes(status);
         if (done || count > 60) {
-          clearInterval(pollRef.current);
-          pollRef.current = null;
-          setGlobalBusy(false);
-          setBusyMsg('');
-          await loadNodes();
-          // After a successful monitoring install, auto-select the node to show its metrics.
-          if (kind === 'monitoring' && op === 'install' && (status === 'SUCCESS' || status === 'SERVICE_INACTIVE')) {
+          clearInterval(pollRef.current[key]);
+          delete pollRef.current[key];
+          removePending(key);
+          await loadNodes(true);
+          // After a successful monitoring install, auto-select the node to show its metrics — but
+          // only when the user isn't already looking at another node, so finishing installs don't
+          // yank the view around when several run at once.
+          if (kind === 'monitoring' && op === 'install' && (status === 'SUCCESS' || status === 'SERVICE_INACTIVE') && !selectedNodeRef.current) {
             try {
               const refreshed = await getNodeList(nsId, infra);
               const found = refreshed.find((n) => (n.node_id || n.id) === nodeId);
@@ -212,17 +224,6 @@ export default function MonitoringConfig() {
 
   return (
     <div className="space-y-4 relative">
-      {/* Global busy overlay (install/uninstall) */}
-      {globalBusy && (
-        <div className="fixed inset-0 bg-white/60 backdrop-blur-sm z-50 flex items-center justify-center">
-          <div className="bg-white rounded-lg shadow-xl p-6 text-center">
-            <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-            <p className="text-sm font-medium text-gray-700">{busyMsg}</p>
-            <p className="text-xs text-gray-400 mt-1">Please wait...</p>
-          </div>
-        </div>
-      )}
-
       {/* Header */}
       <div className="bg-white rounded-lg shadow">
         <div className="px-4 py-3 border-b font-semibold">Monitor Setting</div>
@@ -263,17 +264,20 @@ export default function MonitoringConfig() {
                   const run = nodeRunState(node.status);
                   // Monitoring (telegraf) and Log (fluent-bit) agents are installed independently.
                   const agentControl = (kind, status) => {
+                    const localOp = pending[`${node.infraId || infraId}/${node.id}/${kind}`];
                     const installed = isAgentInstalled(status);
-                    if (status === 'INSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>;
-                    if (status === 'UNINSTALLING') return <span className="text-xs text-yellow-600 animate-pulse">Uninstalling…</span>;
+                    // Show the pending label from either the just-clicked local op (before the server
+                    // status flips) or the server's own INSTALLING/UNINSTALLING state.
+                    if (status === 'INSTALLING' || localOp === 'install') return <span className="text-xs text-yellow-600 animate-pulse">Installing…</span>;
+                    if (status === 'UNINSTALLING' || localOp === 'uninstall') return <span className="text-xs text-yellow-600 animate-pulse">Uninstalling…</span>;
                     // Install AND uninstall both connect to the host over SSH, which fails ("FAILED
                     // TO CONNECT VM") on a VM that isn't running (suspended/failed/stopped). Don't
                     // offer either button then — just reflect the current agent state.
                     if (run !== 'running') {
                       return <span className="text-xs text-gray-400" title={`Node is not running (${node.status || 'unknown'})`}>{installed ? 'installed' : '—'}</span>;
                     }
-                    if (installed) return <button onClick={(e) => handleAgent(e, node, kind, 'uninstall')} disabled={busy} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
-                    return <button onClick={(e) => handleAgent(e, node, kind, 'install')} disabled={busy} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>;
+                    if (installed) return <button onClick={(e) => handleAgent(e, node, kind, 'uninstall')} className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50">Uninstall</button>;
+                    return <button onClick={(e) => handleAgent(e, node, kind, 'install')} className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 disabled:opacity-50">Install</button>;
                   };
                   return (
                   <tr key={node.id} onClick={() => selectNode(node)}


### PR DESCRIPTION
## What / Why

Config 메뉴에서 에이전트를 설치할 때 Install 하나를 누르면 화면 전체가 막히고, 그 에이전트 하나가 끝날 때까지 다른 노드는 손도 댈 수 없었습니다. VM / K8s 경로 모두 Agent 작업 중에는 패널 안의 모든 Install/Uninstall 버튼이 비활성화됐습니다.

## Changes

### Front - VM/노드 (`MonitoringConfig.jsx`)
- 전체 화면을 덮던 `globalBusy` 오버레이 제거.
- 단일 boolean + 단일 `pollRef` → 진행 중 작업 맵으로 전환. 키는 `${infra}/${nodeId}/${kind}`이고, 작업마다 독립된 폴링 인터벌을 가집니다. 여러 에이전트가 각자 폴링하며 병렬로 진행됩니다.
- Install/Uninstall 버튼에서 `disabled={busy}` 제거. "Installing…/Uninstalling…" 라벨은 클릭 직후(로컬 상태)와 서버 상태(INSTALLING/UNINSTALLING) 양쪽으로 표시되어, 서버 상태가 반영되기 전 공백 구간에도 진행 표시가 끊기지 않습니다.
- 같은 노드/에이전트를 중복 클릭하면 무시하도록 가드 추가.
- 백그라운드 상태 재조회(10초)를 설치 중에도 계속 돌리고(메트릭 apply 중에만 일시정지), 설치 완료 시에는 전체 로딩 스피너 대신 조용히 갱신(`loadNodes(true)`).
- 모니터링 설치 완료 후 자동 노드 선택은 선택된 노드가 없을 때만 동작하도록 변경 - 여러 설치가 동시에 끝날 때 보고 있던 화면이 튀지 않게 합니다.

### Front - K8s 노드 (`K8sAgentPanel.jsx`)
- 단일 `busy` 문자열 → 진행 중 작업 맵(`${clusterId}/${node}/${mon|log}` → INSTALLING/UNINSTALLING).
- 클러스터 카드를 덮던 블로킹 오버레이와, 패널 전체 버튼을 막던 `disabled={!!busy}` 제거.
- 진행 표시는 로컬 작업 상태와 서버 `taskStatus`를 함께 사용해 해당 노드 행에만 인라인으로 표시. 서버 상태가 이어받으므로 탭 간 진행 표시도 그대로 유지됩니다.
- 상태 주기 재조회를 작업 중에도 멈추지 않도록 변경해, 동시 설치들의 진행이 실시간 반영됩니다(진행 중 노드는 자체 로컬 상태를 유지하므로 중간 갱신에 라벨이 사라지지 않음).
- 메트릭 Apply 버튼은 해당 노드 작업에 대해서만 비활성화.